### PR TITLE
fix: bulk episode process/reprocess never triggers processing

### DIFF
--- a/src/api/episodes.py
+++ b/src/api/episodes.py
@@ -549,6 +549,7 @@ def bulk_episode_action(slug):
     skipped = 0
     freed_mb = 0.0
     errors = []
+    eligible_ids = []
 
     # Batch-fetch all episodes upfront to avoid N+1 queries
     all_episodes = db.get_episodes_by_ids(slug, episode_ids)
@@ -607,13 +608,24 @@ def bulk_episode_action(slug):
                 logger.error(f"Bulk delete error for {slug}: {e}")
                 errors.append('bulk delete failed')
 
-    # Trigger background processing for process/reprocess actions
+    # Enqueue episodes into auto_process_queue so the background processor
+    # picks them up sequentially. Previously this called start_background_processing()
+    # with no arguments (a TypeError silently swallowed by `except Exception: pass`),
+    # which meant episodes were marked pending in the DB but never actually processed.
     if action in ('process', 'reprocess', 'reprocess_full') and queued > 0:
-        try:
-            from main_app.processing import start_background_processing
-            start_background_processing()
-        except Exception:
-            pass
+        for episode_id in eligible_ids:
+            try:
+                ep = episodes_by_id.get(episode_id)
+                if ep:
+                    db.upsert_episode_for_processing(
+                        slug, episode_id,
+                        ep.get('original_url', ''),
+                        ep.get('title'),
+                        ep.get('published_at'),
+                        ep.get('description'),
+                    )
+            except Exception as e:
+                logger.warning(f"[{slug}:{episode_id}] Could not enqueue for processing: {e}")
 
     logger.info(f"Bulk {action} on {slug}: {queued} queued, {skipped} skipped, {freed_mb:.1f} MB freed")
 

--- a/src/database/queue.py
+++ b/src/database/queue.py
@@ -65,6 +65,52 @@ class QueueMixin:
             logger.error(f"Failed to queue episode for processing: {e}")
             return None
 
+    def upsert_episode_for_processing(self, slug: str, episode_id: str,
+                                      original_url: str, title: str = None,
+                                      published_at: str = None,
+                                      description: str = None) -> Optional[int]:
+        """Add or reset an episode in the auto-process queue to 'pending'.
+
+        Unlike queue_episode_for_processing (which skips already-queued rows),
+        this method resets the status and attempt counter even when a completed
+        or failed row already exists.  Used by bulk process/reprocess actions
+        so re-queuing is reliable regardless of prior queue history.
+
+        Returns queue row ID or None on failure.
+        """
+        conn = self.get_connection()
+
+        podcast = self.get_podcast_by_slug(slug)
+        if not podcast:
+            logger.error(f"Cannot upsert episode for processing: podcast not found: {slug}")
+            return None
+
+        podcast_id = podcast['id']
+
+        try:
+            cursor = conn.execute(
+                """INSERT INTO auto_process_queue
+                   (podcast_id, episode_id, original_url, title, published_at, description,
+                    status, attempts, error_message)
+                   VALUES (?, ?, ?, ?, ?, ?, 'pending', 0, NULL)
+                   ON CONFLICT(podcast_id, episode_id) DO UPDATE SET
+                     status = 'pending',
+                     attempts = 0,
+                     error_message = NULL,
+                     original_url = excluded.original_url,
+                     title = COALESCE(excluded.title, auto_process_queue.title),
+                     published_at = COALESCE(excluded.published_at, auto_process_queue.published_at),
+                     description = COALESCE(excluded.description, auto_process_queue.description),
+                     updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')""",
+                (podcast_id, episode_id, original_url, title, published_at, description)
+            )
+            conn.commit()
+            return cursor.lastrowid if cursor.lastrowid else None
+        except Exception as e:
+            logger.error(f"Failed to upsert episode for processing: {e}")
+            return None
+
+
     def get_next_queued_episode(self) -> Optional[Dict]:
         """Get the next pending episode from the queue (FIFO order)."""
         conn = self.get_connection()


### PR DESCRIPTION
# fix: bulk episode actions never trigger processing

## Summary

Bulk `process` and `reprocess` actions (used when selecting multiple episodes in the UI) correctly marked episodes as `pending` in the database but **never actually started processing**. Episodes would sit in the `pending` state indefinitely and never move to `processing`.

---

## Root Cause

In `src/api/episodes.py`, the `bulk_episode_action` endpoint had a broken "kick off processing" step at the bottom of the handler:

```python
# BEFORE — broken
if action in ('process', 'reprocess', 'reprocess_full') and queued > 0:
    try:
        from main_app.processing import start_background_processing
        start_background_processing()          # ← called with 0 arguments
    except Exception:
        pass                                   # ← TypeError silently eaten
```

`start_background_processing` has this signature:

```python
def start_background_processing(
    slug, episode_id, original_url, title,
    podcast_name, description, artwork_url,
    published_at=None
):
```

Calling it with **zero arguments** raises a `TypeError` immediately. The bare `except Exception: pass` swallowed the error without logging it, making the failure completely invisible. The database writes (setting episodes to `pending`) succeeded, but processing was never triggered — leaving every bulk-queued episode permanently stuck in the `pending` state.

### Why episodes never recovered on their own

The background `background_queue_processor` thread only polls the `auto_process_queue` table, not the `episodes` table directly. Because the bulk action never inserted rows into `auto_process_queue`, the background processor had nothing to pick up. Episodes in `pending` status with no `auto_process_queue` row are invisible to the scheduler.

---

## Changes

### `src/api/episodes.py`

- Removed the broken `start_background_processing()` no-arg call.
- After successfully batch-setting episodes to `pending`, now iterates over `eligible_ids` (already in-scope from the action branch) and calls `db.upsert_episode_for_processing()` for each one.
- Added `eligible_ids = []` initialization at the top of the handler so the variable is always defined regardless of which action branch runs.
- Per-episode enqueue failures are logged as warnings and do not abort the response — the DB status update is already committed and the user gets a correct `queued` count back.

### `src/database/queue.py`

Added `upsert_episode_for_processing()` — a new `QueueMixin` method that **always** resets a queue row to `pending`, even if a `completed` or `failed` row already exists for that `(podcast_id, episode_id)` pair.

The existing `queue_episode_for_processing()` uses `ON CONFLICT DO NOTHING`, which was intentionally designed to be idempotent for auto-discovery flows. That behavior would silently skip re-queuing for **reprocess** actions (where a `completed` row from the first processing run already exists in the table), so a separate method with `ON CONFLICT DO UPDATE` semantics was needed.

```sql
INSERT INTO auto_process_queue (...)
VALUES (?, ?, ?, ?, ?, ?, 'pending', 0, NULL)
ON CONFLICT(podcast_id, episode_id) DO UPDATE SET
  status = 'pending',
  attempts = 0,
  error_message = NULL,
  original_url   = excluded.original_url,
  title          = COALESCE(excluded.title,       auto_process_queue.title),
  published_at   = COALESCE(excluded.published_at, auto_process_queue.published_at),
  description    = COALESCE(excluded.description,  auto_process_queue.description),
  updated_at     = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
```

`title`, `published_at`, and `description` use `COALESCE` so that existing metadata is preserved if the caller passes `None` (e.g. when the episode row has no title yet). `original_url` is always overwritten since it is required for downloading.

---

## Diff

```diff
--- a/src/api/episodes.py
+++ b/src/api/episodes.py
@@ -549,6 +549,7 @@ def bulk_episode_action(slug):
     skipped = 0
     freed_mb = 0.0
     errors = []
+    eligible_ids = []

     # Batch-fetch all episodes upfront to avoid N+1 queries
     all_episodes = db.get_episodes_by_ids(slug, episode_ids)
@@ -607,13 +608,24 @@ def bulk_episode_action(slug):
                 logger.error(f"Bulk delete error for {slug}: {e}")
                 errors.append('bulk delete failed')

-    # Trigger background processing for process/reprocess actions
+    # Enqueue episodes into auto_process_queue so the background processor
+    # picks them up sequentially. Previously this called start_background_processing()
+    # with no arguments (a TypeError silently swallowed by `except Exception: pass`),
+    # which meant episodes were marked pending in the DB but never actually processed.
     if action in ('process', 'reprocess', 'reprocess_full') and queued > 0:
-        try:
-            from main_app.processing import start_background_processing
-            start_background_processing()
-        except Exception:
-            pass
+        for episode_id in eligible_ids:
+            try:
+                ep = episodes_by_id.get(episode_id)
+                if ep:
+                    db.upsert_episode_for_processing(
+                        slug, episode_id,
+                        ep.get('original_url', ''),
+                        ep.get('title'),
+                        ep.get('published_at'),
+                        ep.get('description'),
+                    )
+            except Exception as e:
+                logger.warning(f"[{slug}:{episode_id}] Could not enqueue for processing: {e}")
```

```diff
--- a/src/database/queue.py
+++ b/src/database/queue.py
@@ -65,6 +65,52 @@ class QueueMixin:
             logger.error(f"Failed to queue episode for processing: {e}")
             return None

+    def upsert_episode_for_processing(self, slug: str, episode_id: str,
+                                      original_url: str, title: str = None,
+                                      published_at: str = None,
+                                      description: str = None) -> Optional[int]:
+        """Add or reset an episode in the auto-process queue to 'pending'.
+
+        Unlike queue_episode_for_processing (which skips already-queued rows),
+        this method resets the status and attempt counter even when a completed
+        or failed row already exists.  Used by bulk process/reprocess actions
+        so re-queuing is reliable regardless of prior queue history.
+
+        Returns queue row ID or None on failure.
+        """
+        conn = self.get_connection()
+
+        podcast = self.get_podcast_by_slug(slug)
+        if not podcast:
+            logger.error(f"Cannot upsert episode for processing: podcast not found: {slug}")
+            return None
+
+        podcast_id = podcast['id']
+
+        try:
+            cursor = conn.execute(
+                """INSERT INTO auto_process_queue
+                   (podcast_id, episode_id, original_url, title, published_at, description,
+                    status, attempts, error_message)
+                   VALUES (?, ?, ?, ?, ?, ?, 'pending', 0, NULL)
+                   ON CONFLICT(podcast_id, episode_id) DO UPDATE SET
+                     status = 'pending',
+                     attempts = 0,
+                     error_message = NULL,
+                     original_url = excluded.original_url,
+                     title = COALESCE(excluded.title, auto_process_queue.title),
+                     published_at = COALESCE(excluded.published_at, auto_process_queue.published_at),
+                     description = COALESCE(excluded.description, auto_process_queue.description),
+                     updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')""",
+                (podcast_id, episode_id, original_url, title, published_at, description)
+            )
+            conn.commit()
+            return cursor.lastrowid if cursor.lastrowid else None
+        except Exception as e:
+            logger.error(f"Failed to upsert episode for processing: {e}")
+            return None
+
+
     def get_next_queued_episode(self) -> Optional[Dict]:
```

---

## Behaviour Before / After

| Scenario | Before | After |
|---|---|---|
| Bulk **process** (discovered → pending) | Episodes set to `pending`, never processed | Episodes set to `pending` **and** inserted into `auto_process_queue`; background processor picks them up in FIFO order |
| Bulk **reprocess** / **reprocess_full** | Same — audio deleted, DB reset, then stuck forever in `pending` | Same reset, then `auto_process_queue` row is upserted to `pending` (resetting attempts=0), background processor re-runs them |
| Single episode reprocess (existing endpoint) | Unaffected — uses `start_background_processing()` with correct args | Unaffected |
| Auto-discovery auto-process | Unaffected — uses `queue_episode_for_processing()` | Unaffected |

---

## No Breaking Changes

- `queue_episode_for_processing()` is unchanged — existing callers (auto-discovery, single-episode reprocess fallback) retain their `DO NOTHING` idempotency.
- No schema migrations required — `upsert_episode_for_processing` writes to the existing `auto_process_queue` table.
- No API surface changes — the `/feeds/<slug>/episodes/bulk` endpoint request/response contract is identical.
- The background `background_queue_processor` thread is unchanged; it naturally picks up the newly queued rows.

---

## Files Changed

| File | Change |
|---|---|
| `src/api/episodes.py` | Fixed broken processing trigger in `bulk_episode_action`; +18 / -6 |
| `src/database/queue.py` | Added `upsert_episode_for_processing` to `QueueMixin`; +46 / -0 |
