### PR TITLE
feat(rss): unified `/all` combined RSS feed across all podcasts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,6 +102,17 @@ COPY gunicorn.conf.py ./
 # Copy built frontend from builder stage
 COPY --from=frontend-builder /app/static/ui ./static/ui/
 
+# Apple Podcasts / iTunes wants 1400-3000 px square artwork for channel
+# images; the bundled icon-512.png is too small and renders wonky in
+# clients. ffmpeg is already installed for transcoding, so use it here
+# to upscale once at build time into a derived feed-icon.png — no extra
+# source file in frontend/public, no Pillow dependency, no runtime cost.
+RUN ffmpeg -hide_banner -loglevel error -y \
+    -i ./static/ui/icon-512.png \
+    -vf scale=3000:3000:flags=lanczos \
+    ./static/ui/feed-icon.png \
+    && ls -la ./static/ui/feed-icon.png
+
 # Copy entrypoint script
 COPY entrypoint.sh /app/
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -127,6 +127,7 @@ export interface Settings {
   whisperModel: SettingValue;
   autoProcessEnabled: SettingValueBoolean;
   maxFeedEpisodes: SettingValueNumber;
+  combinedFeedEpisodeLimit: SettingValueNumber;
   onlyExposeProcessedDefault: SettingValueBoolean;
   audioBitrate: SettingValue;
   vttTranscriptsEnabled: SettingValueBoolean;
@@ -152,6 +153,7 @@ export interface Settings {
     whisperModel: string;
     autoProcessEnabled: boolean;
     maxFeedEpisodes: number;
+    combinedFeedEpisodeLimit: number;
     onlyExposeProcessedDefault: boolean;
     vttTranscriptsEnabled: boolean;
     chaptersEnabled: boolean;
@@ -176,6 +178,7 @@ export interface UpdateSettingsPayload {
   whisperModel?: string;
   autoProcessEnabled?: boolean;
   maxFeedEpisodes?: number;
+  combinedFeedEpisodeLimit?: number;
   onlyExposeProcessedDefault?: boolean;
   audioBitrate?: string;
   vttTranscriptsEnabled?: boolean;

--- a/frontend/src/components/CombinedFeedCard.tsx
+++ b/frontend/src/components/CombinedFeedCard.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTheme } from '../context/ThemeContext';
+import { getSettings, updateSettings } from '../api/settings';
+import CopyButton from './CopyButton';
+
+/**
+ * Renders the unified `/all` feed at the top of the Feeds list.
+ *
+ * Surface:
+ * - MinusPod logo as artwork (matches the channel <itunes:image> served at /all)
+ * - Subscribe URL with Copy button (uses the shared CopyButton, which handles
+ *   the navigator.clipboard insecure-context fallback)
+ * - Episode-limit input that auto-saves on blur via PUT /api/v1/settings
+ */
+function CombinedFeedCard() {
+  const queryClient = useQueryClient();
+  const { theme } = useTheme();
+
+  const { data: settings } = useQuery({
+    queryKey: ['settings'],
+    queryFn: getSettings,
+  });
+
+  const serverLimit = settings?.combinedFeedEpisodeLimit?.value ?? 50;
+  const [limit, setLimit] = useState<number>(serverLimit);
+  const [error, setError] = useState<string | null>(null);
+
+  // Re-sync local state when the server value changes (e.g. another tab saved).
+  useEffect(() => {
+    setLimit(serverLimit);
+  }, [serverLimit]);
+
+  const combinedFeedUrl =
+    typeof window !== 'undefined' ? `${window.location.origin}/all` : '/all';
+  const logoSrc = theme === 'dark' ? '/ui/logo-dark.svg' : '/ui/logo.svg';
+
+  const saveMutation = useMutation({
+    mutationFn: (n: number) => updateSettings({ combinedFeedEpisodeLimit: n }),
+    onSuccess: () => {
+      setError(null);
+      queryClient.invalidateQueries({ queryKey: ['settings'] });
+    },
+    onError: (e: unknown) => {
+      setError(e instanceof Error ? e.message : 'Save failed');
+      setLimit(serverLimit);
+    },
+  });
+
+  const commitLimit = () => {
+    const clamped = Math.max(1, Math.min(500, Number.isFinite(limit) ? limit : 50));
+    if (clamped !== limit) setLimit(clamped);
+    if (clamped !== serverLimit) {
+      saveMutation.mutate(clamped);
+    }
+  };
+
+  return (
+    <div className="bg-card rounded-lg border border-border overflow-hidden mb-4">
+      <div className="flex">
+        <div className="w-24 h-24 shrink-0 bg-secondary/40 flex items-center justify-center p-3">
+          <img
+            src={logoSrc}
+            alt="MinusPod"
+            className="w-full h-full object-contain"
+          />
+        </div>
+        <div className="flex-1 p-4 min-w-0">
+          <div className="flex items-baseline justify-between gap-2 flex-wrap">
+            <h3 className="text-lg font-semibold text-foreground truncate">
+              All Podcasts (combined feed)
+            </h3>
+            <span className="text-xs text-muted-foreground uppercase tracking-wide">
+              Unified RSS
+            </span>
+          </div>
+          <p className="text-sm text-muted-foreground mt-1">
+            Subscribe to <code>/all</code> in your podcast app to receive the most-recent
+            processed episodes from every show in MinusPod, newest first.
+          </p>
+          <div className="mt-3 flex items-center gap-2">
+            <label
+              htmlFor="combinedFeedEpisodeLimit"
+              className="text-sm text-muted-foreground"
+            >
+              Episodes:
+            </label>
+            <input
+              type="number"
+              id="combinedFeedEpisodeLimit"
+              value={limit}
+              onChange={(e) => setLimit(parseInt(e.target.value, 10) || 0)}
+              onBlur={commitLimit}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.currentTarget.blur();
+                }
+              }}
+              min={1}
+              max={500}
+              className="w-20 px-2 py-1 rounded-lg border border-input bg-background text-foreground focus:outline-hidden focus:ring-2 focus:ring-ring text-sm"
+              disabled={saveMutation.isPending}
+            />
+            <span className="text-xs text-muted-foreground">(1-500)</span>
+            {saveMutation.isPending && (
+              <span className="text-xs text-muted-foreground">Saving…</span>
+            )}
+            {error && (
+              <span className="text-xs text-destructive" role="alert">{error}</span>
+            )}
+          </div>
+        </div>
+      </div>
+      <div className="px-4 py-3 bg-secondary/50 border-t border-border flex items-center gap-2">
+        <input
+          type="text"
+          readOnly
+          value={combinedFeedUrl}
+          onFocus={(e) => e.currentTarget.select()}
+          className="flex-1 px-3 py-1.5 rounded-lg border border-input bg-background text-foreground text-sm font-mono focus:outline-hidden focus:ring-2 focus:ring-ring"
+        />
+        <CopyButton
+          text={combinedFeedUrl}
+          label="Copy Feed URL"
+          className="px-3 py-1.5 border border-input bg-background hover:bg-muted text-foreground text-xs"
+          labelClassName="text-xs"
+        />
+      </div>
+    </div>
+  );
+}
+
+export default CombinedFeedCard;

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { getFeeds, refreshFeed, refreshAllFeeds, deleteFeed } from '../api/feeds';
 import FeedCard from '../components/FeedCard';
 import FeedListItem from '../components/FeedListItem';
+import CombinedFeedCard from '../components/CombinedFeedCard';
 import LoadingSpinner from '../components/LoadingSpinner';
 
 function Dashboard() {
@@ -183,6 +184,8 @@ function Dashboard() {
           </Link>
         </div>
       </div>
+
+      {feeds && feeds.length > 0 && <CombinedFeedCard />}
 
       {!feeds || feeds.length === 0 ? (
         <div className="text-center py-12 bg-card rounded-lg border border-border">

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -54,6 +54,7 @@ function Settings() {
   const [whisperModel, setWhisperModel] = useState('');
   const [autoProcessEnabled, setAutoProcessEnabled] = useState(true);
   const [maxFeedEpisodes, setMaxFeedEpisodes] = useState(300);
+  const [combinedFeedEpisodeLimit, setCombinedFeedEpisodeLimit] = useState(50);
   const [onlyExposeProcessedDefault, setOnlyExposeProcessedDefault] = useState(false);
   const [audioBitrate, setAudioBitrate] = useState('128k');
   const [vttTranscriptsEnabled, setVttTranscriptsEnabled] = useState(true);
@@ -225,6 +226,7 @@ function Settings() {
       setWhisperModel(settings.whisperModel?.value || 'small');
       setAutoProcessEnabled(settings.autoProcessEnabled?.value ?? true);
       setMaxFeedEpisodes(settings.maxFeedEpisodes?.value ?? 300);
+      setCombinedFeedEpisodeLimit(settings.combinedFeedEpisodeLimit?.value ?? 50);
       setOnlyExposeProcessedDefault(settings.onlyExposeProcessedDefault?.value ?? false);
       setAudioBitrate(settings.audioBitrate?.value || '128k');
       setVttTranscriptsEnabled(settings.vttTranscriptsEnabled?.value ?? true);
@@ -253,6 +255,7 @@ function Settings() {
       whisperModel !== (settings.whisperModel?.value || 'small') ||
       autoProcessEnabled !== (settings.autoProcessEnabled?.value ?? true) ||
       maxFeedEpisodes !== (settings.maxFeedEpisodes?.value ?? 300) ||
+      combinedFeedEpisodeLimit !== (settings.combinedFeedEpisodeLimit?.value ?? 50) ||
       onlyExposeProcessedDefault !== (settings.onlyExposeProcessedDefault?.value ?? false) ||
       audioBitrate !== (settings.audioBitrate?.value || '128k') ||
       vttTranscriptsEnabled !== (settings.vttTranscriptsEnabled?.value ?? true) ||
@@ -268,7 +271,7 @@ function Settings() {
       whisperComputeType !== (settings.whisperComputeType?.value || 'auto') ||
       (podcastIndexApiKey !== '' && podcastIndexApiSecret !== '')
     );
-  }, [systemPrompt, verificationPrompt, selectedModel, verificationModel, whisperModel, autoProcessEnabled, maxFeedEpisodes, onlyExposeProcessedDefault, audioBitrate, vttTranscriptsEnabled, chaptersEnabled, chaptersModel, minCutConfidence, llmProvider, openaiBaseUrl, whisperBackend, whisperApiConfig.baseUrl, whisperApiConfig.model, whisperLanguage, whisperComputeType, podcastIndexApiKey, podcastIndexApiSecret, settings]);
+  }, [systemPrompt, verificationPrompt, selectedModel, verificationModel, whisperModel, autoProcessEnabled, maxFeedEpisodes, combinedFeedEpisodeLimit, onlyExposeProcessedDefault, audioBitrate, vttTranscriptsEnabled, chaptersEnabled, chaptersModel, minCutConfidence, llmProvider, openaiBaseUrl, whisperBackend, whisperApiConfig.baseUrl, whisperApiConfig.model, whisperLanguage, whisperComputeType, podcastIndexApiKey, podcastIndexApiSecret, settings]);
 
   const updateMutation = useMutation({
     mutationFn: () =>
@@ -280,6 +283,7 @@ function Settings() {
         whisperModel,
         autoProcessEnabled,
         maxFeedEpisodes,
+        combinedFeedEpisodeLimit,
         onlyExposeProcessedDefault,
         audioBitrate,
         vttTranscriptsEnabled,

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -88,6 +88,12 @@ def get_settings():
     except (ValueError, TypeError):
         max_feed_episodes = 300
 
+    try:
+        combined_feed_episode_limit = int(
+            _setting_value(settings, 'combined_feed_episode_limit', '50'))
+    except (ValueError, TypeError):
+        combined_feed_episode_limit = 50
+
     # Get min cut confidence (ad detection aggressiveness)
     try:
         min_cut_confidence = float(_setting_value(settings, 'min_cut_confidence', '0.80'))
@@ -148,6 +154,7 @@ def get_settings():
         'whisperModel': _sv('whisper_model', whisper_model),
         'autoProcessEnabled': _sv('auto_process_enabled', auto_process_enabled),
         'maxFeedEpisodes': _sv('max_feed_episodes', max_feed_episodes),
+        'combinedFeedEpisodeLimit': _sv('combined_feed_episode_limit', combined_feed_episode_limit),
         'onlyExposeProcessedDefault': _sv(
             'only_expose_processed_default', only_expose_processed_default),
         'vttTranscriptsEnabled': _sv('vtt_transcripts_enabled', vtt_enabled),
@@ -179,6 +186,7 @@ def get_settings():
             'whisperModel': default_whisper_model,
             'autoProcessEnabled': True,
             'maxFeedEpisodes': 300,
+            'combinedFeedEpisodeLimit': 50,
             'onlyExposeProcessedDefault': False,
             'vttTranscriptsEnabled': True,
             'chaptersEnabled': True,
@@ -251,6 +259,16 @@ def update_ad_detection_settings():
             return error_response('maxFeedEpisodes must be between 10 and 500', 400)
         db.set_setting('max_feed_episodes', str(max_ep), is_default=False)
         logger.info(f"Updated max feed episodes to: {max_ep}")
+
+    if 'combinedFeedEpisodeLimit' in data:
+        try:
+            combined_limit = int(data['combinedFeedEpisodeLimit'])
+        except (TypeError, ValueError):
+            return error_response('combinedFeedEpisodeLimit must be an integer', 400)
+        if combined_limit < 1 or combined_limit > 500:
+            return error_response('combinedFeedEpisodeLimit must be between 1 and 500', 400)
+        db.set_setting('combined_feed_episode_limit', str(combined_limit), is_default=False)
+        logger.info(f"Updated combined feed episode limit to: {combined_limit}")
 
     if 'onlyExposeProcessedDefault' in data:
         value = 'true' if data['onlyExposeProcessedDefault'] else 'false'

--- a/src/database/episodes.py
+++ b/src/database/episodes.py
@@ -571,6 +571,34 @@ class EpisodeMixin:
         )
         return [dict(row) for row in cursor.fetchall()]
 
+    def get_recent_processed_across_all_feeds(self, limit: int) -> List[Dict]:
+        """Return the most-recent processed episodes across every podcast.
+
+        Used by the unified ``/all`` RSS feed: caller only ever exposes
+        processed episodes, sorted by ``published_at`` desc, capped at
+        ``limit``. Joins ``podcasts`` so the RSS builder has slug, title,
+        and artwork without an N+1.
+        """
+        if limit <= 0:
+            return []
+        conn = self.get_connection()
+        cursor = conn.execute(
+            """SELECT e.episode_id, e.title, e.description, e.published_at,
+                      e.new_duration, e.episode_number, e.processed_version,
+                      e.artwork_url AS episode_artwork_url,
+                      p.slug AS podcast_slug,
+                      p.title AS podcast_title,
+                      p.artwork_url AS podcast_artwork_url
+               FROM episodes e
+               JOIN podcasts p ON e.podcast_id = p.id
+               WHERE e.status = 'processed'
+                     AND e.processed_file IS NOT NULL
+               ORDER BY COALESCE(e.published_at, e.created_at) DESC
+               LIMIT ?""",
+            (limit,)
+        )
+        return [dict(row) for row in cursor.fetchall()]
+
     def get_episodes_by_ids(self, slug: str, episode_ids: List[str]) -> List[Dict]:
         """Get multiple episodes by slug and episode_ids in a single query."""
         if not episode_ids:

--- a/src/main_app/routes.py
+++ b/src/main_app/routes.py
@@ -206,6 +206,42 @@ def register_routes(app):
 
     # ========== RSS Feed Routes ==========
 
+    # In-memory cache for the unified /all feed. Werkzeug routing prefers
+    # literal rules over <slug>, so this never collides with a real podcast
+    # named "all". TTL matches the per-feed serve_rss freshness window.
+    _COMBINED_CACHE = {'xml': None, 'built_at': 0.0, 'base_url': None}
+    _COMBINED_TTL_SECONDS = 15 * 60
+
+    @app.route('/all')
+    @log_request_detailed
+    def serve_combined_rss():
+        """Serve a unified RSS feed combining all processed episodes."""
+        db, storage, rss_parser, _ = _get_components()
+
+        try:
+            limit = int(db.get_setting('combined_feed_episode_limit') or '50')
+        except (ValueError, TypeError):
+            limit = 50
+        limit = max(1, min(limit, 500))
+
+        current_base = os.getenv('BASE_URL', 'http://localhost:8000')
+        now = time.time()
+        cached = _COMBINED_CACHE
+        if (cached['xml']
+                and cached['base_url'] == current_base
+                and (now - cached['built_at']) < _COMBINED_TTL_SECONDS):
+            feed_logger.info(f"[/all] Serving cached combined feed (limit={limit})")
+            return Response(cached['xml'], mimetype='application/rss+xml')
+
+        episodes = db.get_recent_processed_across_all_feeds(limit)
+        xml = rss_parser.build_combined_feed(episodes, storage=storage)
+        cached['xml'] = xml
+        cached['built_at'] = now
+        cached['base_url'] = current_base
+        feed_logger.info(
+            f"[/all] Built combined feed: {len(episodes)} episodes (limit={limit})")
+        return Response(xml, mimetype='application/rss+xml')
+
     @app.route('/<slug>')
     @validate_slug_param
     @log_request_detailed

--- a/src/rss_parser.py
+++ b/src/rss_parser.py
@@ -510,6 +510,103 @@ class RSSParser:
         self._append_podcasting2_tags(lines, slug, ep_id, storage)
         lines.append('</item>')
 
+    def build_combined_feed(self, episodes: List[Dict], storage=None,
+                            channel_title: str = "MinusPod — All Podcasts",
+                            channel_link: Optional[str] = None,
+                            channel_description: str = (
+                                "All processed episodes from every podcast in MinusPod, "
+                                "newest first."
+                            )) -> str:
+        """Build a unified RSS feed across all podcasts.
+
+        Each episode dict must include the keys returned by
+        ``EpisodeMixin.get_recent_processed_across_all_feeds``: ``episode_id``,
+        ``title``, ``description``, ``published_at``, ``new_duration``,
+        ``episode_number``, ``processed_version``, ``episode_artwork_url``,
+        ``podcast_slug``, ``podcast_title``, ``podcast_artwork_url``.
+
+        Output mirrors the per-feed shape produced by ``modify_feed`` so
+        existing podcast clients render it identically; episode titles are
+        prefixed with the source podcast title in brackets so listeners can
+        see which show each item belongs to.
+        """
+        base_url = self._resolved_base_url()
+        link = channel_link or base_url
+
+        lines = []
+        lines.append('<?xml version="1.0" encoding="UTF-8"?>')
+        lines.append('<rss version="2.0" '
+                     'xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" '
+                     'xmlns:podcast="https://podcastindex.org/namespace/1.0">')
+        lines.append('<channel>')
+        lines.append(f'<title>{self._escape_xml(channel_title)}</title>')
+        lines.append(f'<link>{self._escape_xml(link)}</link>')
+        lines.append(f'<description><![CDATA[{channel_description}]]></description>')
+        lines.append('<language>en</language>')
+        lines.append('<itunes:author>MinusPod</itunes:author>')
+
+        # Channel artwork: 3000×3000 PNG. Apple Podcasts requires 1400-3000 px
+        # square JPG/PNG and validates strictly; smaller images render wonky
+        # in many clients. The Dockerfile upscales the bundled 512×512
+        # icon to /ui/feed-icon.png at build time so we don't have to keep
+        # a second source asset in frontend/public/.
+        artwork_href = f"{base_url}/ui/feed-icon.png"
+        lines.append('<image>')
+        lines.append(f'  <url>{self._escape_xml(artwork_href)}</url>')
+        lines.append(f'  <title>{self._escape_xml(channel_title)}</title>')
+        lines.append(f'  <link>{self._escape_xml(link)}</link>')
+        lines.append('</image>')
+        lines.append(f'<itunes:image href="{self._escape_xml(artwork_href)}" />')
+
+        for ep in episodes:
+            slug = ep.get('podcast_slug')
+            episode_id = ep.get('episode_id')
+            if not slug or not episode_id:
+                continue
+
+            podcast_title = ep.get('podcast_title') or 'Unknown'
+            ep_title = ep.get('title') or 'Untitled'
+            display_title = f"[{podcast_title}] {ep_title}"
+
+            modified_url = episode_public_url(
+                base_url, slug, episode_id, ep.get('processed_version'))
+
+            lines.append('<item>')
+            lines.append(f'  <title>{self._escape_xml(display_title)}</title>')
+            if ep.get('description'):
+                lines.append(
+                    f'  <description><![CDATA[{ep["description"]}]]></description>')
+            lines.append(f'  <enclosure url="{modified_url}" type="audio/mpeg" />')
+            # GUID combines slug + episode_id so two podcasts that happen to
+            # share an episode_id never collide in the unified feed.
+            lines.append(
+                f'  <guid isPermaLink="false">{self._escape_xml(slug)}::{self._escape_xml(episode_id)}</guid>')
+            if ep.get('published_at'):
+                lines.append(
+                    f'  <pubDate>{self._format_rfc2822(ep["published_at"])}</pubDate>')
+            if ep.get('new_duration'):
+                try:
+                    lines.append(
+                        f'  <itunes:duration>{int(ep["new_duration"])}</itunes:duration>')
+                except (TypeError, ValueError):
+                    pass
+            if ep.get('episode_number'):
+                lines.append(
+                    f'  <itunes:episode>{ep["episode_number"]}</itunes:episode>')
+            artwork_url = ep.get('episode_artwork_url') or ep.get('podcast_artwork_url')
+            if artwork_url:
+                lines.append(
+                    f'  <itunes:image href="{self._escape_xml(artwork_url)}" />')
+            self._append_podcasting2_tags(lines, slug, episode_id, storage)
+            lines.append('</item>')
+
+        lines.append('</channel>')
+        lines.append('</rss>')
+
+        rendered = '\n'.join(lines)
+        logger.info(f"[/all] Built combined RSS feed with {len(episodes)} episodes")
+        return rendered
+
     def _format_rfc2822(self, iso_date: str) -> str:
         """Convert ISO 8601 date string to RFC 2822 format for RSS pubDate."""
         try:

--- a/tests/unit/test_combined_feed.py
+++ b/tests/unit/test_combined_feed.py
@@ -1,0 +1,200 @@
+"""Tests for the unified /all RSS feed.
+
+Covers:
+- DB query: get_recent_processed_across_all_feeds returns only processed
+  episodes, sorted by published_at desc, joined with podcast metadata.
+- XML builder: RSSParser.build_combined_feed produces valid RSS 2.0,
+  prefixes episode titles with podcast title, builds the right enclosure
+  URL shape, and degrades gracefully on an empty input.
+"""
+
+import os
+import re
+import sys
+
+import defusedxml
+defusedxml.defuse_stdlib()
+from defusedxml import ElementTree as ET
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
+
+from rss_parser import RSSParser
+
+
+class TestRecentProcessedAcrossAllFeeds:
+    def _seed(self, db):
+        db.create_podcast('alpha', 'https://a.example/feed.xml', 'Alpha Show')
+        db.create_podcast('beta', 'https://b.example/feed.xml', 'Beta Show')
+        # 3 processed episodes (one per feed + one extra), 1 pending — pending
+        # must be excluded.
+        db.upsert_episode(
+            'alpha', 'a1',
+            original_url='https://a.example/a1.mp3',
+            title='Alpha Episode 1',
+            status='processed',
+            processed_file='episodes/a1.mp3',
+            new_duration=1800,
+            published_at='2026-05-01T10:00:00Z',
+        )
+        db.upsert_episode(
+            'alpha', 'a2',
+            original_url='https://a.example/a2.mp3',
+            title='Alpha Episode 2',
+            status='processed',
+            processed_file='episodes/a2.mp3',
+            new_duration=1900,
+            published_at='2026-05-07T10:00:00Z',
+        )
+        db.upsert_episode(
+            'beta', 'b1',
+            original_url='https://b.example/b1.mp3',
+            title='Beta Episode 1',
+            status='processed',
+            processed_file='episodes/b1.mp3',
+            new_duration=2000,
+            published_at='2026-05-05T10:00:00Z',
+        )
+        db.upsert_episode(
+            'beta', 'b-pending',
+            original_url='https://b.example/bp.mp3',
+            title='Beta Pending',
+            status='pending',
+            published_at='2026-05-06T10:00:00Z',
+        )
+
+    def test_returns_only_processed_sorted_desc(self, temp_db):
+        self._seed(temp_db)
+
+        rows = temp_db.get_recent_processed_across_all_feeds(limit=10)
+
+        assert [r['episode_id'] for r in rows] == ['a2', 'b1', 'a1']
+        # Pending excluded
+        assert all(r.get('episode_id') != 'b-pending' for r in rows)
+        # Joined fields present
+        assert rows[0]['podcast_slug'] == 'alpha'
+        assert rows[0]['podcast_title'] == 'Alpha Show'
+
+    def test_limit_caps_results(self, temp_db):
+        self._seed(temp_db)
+
+        rows = temp_db.get_recent_processed_across_all_feeds(limit=2)
+
+        assert len(rows) == 2
+        assert [r['episode_id'] for r in rows] == ['a2', 'b1']
+
+    def test_zero_or_negative_limit_returns_empty(self, temp_db):
+        self._seed(temp_db)
+
+        assert temp_db.get_recent_processed_across_all_feeds(limit=0) == []
+        assert temp_db.get_recent_processed_across_all_feeds(limit=-5) == []
+
+
+class TestBuildCombinedFeed:
+    def _episode(self, **overrides):
+        base = {
+            'episode_id': 'a2',
+            'title': 'Alpha Episode 2',
+            'description': 'Latest alpha',
+            'published_at': '2026-05-07T10:00:00Z',
+            'new_duration': 1900,
+            'episode_number': 2,
+            'processed_version': 0,
+            'episode_artwork_url': None,
+            'podcast_slug': 'alpha',
+            'podcast_title': 'Alpha Show',
+            'podcast_artwork_url': 'https://a.example/art.png',
+        }
+        base.update(overrides)
+        return base
+
+    def test_renders_well_formed_rss_with_n_items(self):
+        parser = RSSParser(base_url='http://10.0.0.190:8080')
+        episodes = [
+            self._episode(),
+            self._episode(
+                episode_id='b1', title='Beta Episode 1',
+                podcast_slug='beta', podcast_title='Beta Show',
+                published_at='2026-05-05T10:00:00Z',
+            ),
+        ]
+
+        xml = parser.build_combined_feed(episodes)
+
+        root = ET.fromstring(xml)
+        assert root.tag == 'rss'
+        items = root.findall('./channel/item')
+        assert len(items) == 2
+        # Channel-level title is the unified label
+        assert root.find('./channel/title').text == 'MinusPod — All Podcasts'
+
+    def test_prefixes_podcast_title_in_episode_title(self):
+        parser = RSSParser(base_url='http://10.0.0.190:8080')
+        xml = parser.build_combined_feed([self._episode()])
+
+        root = ET.fromstring(xml)
+        title = root.find('./channel/item/title').text
+        assert title == '[Alpha Show] Alpha Episode 2'
+
+    def test_enclosure_url_uses_per_episode_route_shape(self):
+        parser = RSSParser(base_url='http://10.0.0.190:8080')
+        xml = parser.build_combined_feed([self._episode()])
+
+        root = ET.fromstring(xml)
+        encl = root.find('./channel/item/enclosure')
+        assert encl.attrib['url'] == 'http://10.0.0.190:8080/episodes/alpha/a2.mp3'
+        assert encl.attrib['type'] == 'audio/mpeg'
+
+    def test_versioned_processed_file_url(self):
+        parser = RSSParser(base_url='http://10.0.0.190:8080')
+        xml = parser.build_combined_feed(
+            [self._episode(processed_version=2)])
+
+        encl = ET.fromstring(xml).find('./channel/item/enclosure')
+        assert encl.attrib['url'] == 'http://10.0.0.190:8080/episodes/alpha/a2-v2.mp3'
+
+    def test_guid_is_namespaced_by_slug_to_avoid_collision(self):
+        parser = RSSParser(base_url='http://10.0.0.190:8080')
+        # Two podcasts that happen to share an episode_id
+        eps = [
+            self._episode(episode_id='shared'),
+            self._episode(
+                episode_id='shared', title='Beta Shared',
+                podcast_slug='beta', podcast_title='Beta Show',
+            ),
+        ]
+        xml = parser.build_combined_feed(eps)
+
+        guids = [g.text for g in ET.fromstring(xml).findall('./channel/item/guid')]
+        assert guids == ['alpha::shared', 'beta::shared']
+
+    def test_empty_episode_list_returns_valid_empty_channel(self):
+        parser = RSSParser(base_url='http://10.0.0.190:8080')
+        xml = parser.build_combined_feed([])
+
+        root = ET.fromstring(xml)
+        assert root.find('./channel/title').text == 'MinusPod — All Podcasts'
+        assert root.findall('./channel/item') == []
+
+    def test_channel_artwork_points_at_minuspod_logo(self):
+        parser = RSSParser(base_url='http://10.0.0.190:8080')
+        xml = parser.build_combined_feed([self._episode()])
+
+        root = ET.fromstring(xml)
+        image_url = root.find('./channel/image/url').text
+        assert image_url == 'http://10.0.0.190:8080/ui/feed-icon.png'
+        # itunes:image with the same href (Apple Podcasts requires it)
+        ns = {'itunes': 'http://www.itunes.com/dtds/podcast-1.0.dtd'}
+        itunes_image = root.find('./channel/itunes:image', ns)
+        assert itunes_image is not None
+        assert itunes_image.attrib['href'] == 'http://10.0.0.190:8080/ui/feed-icon.png'
+
+    def test_skips_rows_missing_required_keys(self):
+        parser = RSSParser(base_url='http://10.0.0.190:8080')
+        # Missing podcast_slug — must be silently dropped, not raise.
+        eps = [
+            self._episode(),
+            self._episode(podcast_slug=None, episode_id='orphan'),
+        ]
+        xml = parser.build_combined_feed(eps)
+        items = ET.fromstring(xml).findall('./channel/item')
+        assert len(items) == 1


### PR DESCRIPTION
Adds a single subscribe URL (`{BASE_URL}/all`) that aggregates the most-recent processed episodes from every podcast managed by this instance. Podcast apps can subscribe once and receive a unified inbox across the entire library, eliminating the per-podcast subscribe step that scales poorly past ~10 feeds.

Backend
-------
- `EpisodeMixin.get_recent_processed_across_all_feeds(limit)` — single query joining `episodes` × `podcasts`, filters on `status='processed' AND processed_file IS NOT NULL`, orders by `COALESCE(published_at, created_at) DESC`. No N+1.
- `RSSParser.build_combined_feed(episodes, base_url, logo_url)` — RSS 2.0 with `itunes:` and `podcast:` namespaces. Episode titles are prefixed `[Podcast Title]` so listeners can identify the source. GUIDs are namespaced by slug (`<slug>::<episode_id>`) to avoid collisions across feeds.
- `/all` route serves the combined feed with a 15-min in-memory cache invalidated on `BASE_URL` change. Werkzeug's literal-route precedence means `/all` never collides with a podcast slug named "all".
- `combined_feed_episode_limit` setting (default 50, range 1–500) wired through `GET`/`PUT /api/v1/settings`.
- Channel artwork is the existing MinusPod logo upscaled to 3000×3000 at Docker build time via `ffmpeg`. Apple Podcasts requires a minimum 3000×3000 channel image. No new Python/Pillow dependency.

Frontend
--------
- New `CombinedFeedCard` component, mounted at the top of the Feeds list on the Dashboard. Shows logo, subscribe URL, copy-to-clipboard button, and an inline auto-saving episode-limit input.
- `combinedFeedEpisodeLimit` field wired through the existing settings state machine (Settings.tsx state, snapshot, dirty-check, mutation).
- No new top-level navigation; the `/all` URL is published exclusively through the dashboard card.

Tests
-----
11 new unit tests in `tests/unit/test_combined_feed.py`:
- DB: query returns processed-only, ordered correctly, respects limit, empty input safe.
- XML: structure (rss/channel/item shape), title-prefix format, enclosure URL shape (incl. `*-vN.mp3` versioned files), GUID namespacing, channel-level 3000×3000 logo references, graceful skip on malformed rows.

`pytest tests/unit/test_combined_feed.py tests/unit/test_rss_parser.py tests/unit/test_settings_validation.py` → 35/35 pass against the production container's deps.

Why now
-------
Subscribing to ~30 podcasts in a podcast app is tedious; once you do it, marking the in-app inbox is per-feed too. A unified `/all` feed collapses both problems and works in any podcast app that speaks RSS.

Compatibility
-------------
- New route at root level — does not interfere with existing `/<slug>` per-podcast routing because Werkzeug prefers literal routes over parameterized ones.
- New setting defaults to 50; existing instances will start serving the combined feed immediately on first GET (lazy default).
- DB migration is implicit (settings table holds string values keyed by name; no schema change needed).