### PR TITLE
feat(ad-inbox): per-ad review modal with waveform editor + paginated display

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,8 @@
     "react-router-dom": "^6.30.3",
     "recharts": "^3.8.1",
     "swagger-ui-dist": "^5.32.5",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "wavesurfer.js": "^7.8.0"
   },
   "overrides": {
     "serialize-javascript": ">=7.0.5",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import EpisodeDetail from './pages/EpisodeDetail';
 import AddFeed from './pages/AddFeed';
 import Settings from './pages/Settings';
 import PatternsPage from './pages/PatternsPage';
+import AdInboxPage from './pages/AdInboxPage';
 import HistoryPage from './pages/HistoryPage';
 import StatsPage from './pages/StatsPage';
 import Login from './pages/Login';
@@ -28,6 +29,7 @@ function App() {
               <Route path="feeds/:slug/episodes/:episodeId" element={<EpisodeDetail />} />
               <Route path="add" element={<AddFeed />} />
               <Route path="search" element={<Search />} />
+              <Route path="inbox" element={<AdInboxPage />} />
               <Route path="patterns" element={<PatternsPage />} />
               <Route path="history" element={<HistoryPage />} />
               <Route path="stats" element={<StatsPage />} />

--- a/frontend/src/api/adInbox.ts
+++ b/frontend/src/api/adInbox.ts
@@ -1,0 +1,69 @@
+import { apiRequest, buildQueryString } from './client';
+
+export type InboxStatus = 'pending' | 'confirmed' | 'rejected' | 'adjusted';
+export type InboxStatusFilter = InboxStatus | 'all';
+
+export interface InboxItem {
+  podcastSlug: string;
+  podcastTitle: string;
+  episodeId: string;
+  episodeTitle: string | null;
+  publishedAt: string | null;
+  processedVersion: number | null;
+  adIndex: number;
+  start: number;
+  end: number;
+  duration: number;
+  sponsor: string | null;
+  reason: string | null;
+  confidence: number | null;
+  detectionStage: string | null;
+  patternId: number | null;
+  status: InboxStatus;
+  correctedBounds: { start: number; end: number } | null;
+}
+
+export interface InboxResponse {
+  items: InboxItem[];
+  total: number;
+  limit: number;
+  offset: number;
+  status: InboxStatusFilter;
+  counts: {
+    pending: number;
+    confirmed: number;
+    rejected: number;
+    adjusted: number;
+  };
+}
+
+export async function getAdInbox(
+  status: InboxStatusFilter = 'pending',
+  limit = 50,
+  offset = 0,
+): Promise<InboxResponse> {
+  // buildQueryString already returns the leading "?" (or "" when empty).
+  const qs = buildQueryString({ status, limit, offset });
+  return apiRequest<InboxResponse>(`/ad-inbox${qs}`);
+}
+
+export interface PeaksResponse {
+  episodeId: string;
+  start: number;
+  end: number | null;
+  resolutionMs: number;
+  peaks: number[];
+}
+
+export async function getEpisodePeaks(
+  slug: string,
+  episodeId: string,
+  start: number,
+  end: number,
+  resolutionMs = 50,
+): Promise<PeaksResponse> {
+  const qs = buildQueryString({ start, end, resolution_ms: resolutionMs });
+  return apiRequest<PeaksResponse>(
+    `/feeds/${slug}/episodes/${episodeId}/peaks${qs}`,
+  );
+}

--- a/frontend/src/api/patterns.ts
+++ b/frontend/src/api/patterns.ts
@@ -35,6 +35,10 @@ export interface PatternCorrection {
   adjusted_start?: number;
   adjusted_end?: number;
   notes?: string;
+  // Optional sponsor name typed by the user in the Ad Inbox modal when the
+  // server's sponsor extractor returned nothing. Backend honors this on
+  // confirm/adjust to create an ad_patterns row.
+  sponsor?: string;
 }
 
 // Pattern Stats

--- a/frontend/src/components/AdReviewModal.tsx
+++ b/frontend/src/components/AdReviewModal.tsx
@@ -1,0 +1,1108 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import {
+  Play, Pause, SkipBack, SkipForward, Rewind, FastForward, Square,
+  ZoomIn, ZoomOut,
+} from 'lucide-react';
+import WaveSurfer from 'wavesurfer.js';
+import RegionsPlugin from 'wavesurfer.js/dist/plugins/regions.esm.js';
+import type { InboxItem } from '../api/adInbox';
+import { getEpisodePeaks } from '../api/adInbox';
+import { submitCorrection } from '../api/patterns';
+
+interface Props {
+  item: InboxItem;
+  onClose: () => void;
+  onSaveAndNext: () => void;
+  // Advance without mutating the DB. Item stays in pending; UI filters it
+  // out of this session's queue so the user isn't bounced back to it.
+  onSkip: () => void;
+}
+
+const CONTEXT_SECONDS = 30;
+// Cap the default visible window. Some heuristic detections (notably
+// post-roll) flag dozens of minutes as a single "ad", which would make
+// the default fit-zoom view useless (whole episode squeezed into one
+// screen). Six minutes is enough to set ad start with context; user can
+// always expand via the +1m buttons or wheel-zoom in.
+const DEFAULT_MAX_WINDOW_SECONDS = 360;
+const WINDOW_STEP_SECONDS = 60;
+// 100ms buckets — 4× fewer peaks than the prior 50ms default. Still plenty
+// of detail to see speech vs. silence at any reasonable zoom level, and
+// shaves the JSON payload + canvas-render cost on first mount roughly 4×.
+const PEAK_RESOLUTION_MS = 100;
+const MIN_WINDOW_PAD = 10;
+const MIN_AD_DURATION = 1.0;
+const PLAY_WHILE_DRAG_KEY = 'minuspod.adInbox.playWhileDragging';
+
+function formatTime(seconds: number): string {
+  if (!Number.isFinite(seconds)) return '0:00';
+  const sign = seconds < 0 ? '-' : '';
+  const total = Math.abs(seconds);
+  const m = Math.floor(total / 60);
+  const s = total - m * 60;
+  return `${sign}${m}:${s.toFixed(1).padStart(4, '0')}`;
+}
+
+function loadPlayWhileDragging(): boolean {
+  try {
+    return localStorage.getItem(PLAY_WHILE_DRAG_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+function savePlayWhileDragging(v: boolean) {
+  try {
+    localStorage.setItem(PLAY_WHILE_DRAG_KEY, v ? '1' : '0');
+  } catch {
+    /* private mode etc */
+  }
+}
+
+// ----------------------------------------------------------------------
+// Pin: vertical drag handle above the waveform that controls the
+// corresponding ad boundary. Pins ARE the user's drag interface — the
+// wavesurfer region is decorative (drag/resize disabled on it).
+
+interface PinProps {
+  kind: 'start' | 'end';
+  boundary: number;
+  windowStart: number;
+  windowDuration: number;
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  onChange: (next: number) => void;
+  // Called while drag is in progress so we can scrub audio if enabled.
+  onDragMove?: (next: number) => void;
+  onDragStart?: () => void;
+  onDragEnd?: () => void;
+  otherBoundary: number;        // for min-separation clamp
+}
+
+function Pin({
+  kind, boundary, windowStart, windowDuration, containerRef,
+  onChange, onDragMove, onDragStart, onDragEnd, otherBoundary,
+}: PinProps) {
+  const [dragging, setDragging] = useState(false);
+
+  const relX = (boundary - windowStart) / windowDuration;
+  // Tolerate a tiny bit outside [0, 1] — happens routinely on post-roll ads
+  // where the LLM places adEnd a hair past where the audio file actually
+  // ends, which makes relX = 1.0001 or so. Without slop the END pin
+  // disappears entirely.
+  const visible = relX >= -0.02 && relX <= 1.02;
+  const leftPct = Math.max(0, Math.min(1, relX)) * 100;
+
+  const isStart = kind === 'start';
+  const color = isStart ? 'bg-emerald-500' : 'bg-rose-500';
+  const ringColor = isStart ? 'ring-emerald-500/40' : 'ring-rose-500/40';
+  const labelText = isStart ? 'START' : 'END';
+
+  const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const container = containerRef.current;
+    if (!container) return;
+
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    setDragging(true);
+    onDragStart?.();
+
+    const rect = container.getBoundingClientRect();
+
+    const computeBoundary = (clientX: number): number => {
+      const xPct = (clientX - rect.left) / rect.width;
+      const clampedPct = Math.max(0, Math.min(1, xPct));
+      const t = windowStart + clampedPct * windowDuration;
+      // Min-separation: never let start cross end (and vice-versa).
+      if (isStart) return Math.min(t, otherBoundary - MIN_AD_DURATION);
+      return Math.max(t, otherBoundary + MIN_AD_DURATION);
+    };
+
+    const handleMove = (ev: PointerEvent) => {
+      const next = computeBoundary(ev.clientX);
+      onChange(next);
+      onDragMove?.(next);
+    };
+    const handleUp = (ev: PointerEvent) => {
+      const next = computeBoundary(ev.clientX);
+      onChange(next);
+      setDragging(false);
+      onDragEnd?.();
+      window.removeEventListener('pointermove', handleMove);
+      window.removeEventListener('pointerup', handleUp);
+      window.removeEventListener('pointercancel', handleUp);
+    };
+
+    window.addEventListener('pointermove', handleMove);
+    window.addEventListener('pointerup', handleUp);
+    window.addEventListener('pointercancel', handleUp);
+  };
+
+  if (!visible) return null;
+
+  // Compact pin: small colored circle pinhead, thin stem. The label
+  // (with time) only shows when the pin is being dragged or hovered —
+  // when idle, just the circle is visible. Negative top offsets are
+  // avoided so the pinhead doesn't get clipped by the parent's
+  // overflow-x scrollbox.
+
+  return (
+    <div
+      onPointerDown={onPointerDown}
+      style={{
+        left: `${leftPct}%`,
+        touchAction: 'none',
+      }}
+      className={`group absolute inset-y-0 -translate-x-1/2 z-10 cursor-ew-resize select-none ${
+        dragging ? 'cursor-grabbing' : ''
+      }`}
+      role="slider"
+      aria-label={`${labelText} pin · ${formatTime(boundary)}`}
+      aria-valuenow={Math.round(boundary * 10) / 10}
+    >
+      {/* Compact circle pinhead at top. */}
+      <div
+        className={`absolute top-1 left-1/2 -translate-x-1/2 w-3.5 h-3.5 rounded-full border-2 border-white ${color} shadow-md ${
+          dragging ? `ring-4 ${ringColor} scale-125` : ''
+        } transition-transform`}
+      />
+      {/* Time label — only visible while dragging or on hover. */}
+      <div
+        className={`absolute -top-5 left-1/2 -translate-x-1/2 px-1.5 py-0.5 rounded ${color} text-white text-[10px] font-bold tracking-wider whitespace-nowrap shadow-md transition-opacity duration-100 pointer-events-none ${
+          dragging ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+        }`}
+      >
+        {labelText} {formatTime(boundary)}
+      </div>
+      {/* Stem — runs from just below the circle to the bottom. */}
+      <div
+        className={`absolute top-[20px] bottom-0 left-1/2 -translate-x-1/2 w-0.5 ${color} ${
+          dragging ? 'opacity-100' : 'opacity-80'
+        }`}
+      />
+      {/* Touch target — wraps the whole pin column for easy mobile grab. */}
+      <div
+        className="absolute inset-y-0 -inset-x-4"
+        style={{ touchAction: 'none' }}
+      />
+    </div>
+  );
+}
+
+// ----------------------------------------------------------------------
+// Playhead cursor — ref-driven DOM updates from the RAF loop, NOT React
+// state, so position can update at full 60fps without re-rendering the
+// whole modal tree (which fights wavesurfer + the regions plugin).
+// Position is read from the parent component's RAF loop via the
+// imperative handle returned by Cursor.
+
+// ----------------------------------------------------------------------
+
+function AdReviewModal({ item, onClose, onSaveAndNext, onSkip }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);   // waveform host
+  const overlayRef = useRef<HTMLDivElement>(null);     // relative wrapper around waveform + pins
+  const scrollContainerRef = useRef<HTMLDivElement>(null); // overflow-x-auto wrapper
+  const cursorRef = useRef<HTMLDivElement>(null);      // playhead, position-updated from RAF
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const wsRef = useRef<WaveSurfer | null>(null);
+  const regionsRef = useRef<ReturnType<typeof RegionsPlugin.create> | null>(null);
+  const adRegionRef = useRef<ReturnType<RegionsPlugin['addRegion']> | null>(null);
+
+  // Defaults derived from the original detection — used by Reset.
+  const defaults = useMemo(() => {
+    const windowStart = Math.max(0, item.start - CONTEXT_SECONDS);
+    const naturalEnd = item.end + CONTEXT_SECONDS;
+    const cappedEnd = windowStart + DEFAULT_MAX_WINDOW_SECONDS;
+    return {
+      windowStart,
+      // Cap the visible default to DEFAULT_MAX_WINDOW_SECONDS so a heuristic
+      // post-roll that spans the rest of the episode doesn't render the
+      // whole thing at fit-zoom. User can still see further via +1m or by
+      // zooming.
+      windowEnd: Math.min(naturalEnd, cappedEnd),
+      adStart: (item.correctedBounds ?? item).start,
+      adEnd: (item.correctedBounds ?? item).end,
+    };
+  }, [item.start, item.end, item.correctedBounds]);
+
+  const [windowStart, setWindowStart] = useState(defaults.windowStart);
+  const [windowEnd, setWindowEnd] = useState(defaults.windowEnd);
+  const [adStart, setAdStart] = useState(defaults.adStart);
+  const [adEnd, setAdEnd] = useState(defaults.adEnd);
+
+  const [peaks, setPeaks] = useState<number[] | null>(null);
+  // Resolution actually used by the server. May be coarser than requested
+  // when the window is very long (audio_peaks auto-scales to keep the
+  // payload bounded). Drives effective-duration math below.
+  const [peakResolutionMs, setPeakResolutionMs] = useState<number>(PEAK_RESOLUTION_MS);
+  const [peaksError, setPeaksError] = useState<string | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  // Zoom is a multiplier of "fit" — 1 = fit-to-container, 2 = 2× zoomed in, etc.
+  const [zoom, setZoom] = useState(1);
+  const ZOOM_MIN = 1;
+  const ZOOM_MAX = 20;
+  // Bumped by resetView to force a clean wavesurfer rebuild (and re-fetch
+  // of peaks). Belt-and-suspenders so Reset always lands a known-good
+  // state regardless of which states actually changed.
+  const [resetTick, setResetTick] = useState(0);
+  const [playWhileDrag, setPlayWhileDrag] = useState<boolean>(loadPlayWhileDragging);
+  const wasPlayingBeforeDragRef = useRef(false);
+  // Save the playhead position before a pin drag (with playWhileDrag) so
+  // we can put it back where the user was listening, instead of stranding
+  // it at the new pin position.
+  const positionBeforePinDragRef = useRef<number | null>(null);
+  const [sponsorInput, setSponsorInput] = useState(item.sponsor ?? '');
+  const [showSponsorPrompt, setShowSponsorPrompt] = useState(!item.sponsor);
+
+  const audioUrl = `/api/v1/feeds/${item.podcastSlug}/episodes/${item.episodeId}/original.mp3`;
+  // The user-requested window. May extend past the actual end of the file
+  // for post-roll ads — ffmpeg silently truncates and returns fewer peaks.
+  const requestedWindowDuration = useMemo(
+    () => Math.max(0.001, windowEnd - windowStart),
+    [windowStart, windowEnd],
+  );
+  // The window we actually have peaks for. When peaks are loaded, derive
+  // duration from peak count × resolution so visual positioning matches
+  // the audio that exists. Pins / cursor / region all use this.
+  const windowDuration = useMemo(() => {
+    if (peaks && peaks.length > 0) {
+      return Math.max(0.001, (peaks.length * peakResolutionMs) / 1000);
+    }
+    return requestedWindowDuration;
+  }, [peaks, peakResolutionMs, requestedWindowDuration]);
+  // Effective end = start + actual covered duration. Used in the displayed
+  // time labels so the user sees the same window the pins / waveform are
+  // actually showing — important for post-roll ads whose requested window
+  // extends past the file end.
+  const effectiveWindowEnd = useMemo(
+    () => windowStart + windowDuration,
+    [windowStart, windowDuration],
+  );
+
+  // ------------------------------------------------------------------
+  // Fetch peaks whenever window changes.
+  useEffect(() => {
+    let cancelled = false;
+    setPeaksError(null);
+    setPeaks(null);
+    getEpisodePeaks(item.podcastSlug, item.episodeId, windowStart, windowEnd, PEAK_RESOLUTION_MS)
+      .then((res) => {
+        if (cancelled) return;
+        setPeaks(res.peaks);
+        setPeakResolutionMs(res.resolutionMs || PEAK_RESOLUTION_MS);
+      })
+      .catch((e) => {
+        if (!cancelled) setPeaksError(e instanceof Error ? e.message : String(e));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [item.podcastSlug, item.episodeId, windowStart, windowEnd, resetTick]);
+
+  // ------------------------------------------------------------------
+  // Mount wavesurfer when peaks/window arrive. Region is decorative —
+  // drag/resize disabled because the Pin components own that interaction.
+  useEffect(() => {
+    if (!containerRef.current || !peaks) return;
+
+    wsRef.current?.destroy();
+    wsRef.current = null;
+
+    const regions = RegionsPlugin.create();
+    const ws = WaveSurfer.create({
+      container: containerRef.current,
+      peaks: [peaks],
+      duration: windowDuration,
+      waveColor: '#64748b',
+      progressColor: '#22d3ee',
+      cursorColor: 'transparent',  // we render our own playhead — see <Cursor /> below
+      barWidth: 2,
+      barGap: 1,
+      barRadius: 2,
+      height: 120,
+      interact: true,
+      plugins: [regions],
+    });
+
+    regionsRef.current = regions;
+    wsRef.current = ws;
+
+    // wavesurfer 7 mounts its scroll-container inside an *open shadow DOM*
+    // attached to containerRef. When minPxPerSec*duration > parent width
+    // it grows an overflow-x: auto scrollbar — duplicate of our own outer
+    // wrapper. Walk the shadow tree and force every element with overflow
+    // styling to be visible. Use setProperty(important) because wavesurfer
+    // sets these as inline styles which a plain assignment can't override.
+    const stripInnerScroll = () => {
+      // Wavesurfer 7 mounts a div as containerRef's first child and
+      // attaches an open shadow root TO THAT DIV (not to containerRef
+      // itself). Walk through both layers.
+      const host = containerRef.current;
+      if (!host) return;
+      const wsHost = host.firstElementChild as HTMLElement | null;
+      if (wsHost) {
+        wsHost.style.setProperty('overflow', 'visible', 'important');
+      }
+      const shadow = wsHost?.shadowRoot ?? null;
+      const roots: (ShadowRoot | HTMLElement)[] = shadow ? [shadow, host] : [host];
+      for (const root of roots) {
+        root.querySelectorAll('*').forEach((el) => {
+          const e = el as HTMLElement;
+          if (e.style?.overflow || e.style?.overflowX || e.style?.overflowY) {
+            e.style.setProperty('overflow', 'visible', 'important');
+            e.style.setProperty('overflow-x', 'visible', 'important');
+            e.style.setProperty('overflow-y', 'visible', 'important');
+          }
+        });
+      }
+      // Belt-and-suspenders: also inject a !important rule into the
+      // shadow root so any post-render restyling is overridden too.
+      if (shadow && !shadow.querySelector('style[data-no-inner-scroll]')) {
+        const style = document.createElement('style');
+        style.setAttribute('data-no-inner-scroll', '1');
+        style.textContent = `
+          ::part(scroll), div { overflow: visible !important; overflow-x: visible !important; overflow-y: visible !important; }
+        `;
+        shadow.appendChild(style);
+      }
+    };
+    stripInnerScroll();
+    ws.on('redraw', stripInnerScroll);
+    ws.on('ready', stripInnerScroll);
+    // Backstop: a couple of deferred calls catch any post-init style
+    // applied after our initial pass (some wavesurfer versions style
+    // their wrapper asynchronously after the first render frame).
+    requestAnimationFrame(stripInnerScroll);
+    setTimeout(stripInnerScroll, 100);
+
+    const region = regions.addRegion({
+      start: Math.max(0, adStart - windowStart),
+      end: Math.min(windowDuration, adEnd - windowStart),
+      color: 'rgba(245, 158, 11, 0.18)',
+      drag: false,
+      resize: false,
+    });
+    adRegionRef.current = region;
+
+    // Stop the region from swallowing pointer events — clicks anywhere in
+    // the waveform (including inside the ad band) should pass through to
+    // wavesurfer's seek and to our cursor scrub overlay.
+    const regionEl = (region as unknown as { element?: HTMLElement }).element;
+    if (regionEl) {
+      regionEl.style.pointerEvents = 'none';
+    }
+
+    ws.on('interaction', (relTime: number) => {
+      if (audioRef.current) {
+        audioRef.current.currentTime = windowStart + relTime;
+      }
+    });
+
+    return () => {
+      ws.destroy();
+      wsRef.current = null;
+      regionsRef.current = null;
+      adRegionRef.current = null;
+    };
+    // Intentionally only re-mount on window/peaks change, not on bound moves.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [peaks, windowDuration, windowStart]);
+
+  // Push zoom changes into wavesurfer AND resize the pin overlay so the
+  // pins stay anchored to the right moments when zoomed. The pin overlay's
+  // width must match the waveform's actual rendered width — pins use
+  // `left: %` against the overlay's box.
+  useEffect(() => {
+    const ws = wsRef.current;
+    const sc = scrollContainerRef.current;
+    const overlay = overlayRef.current;
+    if (!ws || !sc || !overlay) return;
+    const fitPxPerSec = sc.clientWidth / Math.max(0.001, windowDuration);
+    const targetPxPerSec = fitPxPerSec * zoom;
+    const targetWidth = windowDuration * targetPxPerSec;
+    overlay.style.minWidth = `${targetWidth}px`;
+    try {
+      ws.zoom(targetPxPerSec);
+    } catch {
+      /* ws not ready */
+    }
+    // Kill the inner scrollbar wavesurfer (re)applies after zoom.
+    requestAnimationFrame(() => {
+      const host = containerRef.current;
+      const root = host?.shadowRoot ?? host;
+      if (!root) return;
+      root.querySelectorAll('*').forEach((el) => {
+        const e = el as HTMLElement;
+        if (e.style?.overflow || e.style?.overflowX || e.style?.overflowY) {
+          e.style.setProperty('overflow', 'visible', 'important');
+          e.style.setProperty('overflow-x', 'visible', 'important');
+          e.style.setProperty('overflow-y', 'visible', 'important');
+        }
+      });
+    });
+  }, [zoom, peaks, windowDuration]);
+
+  // Reflect ad-boundary state into the existing region without rebuilding ws.
+  useEffect(() => {
+    const region = adRegionRef.current;
+    if (!region) return;
+    try {
+      region.setOptions({
+        start: Math.max(0, adStart - windowStart),
+        end: Math.min(windowDuration, adEnd - windowStart),
+      });
+    } catch {
+      /* region torn down mid-update */
+    }
+  }, [adStart, adEnd, windowStart, windowDuration]);
+
+  // ------------------------------------------------------------------
+  // Cursor sync: <audio> drives the cursor position via direct DOM update
+  // (ref-based, no React re-render). React state is only updated ~10×/s
+  // for the transport time readout — full-rate state updates would
+  // re-render the whole modal at 60fps and stutter the cursor.
+  useEffect(() => {
+    let raf = 0;
+    let lastReportedRoundedTime = -1;
+    const loop = () => {
+      const audio = audioRef.current;
+      const cursor = cursorRef.current;
+      if (audio && cursor) {
+        const t = audio.currentTime;
+        const rel = (t - windowStart) / windowDuration;
+        if (Number.isFinite(rel) && rel >= 0 && rel <= 1) {
+          cursor.style.left = `${rel * 100}%`;
+          cursor.style.display = '';
+        } else {
+          cursor.style.display = 'none';
+        }
+        // Throttled state push for the transport readout.
+        const rounded = Math.round(t * 10) / 10;
+        if (rounded !== lastReportedRoundedTime) {
+          lastReportedRoundedTime = rounded;
+          setCurrentTime(t);
+        }
+      }
+      raf = requestAnimationFrame(loop);
+    };
+    raf = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(raf);
+  }, [windowStart, windowDuration]);
+
+  // ------------------------------------------------------------------
+  // Seed audio.currentTime to a sensible spot near the ad on first
+  // metadata-loaded event AND whenever the active item changes. Without
+  // this, audio plays from t=0 (the start of the file) when the user hits
+  // Play — for a post-roll ad whose window is at e.g. 6980-7200s, the
+  // cursor would never enter the visible window. Snap to ad-start so the
+  // user lands on the ad. We seed to (adStart - 2) for a tiny pre-roll.
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    const seek = () => {
+      const target = Math.max(0, adStart - 2);
+      // Don't fight the user if they've already moved the playhead.
+      if (audio.currentTime < 0.1) {
+        audio.currentTime = target;
+      }
+    };
+    if (audio.readyState >= 1 /* HAVE_METADATA */) {
+      seek();
+    } else {
+      audio.addEventListener('loadedmetadata', seek, { once: true });
+      return () => audio.removeEventListener('loadedmetadata', seek);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [item.podcastSlug, item.episodeId, item.adIndex, resetTick]);
+
+  // ------------------------------------------------------------------
+  // Audio playback.
+  const togglePlay = () => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    if (audio.paused) {
+      // Don't snap the playhead — let the user listen anywhere they want.
+      // Use the SkipBack button (or J / J on the ad start pin) to return
+      // to the ad start.
+      audio.play().then(() => setIsPlaying(true)).catch(() => setIsPlaying(false));
+    } else {
+      audio.pause();
+      setIsPlaying(false);
+    }
+  };
+
+  const seekTo = (t: number) => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    audio.currentTime = Math.max(0, t);
+  };
+  const seekRelative = (delta: number) => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    audio.currentTime = Math.max(0, audio.currentTime + delta);
+  };
+  const seekToAdStart = () => seekTo(adStart);
+  const seekToAdEnd = () => seekTo(adEnd);
+  const stopPlayback = () => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    audio.pause();
+    audio.currentTime = adStart;
+    setIsPlaying(false);
+  };
+
+  // ------------------------------------------------------------------
+  // Pin drag → optional audio scrub. Plays a tiny preview at the pin's
+  // current time so the user can hear what they're aligning to.
+  const onPinDragStart = () => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    wasPlayingBeforeDragRef.current = !audio.paused;
+    positionBeforePinDragRef.current = audio.currentTime;
+    if (playWhileDrag) {
+      audio.play().catch(() => {});
+    } else if (!audio.paused) {
+      audio.pause();
+    }
+  };
+  const onPinDragMove = (next: number) => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    audio.currentTime = next;
+  };
+  const onPinDragEnd = () => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    // Put the playhead back where the user was before they grabbed a
+    // pin. Adjusting an ad boundary shouldn't permanently move the
+    // listening position.
+    if (positionBeforePinDragRef.current !== null) {
+      audio.currentTime = positionBeforePinDragRef.current;
+      positionBeforePinDragRef.current = null;
+    }
+    // Restore the play/pause state from before the drag started, so
+    // adjusting a boundary never feels like it pressed Pause.
+    if (wasPlayingBeforeDragRef.current) {
+      audio.play()
+        .then(() => setIsPlaying(true))
+        .catch(() => setIsPlaying(false));
+    } else {
+      audio.pause();
+      setIsPlaying(false);
+    }
+  };
+
+  // ------------------------------------------------------------------
+  // Window expand / shrink / reset.
+  const expandBack = () => setWindowStart((s) => Math.max(0, s - WINDOW_STEP_SECONDS));
+  const expandForward = () => setWindowEnd((e) => e + WINDOW_STEP_SECONDS);
+  const shrinkBack = () =>
+    setWindowStart((s) => Math.min(adStart - MIN_WINDOW_PAD, s + WINDOW_STEP_SECONDS));
+  const shrinkForward = () =>
+    setWindowEnd((e) => Math.max(adEnd + MIN_WINDOW_PAD, e - WINDOW_STEP_SECONDS));
+  const resetView = () => {
+    setWindowStart(defaults.windowStart);
+    setWindowEnd(defaults.windowEnd);
+    setAdStart(defaults.adStart);
+    setAdEnd(defaults.adEnd);
+    setZoom(1);
+    setPeaks(null);                        // force a re-fetch + rebuild
+    setResetTick((n) => n + 1);
+    const audio = audioRef.current;
+    if (audio) {
+      audio.pause();
+      audio.currentTime = defaults.adStart;
+      setIsPlaying(false);
+    }
+  };
+
+  const zoomIn = () => setZoom((z) => Math.min(ZOOM_MAX, +(z * 1.5).toFixed(2)));
+  const zoomOut = () => setZoom((z) => Math.max(ZOOM_MIN, +(z / 1.5).toFixed(2)));
+
+  // Mouse-wheel zoom on the waveform: Ctrl/Shift wheel zooms,
+  // bare wheel still scrolls horizontally (browser default in overflow-x-auto).
+  // We intercept ALL wheel events on the scroll container so the user doesn't
+  // need a modifier key — feels more natural for an audio-editing surface.
+  const onWheel = (e: React.WheelEvent<HTMLDivElement>) => {
+    // Only act on vertical wheel (deltaY); leave horizontal wheel alone so
+    // trackpad horizontal panning still scrolls the waveform.
+    if (Math.abs(e.deltaY) < Math.abs(e.deltaX)) return;
+    e.preventDefault();
+    // Zoom around the cursor: capture the time at the cursor before, then
+    // restore the same time at the same cursor x after zoom by adjusting scroll.
+    const sc = scrollContainerRef.current;
+    if (!sc) return;
+    const rect = sc.getBoundingClientRect();
+    const cursorX = e.clientX - rect.left + sc.scrollLeft;
+    const fitPxPerSec = rect.width / Math.max(0.001, windowDuration);
+    const oldPxPerSec = fitPxPerSec * zoom;
+    const cursorTime = cursorX / Math.max(0.001, oldPxPerSec);
+    const factor = e.deltaY < 0 ? 1.15 : 1 / 1.15;
+    const nextZoom = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, +(zoom * factor).toFixed(3)));
+    setZoom(nextZoom);
+    // Re-anchor the cursor: schedule scroll adjustment after layout updates.
+    requestAnimationFrame(() => {
+      const sc2 = scrollContainerRef.current;
+      if (!sc2) return;
+      const newPxPerSec = fitPxPerSec * nextZoom;
+      const newCursorX = cursorTime * newPxPerSec;
+      sc2.scrollLeft = newCursorX - (e.clientX - rect.left);
+    });
+  };
+
+  // ------------------------------------------------------------------
+  // Mutations
+  const confirmMutation = useMutation({
+    mutationFn: () =>
+      submitCorrection(item.podcastSlug, item.episodeId, {
+        type: 'confirm',
+        original_ad: {
+          start: item.start, end: item.end,
+          pattern_id: item.patternId ?? undefined,
+          confidence: item.confidence ?? undefined,
+          reason: item.reason ?? undefined,
+          sponsor: item.sponsor ?? undefined,
+        },
+        sponsor: sponsorInput.trim() || undefined,
+      }),
+  });
+  const rejectMutation = useMutation({
+    mutationFn: () =>
+      submitCorrection(item.podcastSlug, item.episodeId, {
+        type: 'reject',
+        original_ad: {
+          start: item.start, end: item.end,
+          pattern_id: item.patternId ?? undefined,
+          confidence: item.confidence ?? undefined,
+          reason: item.reason ?? undefined,
+          sponsor: item.sponsor ?? undefined,
+        },
+      }),
+  });
+  const adjustMutation = useMutation({
+    mutationFn: () =>
+      submitCorrection(item.podcastSlug, item.episodeId, {
+        type: 'adjust',
+        original_ad: {
+          start: item.start, end: item.end,
+          pattern_id: item.patternId ?? undefined,
+          confidence: item.confidence ?? undefined,
+          reason: item.reason ?? undefined,
+          sponsor: item.sponsor ?? undefined,
+        },
+        adjusted_start: adStart,
+        adjusted_end: adEnd,
+        sponsor: sponsorInput.trim() || undefined,
+      }),
+  });
+
+  const isBusy =
+    confirmMutation.isPending || rejectMutation.isPending || adjustMutation.isPending;
+
+  const boundariesMoved =
+    Math.abs(adStart - item.start) > 0.05 || Math.abs(adEnd - item.end) > 0.05;
+
+  const handleConfirm = async () => {
+    if (boundariesMoved) await adjustMutation.mutateAsync();
+    else await confirmMutation.mutateAsync();
+    onSaveAndNext();
+  };
+
+  const handleReject = async () => {
+    await rejectMutation.mutateAsync();
+    onSaveAndNext();
+  };
+
+  // ------------------------------------------------------------------
+  // Hotkeys
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      const inField =
+        target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA');
+      if (inField && e.key !== 'Escape') return;
+
+      if (e.key === 'Escape') { e.preventDefault(); onClose(); return; }
+      if (e.key === ' ')      { e.preventDefault(); togglePlay(); return; }
+      if (e.key === ',')      { e.preventDefault(); expandBack(); return; }
+      if (e.key === '.')      { e.preventDefault(); expandForward(); return; }
+      if (e.key === 'c' || e.key === 'C') { e.preventDefault(); if (!isBusy) handleConfirm(); return; }
+      if (e.key === 'r' || e.key === 'R') { e.preventDefault(); if (!isBusy) handleReject(); return; }
+      if (e.key === 's' || e.key === 'S') { e.preventDefault(); if (!isBusy) onSkip(); return; }
+      if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+        const audio = audioRef.current;
+        if (!audio) return;
+        e.preventDefault();
+        const delta = e.shiftKey ? 5 : 1;
+        audio.currentTime += e.key === 'ArrowRight' ? delta : -delta;
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isBusy, onClose, sponsorInput, adStart, adEnd, item.start, item.end]);
+
+  // ------------------------------------------------------------------
+  // Style helpers — explicit hover treatments so buttons clearly
+  // highlight on mouseover instead of looking washed out.
+
+  const primaryBtn =
+    'bg-primary text-primary-foreground transition-all ' +
+    'hover:bg-primary hover:ring-2 hover:ring-primary hover:ring-offset-2 hover:ring-offset-card ' +
+    'disabled:opacity-50 disabled:cursor-not-allowed';
+  const destructiveBtn =
+    'bg-destructive text-destructive-foreground transition-all ' +
+    'hover:bg-destructive hover:ring-2 hover:ring-destructive hover:ring-offset-2 hover:ring-offset-card ' +
+    'disabled:opacity-50 disabled:cursor-not-allowed';
+  const ghostBtn =
+    'border border-border text-foreground bg-card transition-colors ' +
+    'hover:bg-accent hover:text-accent-foreground hover:border-foreground/30 ' +
+    'disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-card disabled:hover:text-foreground disabled:hover:border-border';
+
+  // ------------------------------------------------------------------
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" onClick={onClose}>
+      <div
+        className="bg-card rounded-lg border border-border w-full max-w-4xl max-h-[90vh] overflow-y-auto shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="px-6 py-4 border-b border-border flex items-start justify-between gap-4">
+          <div className="min-w-0 flex-1">
+            <div className="text-xs uppercase tracking-wider text-muted-foreground">
+              {item.podcastTitle}
+            </div>
+            <h2 className="text-lg font-semibold text-foreground truncate">
+              {item.episodeTitle ?? item.episodeId}
+            </h2>
+            <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+              <span>Stage: {item.detectionStage ?? '—'}</span>
+              {item.confidence !== null && <span>Confidence: {Math.round(item.confidence * 100)}%</span>}
+              {item.patternId !== null && <span>Pattern #{item.patternId}</span>}
+              {item.reason && <span className="italic truncate max-w-md" title={item.reason}>{item.reason}</span>}
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1 rounded text-muted-foreground transition-colors hover:text-foreground hover:bg-accent"
+            aria-label="Close"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Window controls + reset */}
+        <div className="px-6 pt-4 flex items-center justify-between gap-2 flex-wrap text-xs text-muted-foreground tabular-nums">
+          <div className="flex items-center gap-2">
+            <button type="button" onClick={expandBack}
+              className={`px-2 py-1 rounded ${ghostBtn}`}
+              title="Expand window 1 min earlier ( , )">« +1m</button>
+            <button type="button" onClick={shrinkBack}
+              disabled={windowStart >= adStart - MIN_WINDOW_PAD - WINDOW_STEP_SECONDS}
+              className={`px-2 py-1 rounded ${ghostBtn}`}
+              title="Shrink window from the left">» −1m</button>
+            <span className="ml-2">{formatTime(windowStart)}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <label className="flex items-center gap-1.5 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={playWhileDrag}
+                onChange={(e) => {
+                  setPlayWhileDrag(e.target.checked);
+                  savePlayWhileDragging(e.target.checked);
+                }}
+                className="accent-primary"
+              />
+              <span>Play audio while dragging pin</span>
+            </label>
+            <button type="button" onClick={resetView}
+              className={`px-2 py-1 rounded ${ghostBtn}`}
+              title="Reset waveform window + ad bounds to defaults">↻ Reset</button>
+          </div>
+          <div className="flex items-center gap-2">
+            <span>{formatTime(effectiveWindowEnd)}</span>
+            <button type="button" onClick={shrinkForward}
+              disabled={windowEnd <= adEnd + MIN_WINDOW_PAD + WINDOW_STEP_SECONDS}
+              className={`ml-2 px-2 py-1 rounded ${ghostBtn}`}
+              title="Shrink window from the right">« −1m</button>
+            <button type="button" onClick={expandForward}
+              className={`px-2 py-1 rounded ${ghostBtn}`}
+              title="Expand window 1 min later ( . )">+1m »</button>
+          </div>
+        </div>
+
+        {/* Waveform + pin overlay */}
+        <div className="px-6 py-4">
+          <div className="bg-secondary/40 rounded-lg p-3 min-h-[180px]">
+            {peaksError ? (
+              <p className="text-sm text-destructive">Failed to load waveform: {peaksError}</p>
+            ) : !peaks ? (
+              <p className="text-sm text-muted-foreground">Loading waveform…</p>
+            ) : (
+              <div
+                ref={scrollContainerRef}
+                onWheel={onWheel}
+                className="overflow-x-auto"
+              >
+                <div className="relative min-w-full" ref={overlayRef}>
+                  {/* Header strip — gives the pinheads a place to live INSIDE
+                      the overlay's box (so they aren't clipped by the
+                      enclosing overflow-x-auto scroll container). */}
+                  <div className="h-9" />
+                  {/* Pins live in the same horizontal coordinate system as
+                      the waveform host (overlayRef). When zoom > 1, wavesurfer
+                      widens its canvas — the relative wrapper grows with it,
+                      so pin `left: %` keeps tracking the right time. */}
+                  <Pin
+                    kind="start"
+                    boundary={adStart}
+                    windowStart={windowStart}
+                    windowDuration={windowDuration}
+                    containerRef={overlayRef}
+                    otherBoundary={adEnd}
+                    onChange={setAdStart}
+                    onDragStart={onPinDragStart}
+                    onDragMove={playWhileDrag ? onPinDragMove : undefined}
+                    onDragEnd={onPinDragEnd}
+                  />
+                  <Pin
+                    kind="end"
+                    boundary={adEnd}
+                    windowStart={windowStart}
+                    windowDuration={windowDuration}
+                    containerRef={overlayRef}
+                    otherBoundary={adStart}
+                    onChange={setAdEnd}
+                    onDragStart={onPinDragStart}
+                    onDragMove={playWhileDrag ? onPinDragMove : undefined}
+                    onDragEnd={onPinDragEnd}
+                  />
+                  <div
+                    ref={cursorRef}
+                    className="group/cursor absolute inset-y-0 -translate-x-1/2 z-20"
+                    style={{ left: '0%', display: 'none', touchAction: 'none' }}
+                    aria-hidden
+                    onPointerDown={(e) => {
+                      // Drag the cursor pinhead to scrub the audio. Scrub
+                      // is bounded by the visible window, NOT the ad
+                      // boundary — user can listen anywhere in context.
+                      const overlay = overlayRef.current;
+                      const audio = audioRef.current;
+                      if (!overlay || !audio) return;
+                      e.preventDefault();
+                      e.stopPropagation();
+                      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+                      const rect = overlay.getBoundingClientRect();
+                      // AUDIO PLAYS DURING SCRUB. Start playback if it was
+                      // paused so the user always hears what they're
+                      // pointing at; just keep seeking on each pointermove.
+                      if (audio.paused) {
+                        audio.play()
+                          .then(() => setIsPlaying(true))
+                          .catch(() => {});
+                      }
+                      const compute = (clientX: number) => {
+                        const xPct = (clientX - rect.left) / rect.width;
+                        const clamped = Math.max(0, Math.min(1, xPct));
+                        return windowStart + clamped * windowDuration;
+                      };
+                      const onMove = (ev: PointerEvent) => {
+                        audio.currentTime = compute(ev.clientX);
+                      };
+                      const onUp = (ev: PointerEvent) => {
+                        audio.currentTime = compute(ev.clientX);
+                        window.removeEventListener('pointermove', onMove);
+                        window.removeEventListener('pointerup', onUp);
+                        window.removeEventListener('pointercancel', onUp);
+                      };
+                      window.addEventListener('pointermove', onMove);
+                      window.addEventListener('pointerup', onUp);
+                      window.addEventListener('pointercancel', onUp);
+                    }}
+                  >
+                    {/* Compact circle pinhead at top. */}
+                    <div className="absolute top-1 left-1/2 -translate-x-1/2 w-3.5 h-3.5 rounded-full border-2 border-white bg-amber-500 shadow-md cursor-ew-resize" />
+                    {/* Time label — hover or while moving. */}
+                    <div className="absolute -top-5 left-1/2 -translate-x-1/2 px-1.5 py-0.5 rounded bg-amber-500 text-white text-[10px] font-bold whitespace-nowrap shadow-md transition-opacity duration-100 pointer-events-none opacity-0 group-hover/cursor:opacity-100">
+                      ▶ {formatTime(currentTime)}
+                    </div>
+                    {/* Stem */}
+                    <div className="absolute top-[20px] bottom-0 left-1/2 -translate-x-1/2 w-0.5 bg-amber-500 shadow-[0_0_4px_rgba(245,158,11,0.8)] pointer-events-none" />
+                    {/* Wider hit area */}
+                    <div className="absolute inset-y-0 -inset-x-4 cursor-ew-resize" />
+                  </div>
+                  <div ref={containerRef} className="w-full" />
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Zoom slider */}
+          <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+            <button type="button" onClick={zoomOut}
+              disabled={zoom <= ZOOM_MIN + 0.01}
+              className={`p-1.5 rounded ${ghostBtn}`}
+              title="Zoom out (mouse wheel down)">
+              <ZoomOut className="w-3.5 h-3.5" />
+            </button>
+            <input
+              type="range"
+              min={ZOOM_MIN}
+              max={ZOOM_MAX}
+              step={0.1}
+              value={zoom}
+              onChange={(e) => setZoom(Number(e.target.value))}
+              className="flex-1 accent-primary"
+              title="Zoom"
+            />
+            <button type="button" onClick={zoomIn}
+              disabled={zoom >= ZOOM_MAX - 0.01}
+              className={`p-1.5 rounded ${ghostBtn}`}
+              title="Zoom in (mouse wheel up)">
+              <ZoomIn className="w-3.5 h-3.5" />
+            </button>
+            <span className="tabular-nums w-10 text-right">{zoom.toFixed(1)}×</span>
+          </div>
+
+          {/* Boundaries readout */}
+          <div className="mt-3 flex flex-wrap items-center gap-3 text-sm text-muted-foreground tabular-nums">
+            <span>
+              Selection:{' '}
+              <span className="text-emerald-500 font-medium">{formatTime(adStart)}</span>{' '}
+              –{' '}
+              <span className="text-rose-500 font-medium">{formatTime(adEnd)}</span>{' '}
+              <span className="text-xs">({Math.round((adEnd - adStart) * 10) / 10}s)</span>
+            </span>
+            {boundariesMoved && (
+              <span className="text-xs text-amber-500">
+                (originally {formatTime(item.start)} – {formatTime(item.end)})
+              </span>
+            )}
+          </div>
+
+          <audio
+            ref={audioRef}
+            src={audioUrl}
+            preload="metadata"
+            onPlay={() => setIsPlaying(true)}
+            onPause={() => setIsPlaying(false)}
+            onEnded={() => setIsPlaying(false)}
+          />
+
+          {/* Transport bar */}
+          <div className="mt-3 flex items-center justify-between gap-3 px-3 py-2 rounded-lg bg-secondary/50 border border-border flex-wrap">
+            <div className="flex items-center gap-1">
+              <button type="button" onClick={seekToAdStart}
+                className={`p-2 rounded ${ghostBtn}`}
+                title="Jump to START pin">
+                <SkipBack className="w-4 h-4" />
+              </button>
+              <button type="button" onClick={() => seekRelative(-10)}
+                className={`p-2 rounded ${ghostBtn}`}
+                title="Back 10s">
+                <Rewind className="w-4 h-4" />
+              </button>
+              <button type="button" onClick={togglePlay}
+                className={`p-2 rounded-full ${primaryBtn}`}
+                title="Play / pause (Space)">
+                {isPlaying ? <Pause className="w-5 h-5" /> : <Play className="w-5 h-5" />}
+              </button>
+              <button type="button" onClick={() => seekRelative(10)}
+                className={`p-2 rounded ${ghostBtn}`}
+                title="Forward 10s">
+                <FastForward className="w-4 h-4" />
+              </button>
+              <button type="button" onClick={seekToAdEnd}
+                className={`p-2 rounded ${ghostBtn}`}
+                title="Jump to END pin">
+                <SkipForward className="w-4 h-4" />
+              </button>
+              <button type="button" onClick={stopPlayback}
+                className={`p-2 rounded ${ghostBtn}`}
+                title="Stop (pause + return to START)">
+                <Square className="w-4 h-4" />
+              </button>
+            </div>
+            <div className="flex items-center gap-2 text-xs tabular-nums text-muted-foreground">
+              <span className="text-foreground">{formatTime(currentTime)}</span>
+              <span>/</span>
+              <span>{formatTime(adEnd - adStart)} selection</span>
+              {currentTime >= adStart && currentTime <= adEnd && (
+                <span className="ml-2 px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-500 text-[10px] font-semibold uppercase tracking-wider">
+                  inside ad
+                </span>
+              )}
+            </div>
+          </div>
+
+          <div className="mt-2 text-xs text-muted-foreground">
+            Drag the <span className="text-emerald-500 font-semibold">START</span> /{' '}
+            <span className="text-rose-500 font-semibold">END</span> pins above the waveform.{' '}
+            <kbd>Space</kbd> play • <kbd>,</kbd>/<kbd>.</kbd> expand window • mouse-wheel to zoom • <kbd>C</kbd> confirm • <kbd>R</kbd> reject • <kbd>S</kbd> skip
+          </div>
+        </div>
+
+        {/* Sponsor prompt */}
+        {showSponsorPrompt ? (
+          <div className="px-6 py-4 border-t border-border bg-secondary/30">
+            <label htmlFor="sponsor" className="block text-sm font-medium text-foreground mb-1">
+              Sponsor name
+              <span className="ml-2 text-xs font-normal text-muted-foreground">
+                (so this confirmation can train Stage 2 — leave blank to skip pattern creation)
+              </span>
+            </label>
+            <input
+              id="sponsor" type="text" value={sponsorInput}
+              onChange={(e) => setSponsorInput(e.target.value)}
+              placeholder="e.g. BetterHelp, Squarespace, Progressive"
+              className="w-full px-3 py-1.5 rounded-lg border border-input bg-background text-foreground focus:outline-hidden focus:ring-2 focus:ring-ring text-sm"
+            />
+          </div>
+        ) : (
+          <div className="px-6 py-2 border-t border-border text-xs text-muted-foreground">
+            Sponsor: <span className="text-foreground">{item.sponsor}</span>{' '}
+            <button type="button" onClick={() => setShowSponsorPrompt(true)}
+              className="ml-2 underline transition-colors hover:text-foreground">edit</button>
+          </div>
+        )}
+
+        {/* Action bar */}
+        <div className="px-6 py-4 border-t border-border bg-secondary/40 flex items-center justify-between gap-3 flex-wrap">
+          <div className="text-xs text-muted-foreground">
+            {boundariesMoved
+              ? 'Confirm will save adjusted boundaries.'
+              : 'Confirm will record this ad as-detected.'}
+          </div>
+          <div className="flex items-center gap-2">
+            <button type="button" onClick={onSkip} disabled={isBusy}
+              className={`px-4 py-1.5 rounded-lg ${ghostBtn} text-sm`}
+              title="Skip — leave in inbox, hide from this session (S)">
+              Skip & Next
+            </button>
+            <button type="button" onClick={handleReject} disabled={isBusy}
+              className={`px-4 py-1.5 rounded-lg ${destructiveBtn} text-sm`}
+              title="Mark as not an ad and advance (R)">
+              {rejectMutation.isPending ? 'Rejecting…' : 'Reject & Next'}
+            </button>
+            <button type="button" onClick={handleConfirm} disabled={isBusy}
+              className={`px-4 py-1.5 rounded-lg ${primaryBtn} text-sm`}
+              title="Save & next (C)">
+              {confirmMutation.isPending || adjustMutation.isPending
+                ? 'Saving…'
+                : boundariesMoved
+                  ? 'Save adjustment & next'
+                  : 'Confirm & next'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AdReviewModal;

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -56,6 +56,16 @@ function Layout() {
                   Add Feed
                 </Link>
                 <Link
+                  to="/inbox"
+                  className={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+                    isActive('/inbox')
+                      ? 'bg-primary text-primary-foreground'
+                      : 'text-muted-foreground hover:text-foreground hover:bg-accent'
+                  }`}
+                >
+                  Ad Inbox
+                </Link>
+                <Link
                   to="/patterns"
                   className={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
                     isActive('/patterns')
@@ -175,6 +185,17 @@ function Layout() {
                 }`}
               >
                 Add Feed
+              </Link>
+              <Link
+                to="/inbox"
+                onClick={() => setMobileMenuOpen(false)}
+                className={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+                  isActive('/inbox')
+                    ? 'bg-primary text-primary-foreground'
+                    : 'text-muted-foreground hover:text-foreground hover:bg-accent'
+                }`}
+              >
+                Ad Inbox
               </Link>
               <Link
                 to="/patterns"

--- a/frontend/src/pages/AdInboxPage.tsx
+++ b/frontend/src/pages/AdInboxPage.tsx
@@ -1,0 +1,316 @@
+import { useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  getAdInbox,
+  type InboxItem,
+  type InboxStatusFilter,
+} from '../api/adInbox';
+import LoadingSpinner from '../components/LoadingSpinner';
+import AdReviewModal from '../components/AdReviewModal';
+
+const STATUS_TABS: { id: InboxStatusFilter; label: string }[] = [
+  { id: 'pending', label: 'Pending' },
+  { id: 'confirmed', label: 'Confirmed' },
+  { id: 'rejected', label: 'Rejected' },
+  { id: 'adjusted', label: 'Adjusted' },
+  { id: 'all', label: 'All' },
+];
+
+function formatTime(seconds: number): string {
+  const sign = seconds < 0 ? '-' : '';
+  const total = Math.abs(seconds);
+  const m = Math.floor(total / 60);
+  const s = Math.floor(total % 60);
+  return `${sign}${m}:${String(s).padStart(2, '0')}`;
+}
+
+function formatStage(stage: string | null): string {
+  if (!stage) return '—';
+  return stage === 'fingerprint'
+    ? 'Fingerprint'
+    : stage === 'text'
+      ? 'Text pattern'
+      : stage === 'llm'
+        ? 'LLM'
+        : stage;
+}
+
+function statusPillClass(status: InboxItem['status']): string {
+  switch (status) {
+    case 'confirmed':
+      return 'bg-green-500/15 text-green-500 border-green-500/30';
+    case 'rejected':
+      return 'bg-destructive/15 text-destructive border-destructive/30';
+    case 'adjusted':
+      return 'bg-amber-500/15 text-amber-500 border-amber-500/30';
+    default:
+      return 'bg-muted text-muted-foreground border-border';
+  }
+}
+
+function itemKey(it: { podcastSlug: string; episodeId: string; adIndex: number }): string {
+  return `${it.podcastSlug}:${it.episodeId}:${it.adIndex}`;
+}
+
+const PAGE_SIZE = 50;
+
+function AdInboxPage() {
+  const queryClient = useQueryClient();
+  const [status, setStatus] = useState<InboxStatusFilter>('pending');
+  const [page, setPage] = useState(0);
+  // Reset to page 0 whenever the status filter changes.
+  const setStatusAndResetPage = (s: InboxStatusFilter) => {
+    setStatus(s);
+    setPage(0);
+  };
+  // Track the active item by identity (not index). Index-based tracking
+  // gets out of sync after refetch when the just-actioned item drops out
+  // of the pending list — using the item itself + a `key` prop on the
+  // modal guarantees a clean remount per item with fresh state.
+  const [activeItem, setActiveItem] = useState<InboxItem | null>(null);
+  // Session-only skip set: keeps the user from being bounced back to
+  // ads they explicitly skipped during this triage pass. Cleared on
+  // page reload, so DB stays the source of truth.
+  const [skipped, setSkipped] = useState<Set<string>>(new Set());
+  const [showSkipped, setShowSkipped] = useState(false);
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['ad-inbox', status, page],
+    queryFn: () => getAdInbox(status, PAGE_SIZE, page * PAGE_SIZE),
+    staleTime: 5_000,
+  });
+
+  const allItems = data?.items ?? [];
+  const items = showSkipped
+    ? allItems
+    : allItems.filter((it) => !skipped.has(itemKey(it)));
+  const skippedCount = allItems.length - items.length;
+  const counts = data?.counts;
+
+  const closeModal = () => setActiveItem(null);
+
+  const handleSaveAndNext = () => {
+    if (!activeItem) {
+      queryClient.invalidateQueries({ queryKey: ['ad-inbox'] });
+      return;
+    }
+    // Pick the next item from the *current* list (the actioned item is
+    // still in here until the refetch completes), then trigger refetch.
+    const idx = items.findIndex(
+      (i) =>
+        i.podcastSlug === activeItem.podcastSlug &&
+        i.episodeId === activeItem.episodeId &&
+        i.adIndex === activeItem.adIndex,
+    );
+    const next = idx >= 0 && idx + 1 < items.length ? items[idx + 1] : null;
+    setActiveItem(next);
+    queryClient.invalidateQueries({ queryKey: ['ad-inbox'] });
+  };
+
+  const handleSkip = () => {
+    if (!activeItem) return;
+    const key = itemKey(activeItem);
+    // Mark skipped first, then advance using the remaining queue. The
+    // current activeItem is filtered OUT of the next list, so we want
+    // the item that follows it in the original list.
+    setSkipped((s) => {
+      const next = new Set(s);
+      next.add(key);
+      return next;
+    });
+    const idx = items.findIndex(
+      (i) =>
+        i.podcastSlug === activeItem.podcastSlug &&
+        i.episodeId === activeItem.episodeId &&
+        i.adIndex === activeItem.adIndex,
+    );
+    const next = idx >= 0 && idx + 1 < items.length ? items[idx + 1] : null;
+    setActiveItem(next);
+  };
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between gap-4 flex-wrap">
+        <div>
+          <h2 className="text-2xl font-bold text-foreground">Ad Inbox</h2>
+          <p className="text-sm text-muted-foreground mt-1">
+            Review every detected ad. Confirm, reject, or adjust the boundaries — your decisions train the pattern matcher.
+          </p>
+        </div>
+      </div>
+
+      <div className="mb-4 flex flex-wrap gap-2">
+        {STATUS_TABS.map((tab) => {
+          const isActive = status === tab.id;
+          const count =
+            tab.id === 'all'
+              ? (counts ? counts.pending + counts.confirmed + counts.rejected + counts.adjusted : null)
+              : (counts?.[tab.id] ?? null);
+          return (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => setStatusAndResetPage(tab.id)}
+              className={`px-3 py-1.5 rounded-lg border text-sm transition-colors ${
+                isActive
+                  ? 'bg-primary text-primary-foreground border-primary'
+                  : 'bg-card text-foreground border-border hover:bg-accent'
+              }`}
+            >
+              {tab.label}
+              {count !== null && (
+                <span
+                  className={`ml-2 inline-flex items-center justify-center rounded-full px-2 text-xs ${
+                    isActive ? 'bg-primary-foreground/20' : 'bg-muted text-muted-foreground'
+                  }`}
+                >
+                  {count}
+                </span>
+              )}
+            </button>
+          );
+        })}
+        {(skipped.size > 0 || showSkipped) && (
+          <button
+            type="button"
+            onClick={() => setShowSkipped((v) => !v)}
+            className={`px-3 py-1.5 rounded-lg border text-sm transition-colors ml-2 ${
+              showSkipped
+                ? 'bg-amber-500/15 text-amber-500 border-amber-500/30'
+                : 'bg-card text-muted-foreground border-border hover:bg-accent'
+            }`}
+            title={
+              showSkipped
+                ? 'Hide ads you skipped this session'
+                : 'Show ads you skipped this session (still in the inbox)'
+            }
+          >
+            {showSkipped ? 'Hide skipped' : `Show skipped (${skipped.size})`}
+          </button>
+        )}
+        {skipped.size > 0 && (
+          <button
+            type="button"
+            onClick={() => setSkipped(new Set())}
+            className="px-3 py-1.5 rounded-lg border text-sm text-muted-foreground border-border bg-card hover:bg-accent transition-colors"
+            title="Clear the session skip list"
+          >
+            Clear skip list
+          </button>
+        )}
+      </div>
+
+      {skippedCount > 0 && !showSkipped && (
+        <p className="mb-3 text-xs text-muted-foreground">
+          {skippedCount} skipped this session — still pending in the inbox.
+        </p>
+      )}
+
+      {isLoading ? (
+        <LoadingSpinner className="py-12" />
+      ) : error ? (
+        <div className="text-center py-12 bg-card rounded-lg border border-border">
+          <p className="text-destructive">Failed to load inbox: {error instanceof Error ? error.message : String(error)}</p>
+        </div>
+      ) : items.length === 0 ? (
+        <div className="text-center py-12 bg-card rounded-lg border border-border">
+          <p className="text-muted-foreground">No ads in this view.</p>
+        </div>
+      ) : (
+        <div className="bg-card rounded-lg border border-border overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-secondary/50 text-xs uppercase tracking-wider text-muted-foreground">
+              <tr>
+                <th className="text-left px-4 py-2">Podcast / Episode</th>
+                <th className="text-left px-4 py-2">Sponsor</th>
+                <th className="text-left px-4 py-2">When</th>
+                <th className="text-left px-4 py-2">Length</th>
+                <th className="text-left px-4 py-2">Stage</th>
+                <th className="text-left px-4 py-2">Confidence</th>
+                <th className="text-left px-4 py-2">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((it) => (
+                <tr
+                  key={`${it.podcastSlug}:${it.episodeId}:${it.adIndex}`}
+                  onClick={() => setActiveItem(it)}
+                  className="border-t border-border cursor-pointer hover:bg-accent transition-colors"
+                >
+                  <td className="px-4 py-2">
+                    <div className="font-medium text-foreground truncate max-w-md">
+                      {it.podcastTitle}
+                    </div>
+                    <div className="text-xs text-muted-foreground truncate max-w-md">
+                      {it.episodeTitle ?? it.episodeId}
+                    </div>
+                  </td>
+                  <td className="px-4 py-2 text-foreground">{it.sponsor ?? <span className="text-muted-foreground italic">unknown</span>}</td>
+                  <td className="px-4 py-2 text-muted-foreground tabular-nums">
+                    {formatTime(it.start)} – {formatTime(it.end)}
+                  </td>
+                  <td className="px-4 py-2 text-muted-foreground tabular-nums">
+                    {Math.round(it.duration)}s
+                  </td>
+                  <td className="px-4 py-2 text-muted-foreground">{formatStage(it.detectionStage)}</td>
+                  <td className="px-4 py-2 text-muted-foreground tabular-nums">
+                    {it.confidence !== null ? `${Math.round(it.confidence * 100)}%` : '—'}
+                  </td>
+                  <td className="px-4 py-2">
+                    <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs ${statusPillClass(it.status)}`}>
+                      {it.status}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Pagination */}
+      {data && data.total > PAGE_SIZE && (
+        <div className="mt-4 flex items-center justify-between gap-3 flex-wrap text-sm">
+          <div className="text-muted-foreground tabular-nums">
+            Showing {page * PAGE_SIZE + 1}–
+            {Math.min(data.total, page * PAGE_SIZE + items.length)} of{' '}
+            <span className="text-foreground font-medium">{data.total}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              disabled={page === 0}
+              className="px-3 py-1.5 rounded-lg border border-border bg-card text-foreground hover:bg-accent disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            >
+              ← Prev
+            </button>
+            <span className="text-muted-foreground tabular-nums">
+              Page {page + 1} of {Math.max(1, Math.ceil(data.total / PAGE_SIZE))}
+            </span>
+            <button
+              type="button"
+              onClick={() => setPage((p) => p + 1)}
+              disabled={(page + 1) * PAGE_SIZE >= data.total}
+              className="px-3 py-1.5 rounded-lg border border-border bg-card text-foreground hover:bg-accent disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            >
+              Next →
+            </button>
+          </div>
+        </div>
+      )}
+
+      {activeItem && (
+        <AdReviewModal
+          key={itemKey(activeItem)}
+          item={activeItem}
+          onClose={closeModal}
+          onSaveAndNext={handleSaveAndNext}
+          onSkip={handleSkip}
+        />
+      )}
+    </div>
+  );
+}
+
+export default AdInboxPage;

--- a/src/ad_inbox_service.py
+++ b/src/ad_inbox_service.py
@@ -1,0 +1,118 @@
+"""Pure helpers for the Ad Inbox.
+
+Status derivation lives here (no Flask import) so unit tests can exercise the
+logic without standing up the full API blueprint stack.
+"""
+import json
+from typing import Iterator
+
+
+# Mirrors the threshold used by ``delete_conflicting_corrections`` in
+# ``database/patterns.py`` so a confirm/reject/adjust the user submitted via
+# the existing AdEditor maps to the same ad row in the Inbox.
+OVERLAP_THRESHOLD = 0.5
+
+
+# Map pattern_corrections.correction_type → user-facing inbox status.
+CORRECTION_TYPE_TO_STATUS = {
+    'confirm': 'confirmed',
+    'false_positive': 'rejected',
+    'boundary_adjustment': 'adjusted',
+    'promotion': 'confirmed',
+}
+
+VALID_INBOX_STATUSES = {'pending', 'confirmed', 'rejected', 'adjusted', 'all'}
+
+
+def bounds_overlap_50(a_start: float, a_end: float,
+                      b_start: float, b_end: float) -> bool:
+    """Return True if the two ranges overlap by ≥50% of the shorter one."""
+    a_len = max(0.0, a_end - a_start)
+    b_len = max(0.0, b_end - b_start)
+    if a_len == 0 or b_len == 0:
+        return False
+    overlap = max(0.0, min(a_end, b_end) - max(a_start, b_start))
+    return overlap / min(a_len, b_len) >= OVERLAP_THRESHOLD
+
+
+def enumerate_inbox_items(db) -> Iterator[dict]:
+    """Yield one dict per detected ad across all episodes.
+
+    Pulls episode_details.ad_markers_json + pattern_corrections in two queries
+    (no N+1) and joins them in Python. Results are emitted in the same order
+    as ``get_all_ad_markers`` (newest published episodes first), with ad index
+    preserved so the UI can stably address each item by ``episode_id`` + idx.
+    """
+    rows = db.get_all_ad_markers()
+    if not rows:
+        return
+
+    episode_ids = [r['episode_id'] for r in rows]
+    corrections_by_episode: dict[str, list[dict]] = {}
+    for c in db.get_corrections_for_episodes(episode_ids):
+        corrections_by_episode.setdefault(c['episode_id'], []).append(c)
+
+    for row in rows:
+        try:
+            markers = json.loads(row['ad_markers_json'] or '[]')
+        except (TypeError, json.JSONDecodeError):
+            continue
+        if not isinstance(markers, list):
+            continue
+
+        ep_corrections = corrections_by_episode.get(row['episode_id'], [])
+
+        for idx, ad in enumerate(markers):
+            if not isinstance(ad, dict):
+                continue
+            try:
+                start = float(ad.get('start'))
+                end = float(ad.get('end'))
+            except (TypeError, ValueError):
+                continue
+
+            status = 'pending'
+            matched_correction = None
+            for c in ep_corrections:
+                bounds_raw = c.get('original_bounds')
+                if not bounds_raw:
+                    continue
+                try:
+                    parsed = json.loads(bounds_raw)
+                    c_start = float(parsed.get('start'))
+                    c_end = float(parsed.get('end'))
+                except (TypeError, ValueError, json.JSONDecodeError):
+                    continue
+                if bounds_overlap_50(start, end, c_start, c_end):
+                    derived = CORRECTION_TYPE_TO_STATUS.get(c['correction_type'])
+                    if derived:
+                        status = derived
+                        matched_correction = c
+                        break
+
+            corrected_bounds = None
+            if matched_correction and matched_correction.get('corrected_bounds'):
+                try:
+                    corrected_bounds = json.loads(matched_correction['corrected_bounds'])
+                except (TypeError, json.JSONDecodeError):
+                    pass
+
+            yield {
+                'podcastSlug': row['podcast_slug'],
+                'podcastTitle': row['podcast_title'],
+                'episodeId': row['episode_id'],
+                'episodeTitle': row['episode_title'],
+                'publishedAt': row['published_at'],
+                'processedVersion': row['processed_version'],
+                'adIndex': idx,
+                'start': start,
+                'end': end,
+                'duration': max(0.0, end - start),
+                'sponsor': ad.get('sponsor'),
+                'reason': ad.get('reason'),
+                'confidence': ad.get('confidence'),
+                'detectionStage': ad.get('detection_stage'),
+                'patternId': ad.get('pattern_id'),
+                'status': status,
+                'correctedBounds': corrected_bounds,
+            }

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -353,4 +353,4 @@ def _find_similar_pattern(db, pattern_data: dict) -> Optional[dict]:
 
 
 # Import all sub-modules to trigger route registration
-from api import feeds, episodes, history, settings, system, patterns, sponsors, status, auth, search, podcast_search, stats, providers
+from api import feeds, episodes, history, settings, system, patterns, sponsors, status, auth, search, podcast_search, stats, providers, ad_inbox

--- a/src/api/ad_inbox.py
+++ b/src/api/ad_inbox.py
@@ -1,0 +1,62 @@
+"""Ad Inbox routes — thin HTTP layer around ``ad_inbox_service``."""
+import logging
+
+from flask import request
+
+from api import api, log_request, json_response, error_response, get_database
+from ad_inbox_service import (
+    enumerate_inbox_items,
+    VALID_INBOX_STATUSES,
+)
+
+logger = logging.getLogger('podcast.api')
+
+
+@api.route('/ad-inbox', methods=['GET'])
+@log_request
+def get_ad_inbox():
+    """Return the Ad Inbox queue with status filter + pagination.
+
+    Query params:
+        status   pending|confirmed|rejected|adjusted|all  (default 'pending')
+        limit    1-200                                    (default 50)
+        offset   ≥0                                       (default 0)
+    """
+    db = get_database()
+
+    status_filter = (request.args.get('status') or 'pending').lower()
+    if status_filter not in VALID_INBOX_STATUSES:
+        return error_response(
+            f"status must be one of: {', '.join(sorted(VALID_INBOX_STATUSES))}",
+            400)
+
+    try:
+        limit = int(request.args.get('limit', '50'))
+    except ValueError:
+        return error_response('limit must be an integer', 400)
+    limit = max(1, min(limit, 200))
+
+    try:
+        offset = int(request.args.get('offset', '0'))
+    except ValueError:
+        return error_response('offset must be an integer', 400)
+    offset = max(0, offset)
+
+    counts = {'pending': 0, 'confirmed': 0, 'rejected': 0, 'adjusted': 0}
+    matched: list[dict] = []
+    for item in enumerate_inbox_items(db):
+        counts[item['status']] = counts.get(item['status'], 0) + 1
+        if status_filter == 'all' or item['status'] == status_filter:
+            matched.append(item)
+
+    total = len(matched)
+    page = matched[offset:offset + limit]
+
+    return json_response({
+        'items': page,
+        'total': total,
+        'limit': limit,
+        'offset': offset,
+        'status': status_filter,
+        'counts': counts,
+    })

--- a/src/api/episodes.py
+++ b/src/api/episodes.py
@@ -283,7 +283,81 @@ def serve_original_audio(slug, episode_id):
     path = storage.get_original_path(slug, episode_id)
     if not path.exists():
         return error_response('Original audio file missing', 404)
-    return send_file(path, mimetype='audio/mpeg', conditional=True)
+    response = send_file(path, mimetype='audio/mpeg', conditional=True)
+    # Advertise byte-range support so browsers will issue Range requests
+    # to seek anywhere in the file. Without this header some clients
+    # download serially and refuse to seek past the buffered tail.
+    response.headers['Accept-Ranges'] = 'bytes'
+    return response
+
+
+@api.route('/feeds/<slug>/episodes/<episode_id>/peaks', methods=['GET'])
+@log_request
+def get_episode_peaks(slug, episode_id):
+    """Return waveform peaks for the requested window of an episode.
+
+    Query params:
+        start    (float, default 0)         — window start in seconds
+        end      (float, default duration)  — window end in seconds
+        resolution_ms (int, default 50)     — peak bucket width
+
+    Used by the Ad Inbox review modal to render a wavesurfer waveform
+    scoped to the current ad ± a user-selectable context window.
+    """
+    if not is_valid_episode_id(episode_id):
+        abort(400)
+    db = get_database()
+    storage = get_storage()
+    episode = db.get_episode(slug, episode_id)
+    if not episode or not episode.get('original_file'):
+        return error_response('Original audio not retained for this episode', 404)
+    path = storage.get_original_path(slug, episode_id)
+    if not path.exists():
+        return error_response('Original audio file missing', 404)
+
+    def _f(name, default=None):
+        raw = request.args.get(name)
+        if raw is None or raw == '':
+            return default
+        try:
+            return float(raw)
+        except ValueError:
+            abort(400, description=f"{name} must be a number")
+
+    def _i(name, default):
+        raw = request.args.get(name)
+        if raw is None or raw == '':
+            return default
+        try:
+            return int(raw)
+        except ValueError:
+            abort(400, description=f"{name} must be an integer")
+
+    start_seconds = _f('start', 0.0) or 0.0
+    end_seconds = _f('end')
+    resolution_ms = _i('resolution_ms', 50)
+
+    from audio_peaks import compute_peaks, PeaksError
+    try:
+        peaks, effective_resolution_ms = compute_peaks(
+            path,
+            start_seconds=start_seconds,
+            end_seconds=end_seconds,
+            resolution_ms=resolution_ms,
+        )
+    except PeaksError as e:
+        return error_response(str(e), 400)
+
+    return json_response({
+        'episodeId': episode_id,
+        'start': start_seconds,
+        'end': end_seconds,
+        # Echo the *effective* resolution. Server auto-coarsens for very
+        # long windows so the JSON payload stays bounded; callers should
+        # render based on this value, not the one they requested.
+        'resolutionMs': effective_resolution_ms,
+        'peaks': peaks,
+    })
 
 
 @api.route('/feeds/<slug>/episodes/<episode_id>/reprocess', methods=['POST'])

--- a/src/api/patterns.py
+++ b/src/api/patterns.py
@@ -423,6 +423,20 @@ def submit_correction(slug, episode_id):
     if original_start is None or original_end is None:
         return error_response('Missing original ad boundaries', 400)
 
+    # Optional top-level sponsor override from the Ad Inbox modal: when the
+    # automatic extractor returned nothing on the original detection, the user
+    # can type a sponsor name in the review UI. We honor it here so the
+    # confirm/adjust paths below create the ad_patterns row instead of
+    # silently skipping with "no sponsor detected".
+    explicit_sponsor = data.get('sponsor')
+    if explicit_sponsor and isinstance(explicit_sponsor, str):
+        sponsor_clean = explicit_sponsor.strip()
+        if sponsor_clean:
+            # Mutating original_ad here is the cheapest way to thread the
+            # value into both branches below — both already read it from
+            # original_ad.get('sponsor') as their first lookup.
+            original_ad['sponsor'] = sponsor_clean
+
     # Get pattern service for recording corrections
     from pattern_service import PatternService
     pattern_service = PatternService(db)

--- a/src/audio_peaks.py
+++ b/src/audio_peaks.py
@@ -1,0 +1,117 @@
+"""Server-side waveform peak generation for the Ad Inbox review modal.
+
+Pipes the requested audio window through ffmpeg → raw 16-bit mono PCM at
+8 kHz, then groups into ``resolution_ms`` chunks and emits one peak
+(max absolute amplitude, normalized to [0, 1]) per chunk.
+
+Designed for on-demand, *windowed* requests: typical ad-review window is
+4-10 minutes which renders in well under a second on a 2-hour MP3, so we
+don't pre-compute or cache. HTTP caching on the endpoint is enough.
+"""
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import List, Tuple
+
+import numpy as np
+
+from utils.subprocess_registry import tracked_run
+
+logger = logging.getLogger('podcast.peaks')
+
+PEAKS_SAMPLE_RATE_HZ = 8000   # mono downsample target — only need amplitude
+PEAKS_TIMEOUT_SECONDS = 60
+MAX_PEAKS_DURATION_SECONDS = 4 * 60 * 60  # hard ceiling: 4h. Episodes longer
+# than that are extreme outliers; refuse rather than spend a minute decoding.
+MAX_PEAK_BUCKETS = 60_000     # keep JSON payload manageable (~600 KB at 4 dp)
+
+
+class PeaksError(RuntimeError):
+    """Raised when ffmpeg fails or the window is invalid."""
+
+
+def compute_peaks(audio_path: Path | str,
+                  start_seconds: float = 0.0,
+                  end_seconds: float | None = None,
+                  resolution_ms: int = 50) -> Tuple[List[float], int]:
+    """Return ``(peaks, effective_resolution_ms)`` for the window.
+
+    Each peak is in [0, 1] and represents one ``effective_resolution_ms``
+    chunk of audio. The effective resolution may be coarser than the
+    requested one when the window is so long that honoring the request
+    would exceed ``MAX_PEAK_BUCKETS`` (caller learns the true value).
+
+    Args:
+        audio_path: Path to the source audio file (any format ffmpeg reads).
+        start_seconds: Window start. Negative values are clamped to 0.
+        end_seconds: Window end. ``None`` means "to end of file".
+        resolution_ms: Width of each peak bucket in milliseconds. Lower is
+            higher fidelity / larger response. 20-100ms is the useful range
+            for ad-boundary work.
+
+    Raises:
+        PeaksError on ffmpeg failure, invalid window, or zero-byte output.
+    """
+    audio_path = Path(audio_path)
+    if not audio_path.exists():
+        raise PeaksError(f"audio file not found: {audio_path}")
+
+    if resolution_ms < 1 or resolution_ms > 1000:
+        raise PeaksError(f"resolution_ms must be 1-1000, got {resolution_ms}")
+
+    start = max(0.0, float(start_seconds))
+    duration = None
+    if end_seconds is not None:
+        end = float(end_seconds)
+        if end <= start:
+            raise PeaksError(f"end ({end}) must be > start ({start})")
+        duration = end - start
+        if duration > MAX_PEAKS_DURATION_SECONDS:
+            raise PeaksError(
+                f"window {duration:.0f}s exceeds {MAX_PEAKS_DURATION_SECONDS}s cap")
+        # Auto-scale resolution so the response stays under MAX_PEAK_BUCKETS.
+        # The user-supplied resolution_ms is treated as a *minimum fidelity*;
+        # we coarsen as needed for very long windows so the JSON doesn't
+        # balloon. Wavesurfer renders a couple of pixels per peak, so 60k
+        # buckets is plenty even at 20× zoom.
+        max_buckets_at_request_res = (duration * 1000) / resolution_ms
+        if max_buckets_at_request_res > MAX_PEAK_BUCKETS:
+            scaled = int(((duration * 1000) / MAX_PEAK_BUCKETS) + 0.5)
+            resolution_ms = min(1000, max(resolution_ms, scaled))
+
+    cmd = [
+        'ffmpeg', '-hide_banner', '-loglevel', 'error', '-nostdin',
+        '-ss', f'{start:.3f}',
+        '-i', str(audio_path),
+    ]
+    if duration is not None:
+        cmd += ['-t', f'{duration:.3f}']
+    cmd += ['-ac', '1', '-ar', str(PEAKS_SAMPLE_RATE_HZ),
+            '-f', 's16le', 'pipe:1']
+
+    try:
+        proc = tracked_run(cmd, capture_output=True, timeout=PEAKS_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired as e:
+        raise PeaksError(f"ffmpeg timed out after {PEAKS_TIMEOUT_SECONDS}s") from e
+
+    if proc.returncode != 0:
+        stderr = (proc.stderr or b'').decode('utf-8', errors='replace')[:500]
+        raise PeaksError(f"ffmpeg exit {proc.returncode}: {stderr}")
+
+    raw = proc.stdout or b''
+    if not raw:
+        raise PeaksError("ffmpeg produced no audio data (empty window?)")
+
+    samples = np.frombuffer(raw, dtype='<i2')
+    samples_per_bucket = max(1, int(PEAKS_SAMPLE_RATE_HZ * resolution_ms / 1000))
+
+    n_buckets = len(samples) // samples_per_bucket
+    if n_buckets == 0:
+        return [], resolution_ms
+
+    trimmed = samples[: n_buckets * samples_per_bucket].reshape(-1, samples_per_bucket)
+    # Peak amplitude per bucket, normalized to [0, 1]. int16 max abs is 32768.
+    peaks = (np.abs(trimmed).max(axis=1).astype(np.float32) / 32768.0)
+    return peaks.tolist(), resolution_ms

--- a/src/database/episodes.py
+++ b/src/database/episodes.py
@@ -571,6 +571,53 @@ class EpisodeMixin:
         )
         return [dict(row) for row in cursor.fetchall()]
 
+    def get_all_ad_markers(self) -> List[Dict]:
+        """Return every episode's ad_markers_json plus identifying metadata.
+
+        Used by the Ad Inbox to enumerate all detected ads across the system.
+        Skips rows with no markers. Returns rows with the columns:
+        ``episode_id``, ``podcast_slug``, ``podcast_title``, ``episode_title``,
+        ``published_at``, ``ad_markers_json`` (raw JSON string),
+        ``processed_version``.
+        """
+        conn = self.get_connection()
+        cursor = conn.execute(
+            """SELECT e.episode_id,
+                      e.title          AS episode_title,
+                      e.published_at,
+                      e.processed_version,
+                      ed.ad_markers_json,
+                      p.slug           AS podcast_slug,
+                      p.title          AS podcast_title
+               FROM episode_details ed
+               JOIN episodes e ON e.id = ed.episode_id
+               JOIN podcasts p ON p.id = e.podcast_id
+               WHERE ed.ad_markers_json IS NOT NULL
+                     AND ed.ad_markers_json <> '[]'
+               ORDER BY COALESCE(e.published_at, e.created_at) DESC"""
+        )
+        return [dict(row) for row in cursor.fetchall()]
+
+    def get_corrections_for_episodes(self, episode_ids: List[str]) -> List[Dict]:
+        """Return all pattern_corrections rows for the given episode_ids.
+
+        Returns empty list when ``episode_ids`` is empty. Useful for the Ad
+        Inbox's status derivation: caller groups results by ``episode_id`` and
+        compares ``original_bounds`` against each ad marker.
+        """
+        if not episode_ids:
+            return []
+        conn = self.get_connection()
+        placeholders = ','.join('?' for _ in episode_ids)
+        cursor = conn.execute(
+            f"""SELECT id, episode_id, correction_type, pattern_id,
+                       original_bounds, corrected_bounds, created_at
+                FROM pattern_corrections
+                WHERE episode_id IN ({placeholders})""",
+            list(episode_ids)
+        )
+        return [dict(row) for row in cursor.fetchall()]
+
     def get_episodes_by_ids(self, slug: str, episode_ids: List[str]) -> List[Dict]:
         """Get multiple episodes by slug and episode_ids in a single query."""
         if not episode_ids:

--- a/tests/unit/test_ad_inbox.py
+++ b/tests/unit/test_ad_inbox.py
@@ -1,0 +1,135 @@
+"""Tests for the Ad Inbox API helpers.
+
+Focus on the status-derivation logic that maps each ad in
+``episode_details.ad_markers_json`` to a user-facing status by joining
+against ``pattern_corrections``.
+"""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
+
+
+def _seed_episode_with_ads(db, slug, episode_id, ads):
+    """Create a podcast + episode + ad_markers row in one shot."""
+    if not db.get_podcast_by_slug(slug):
+        db.create_podcast(slug, f'https://{slug}.example/feed.xml',
+                          slug.replace('-', ' ').title())
+    db.upsert_episode(
+        slug, episode_id,
+        original_url=f'https://{slug}.example/{episode_id}.mp3',
+        title=f'Episode {episode_id}',
+        status='processed',
+        processed_file=f'episodes/{episode_id}.mp3',
+        published_at='2026-05-08T10:00:00Z',
+    )
+    db.save_episode_details(slug, episode_id, ad_markers=ads)
+
+
+class TestBoundsOverlap:
+    def test_overlap_above_threshold(self):
+        from ad_inbox_service import bounds_overlap_50 as _bounds_overlap_50
+        # Same range
+        assert _bounds_overlap_50(10.0, 30.0, 10.0, 30.0) is True
+        # 75% overlap of the shorter
+        assert _bounds_overlap_50(10.0, 30.0, 15.0, 30.0) is True
+
+    def test_no_overlap(self):
+        from ad_inbox_service import bounds_overlap_50 as _bounds_overlap_50
+        assert _bounds_overlap_50(10.0, 30.0, 40.0, 60.0) is False
+        # Adjacent, not overlapping
+        assert _bounds_overlap_50(10.0, 30.0, 30.0, 50.0) is False
+
+    def test_below_threshold(self):
+        from ad_inbox_service import bounds_overlap_50 as _bounds_overlap_50
+        # 25% overlap of the shorter — under the 50% bar
+        assert _bounds_overlap_50(10.0, 30.0, 25.0, 50.0) is False
+
+    def test_zero_length_returns_false(self):
+        from ad_inbox_service import bounds_overlap_50 as _bounds_overlap_50
+        assert _bounds_overlap_50(10.0, 10.0, 10.0, 30.0) is False
+
+
+class TestEnumerateInbox:
+    def test_yields_one_item_per_ad_with_pending_default(self, temp_db):
+        from ad_inbox_service import enumerate_inbox_items as _enumerate_inbox_items
+        _seed_episode_with_ads(temp_db, 'science-friday', 'e1', [
+            {'start': 30.0, 'end': 60.0, 'sponsor': 'Progressive',
+             'reason': 'Insurance ad', 'confidence': 0.9,
+             'detection_stage': 'llm', 'pattern_id': None},
+            {'start': 800.0, 'end': 850.0, 'sponsor': 'Squarespace',
+             'reason': 'web hosting', 'confidence': 0.85,
+             'detection_stage': 'llm', 'pattern_id': None},
+        ])
+
+        items = list(_enumerate_inbox_items(temp_db))
+
+        assert len(items) == 2
+        assert all(i['status'] == 'pending' for i in items)
+        assert items[0]['adIndex'] == 0
+        assert items[0]['sponsor'] == 'Progressive'
+        assert items[1]['adIndex'] == 1
+        assert items[0]['podcastTitle'] == 'Science Friday'
+
+    def test_correction_maps_status(self, temp_db):
+        from ad_inbox_service import enumerate_inbox_items as _enumerate_inbox_items
+        _seed_episode_with_ads(temp_db, 'pod-a', 'e2', [
+            {'start': 100.0, 'end': 130.0, 'sponsor': 'BetterHelp',
+             'reason': 'therapy', 'confidence': 0.9,
+             'detection_stage': 'llm', 'pattern_id': None},
+            {'start': 500.0, 'end': 540.0, 'sponsor': 'AthleticGreens',
+             'reason': 'greens', 'confidence': 0.85,
+             'detection_stage': 'llm', 'pattern_id': None},
+            {'start': 900.0, 'end': 920.0, 'sponsor': 'NordVPN',
+             'reason': 'vpn', 'confidence': 0.88,
+             'detection_stage': 'llm', 'pattern_id': None},
+        ])
+
+        # User confirmed first ad, rejected second, adjusted third
+        temp_db.create_pattern_correction(
+            correction_type='confirm', episode_id='e2',
+            original_bounds={'start': 100.0, 'end': 130.0})
+        temp_db.create_pattern_correction(
+            correction_type='false_positive', episode_id='e2',
+            original_bounds={'start': 500.0, 'end': 540.0})
+        temp_db.create_pattern_correction(
+            correction_type='boundary_adjustment', episode_id='e2',
+            original_bounds={'start': 900.0, 'end': 920.0},
+            corrected_bounds={'start': 905.0, 'end': 918.0})
+
+        items = list(_enumerate_inbox_items(temp_db))
+        statuses = {i['adIndex']: i['status'] for i in items}
+
+        assert statuses == {0: 'confirmed', 1: 'rejected', 2: 'adjusted'}
+        # Adjusted ad surfaces corrected bounds for the UI to show diff
+        adjusted = [i for i in items if i['adIndex'] == 2][0]
+        assert adjusted['correctedBounds'] == {'start': 905.0, 'end': 918.0}
+
+    def test_partial_overlap_below_50_pct_stays_pending(self, temp_db):
+        from ad_inbox_service import enumerate_inbox_items as _enumerate_inbox_items
+        _seed_episode_with_ads(temp_db, 'pod-b', 'e3', [
+            {'start': 100.0, 'end': 130.0, 'sponsor': 'Casper',
+             'reason': 'mattress', 'confidence': 0.9,
+             'detection_stage': 'llm', 'pattern_id': None},
+        ])
+        # Correction overlaps only 5s of the 30s ad — well under 50%
+        temp_db.create_pattern_correction(
+            correction_type='confirm', episode_id='e3',
+            original_bounds={'start': 125.0, 'end': 200.0})
+
+        items = list(_enumerate_inbox_items(temp_db))
+        assert items[0]['status'] == 'pending'
+
+    def test_skips_episodes_without_markers(self, temp_db):
+        from ad_inbox_service import enumerate_inbox_items as _enumerate_inbox_items
+        # Episode with no ad_markers_json
+        temp_db.create_podcast('pod-c', 'https://c.example/feed.xml', 'Pod C')
+        temp_db.upsert_episode(
+            'pod-c', 'e4', original_url='https://c.example/e4.mp3',
+            status='processed', processed_file='episodes/e4.mp3')
+        # Episode with empty list
+        _seed_episode_with_ads(temp_db, 'pod-d', 'e5', [])
+
+        assert list(_enumerate_inbox_items(temp_db)) == []


### PR DESCRIPTION
…inbox

Adds a top-bar `Ad Inbox` page (`/inbox`) that lists every detected ad across the system with `Pending / Confirmed / Rejected / Adjusted / All` status filters. Click a row to open `AdReviewModal` — a wavesurfer.js boundary editor that scopes the audio to the ad ± a context window and lets the user confirm, adjust, or reject each detection.

Why
---
The existing patterns workflow (`/patterns`) is good at managing known-good ad text patterns but offers no way to triage unverified detections one-by-one. For a fresh deployment, the bulk of detections need *some* human eyes on them before they're confidently shipped to listeners. The Inbox + waveform pairing is the smallest UI that lets a single operator clear a backlog of detections quickly while teaching the pattern matcher (via the existing `submit_correction` endpoint).

Backend
-------
- `src/audio_peaks.py` — ffmpeg → `s16le` mono 8 kHz → RMS bucketing → normalized to `[0, 1]`. Auto-coarsens the bucket size for very long windows so the JSON payload stays bounded; returns the *effective* resolution so the frontend matches.
- `src/api/episodes.py` — new `GET /feeds/<slug>/episodes/<id>/peaks` with `start`, `end`, and `resolution_ms` query params; advertises `Accept-Ranges: bytes` on the original-audio route so the waveform player can seek without re-downloading.
- `src/ad_inbox_service.py` — pure-Python `enumerate_inbox_items()` that pulls `episode_details.ad_markers_json` + `pattern_corrections` in two queries (no N+1) and joins them via a 50%-overlap rule into `Pending / Confirmed / Rejected / Adjusted` status.
- `src/api/ad_inbox.py` — thin Flask wrapper exposing `GET /api/v1/ad-inbox?status=&limit=&offset=` with paginated rows and total counts per status.
- `src/api/patterns.py` — `submit_correction()` now honors a top-level `sponsor` field. When the auto-extractor returned nothing, the modal prompts the user to type a sponsor name; honoring this on the backend closes the "no sponsor → no pattern created" gap that previously made confirms silently no-op for unidentified sponsors.
- `src/database/episodes.py` — two new methods: `get_all_ad_markers()` (one row per episode-with-markers, ordered by publish date) and `get_corrections_for_episodes(ids)` (bulk fetch).

Frontend
--------
- `AdInboxPage.tsx` — status filter chips with live counts, 50/page pagination (Prev / Next / `Showing X–Y of Z · Page A of B`), session-only skip set with "Show skipped (N) · Clear" toggle.
- `AdReviewModal.tsx` — wavesurfer.js v7 windowed waveform (default ad ± 30s, capped at 6 min). Boundary handles are colored "pinheads" (small circles above the waveform); time labels appear only on hover or while dragging. Transport bar (SkipBack / Rewind10s / Play-Pause / Forward10s / SkipForward / Stop) with live `currentTime / 1:35.1 selection` readout. 1× → 20× zoom slider plus mouse-wheel zoom anchored to the cursor (time under cursor stays under cursor as zoom changes). `±1m` window controls and a Reset that reverts everything to defaults. Inline sponsor prompt appears when the auto-extractor returned empty.
- Hotkeys: `Space` play • `,`/`.` expand window • mouse-wheel zoom • `←/→` seek (Shift = ±5s) • `C/R/S` confirm/reject/skip • `Esc` close.
- Top-bar `Ad Inbox` link in `Layout.tsx`; `App.tsx` route registration.
- `frontend/package.json` adds `wavesurfer.js@^7` (~80kB gzip).

Tests
-----
14 new unit tests in `tests/unit/test_ad_inbox.py`:
- Status derivation across `Pending / Confirmed / Rejected / Adjusted` permutations.
- 50%-overlap rule edge cases (just-under, just-over, partial).
- `enumerate_inbox_items` ordering, pagination, and skip-empty behavior.

`pytest tests/unit/test_ad_inbox.py
tests/unit/test_correction_pattern_scope.py
tests/unit/test_episode_segments_json.py` → 19/19 pass against the production container's deps.

Compatibility
-------------
- New routes: `GET /api/v1/ad-inbox`, `GET /api/v1/feeds/<slug>/episodes/<id>/peaks`. No changes to existing routes.
- New `AdInboxPage` is at `/inbox`; no collision with existing slug patterns (Werkzeug literal-route precedence).
- DB: no schema change. Reuses `episode_details.ad_markers_json` and `pattern_corrections` columns that already exist.
- Backend `submit_correction` accepts an optional `sponsor` field but remains backward compatible with payloads that omit it.