### PR TITLE
chore(smoke): phase A - fix existing failures, drop 2.0.0 placeholders, add fixtures scaffold

### DIFF
--- a/smoke/fixtures/README.md
+++ b/smoke/fixtures/README.md
@@ -1,0 +1,29 @@
+# Smoke test fixtures
+
+Static files used by smoke tests that need real-feed-shaped input. Kept
+small (<1 MB total) so the repo doesn't bloat. Larger artifacts (full
+podcast episodes) are downloaded on demand by the tests that need them.
+
+## Files
+
+- `tiny-feed.xml`: minimal valid RSS 2.0 with one episode pointing at
+  `tiny-episode.mp3`. Used by T08-artwork (artwork validator), T12-rss-
+  public-paths (public feed routes), and the planned pattern correction
+  tests.
+- `tiny-episode.mp3`: ~5s of silence at 22.05 kHz / 64 kbps. Real MP3
+  bytes so transcription/audio-analysis paths don't error on a fake
+  payload, but short enough that the full pipeline runs in seconds.
+- `bad-artwork-html.jpg`: HTML body with Content-Type=image/jpeg lie;
+  used by T08 to assert the artwork validator rejects.
+
+## Generation
+
+`tiny-episode.mp3` is generated from silence; regenerate with:
+
+```
+ffmpeg -f lavfi -i anullsrc=channel_layout=mono:sample_rate=22050 \
+       -t 5 -b:a 64k smoke/fixtures/tiny-episode.mp3
+```
+
+`tiny-feed.xml` is hand-edited; keep `<guid>` deterministic so a re-
+import doesn't double-add the episode.

--- a/smoke/fixtures/generate-tiny-episode.sh
+++ b/smoke/fixtures/generate-tiny-episode.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Generate smoke/fixtures/tiny-episode.mp3 if missing. Requires ffmpeg
+# (installed by default in the production minuspod image; on a dev host
+# install via `apt install ffmpeg`).
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT="$HERE/tiny-episode.mp3"
+if [ -s "$OUT" ]; then
+    echo "tiny-episode.mp3 already exists ($(stat -c%s "$OUT") bytes)"
+    exit 0
+fi
+if ! command -v ffmpeg >/dev/null 2>&1; then
+    echo "error: ffmpeg not found; install it or run this script inside the container" >&2
+    exit 1
+fi
+ffmpeg -loglevel error -f lavfi \
+    -i anullsrc=channel_layout=mono:sample_rate=22050 \
+    -t 5 -b:a 64k "$OUT" -y
+echo "wrote $OUT ($(stat -c%s "$OUT") bytes)"

--- a/smoke/fixtures/tiny-feed.xml
+++ b/smoke/fixtures/tiny-feed.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" version="2.0">
+  <channel>
+    <title>Smoke Fixture Podcast</title>
+    <link>http://example.invalid/smoke</link>
+    <description>Used by the smoke harness; not a real show.</description>
+    <language>en-us</language>
+    <itunes:image href="http://example.invalid/smoke/artwork.jpg"/>
+    <item>
+      <title>Tiny Test Episode</title>
+      <guid isPermaLink="false">smoke-fixture-ep-0001</guid>
+      <pubDate>Sat, 17 May 2026 00:00:00 GMT</pubDate>
+      <enclosure url="http://example.invalid/smoke/tiny-episode.mp3" length="5000" type="audio/mpeg"/>
+      <description>Fixture episode for smoke harness; ~5s of silence.</description>
+    </item>
+  </channel>
+</rss>

--- a/smoke/local/00-setup.sh
+++ b/smoke/local/00-setup.sh
@@ -12,7 +12,11 @@ IMAGE="${IMAGE:-ttlequals0/minuspod:2.0.0}"
 PORT="${PORT:-8001}"
 
 log "pulling $IMAGE"
-docker pull "$IMAGE" >/dev/null
+if docker image inspect "$IMAGE" >/dev/null 2>&1; then
+    log "image $IMAGE already present locally; skipping pull"
+else
+    docker pull "$IMAGE" >/dev/null
+fi
 
 if docker inspect "$LOCAL_CONTAINER" >/dev/null 2>&1; then
     log "removing existing container $LOCAL_CONTAINER"
@@ -42,7 +46,12 @@ docker run -d \
     -e MINUSPOD_MASTER_PASSPHRASE=smoke-test-passphrase \
     -e ANTHROPIC_API_KEY=dummy-key-no-llm-calls-in-smoke \
     -e LOG_LEVEL=INFO \
+    -e GUNICORN_GRACEFUL_TIMEOUT=30 \
+    -e GUNICORN_TIMEOUT=60 \
     "$IMAGE" >/dev/null
+# GUNICORN_GRACEFUL_TIMEOUT defaults to 330s in prod; that's longer than the
+# T17-shutdown test's 90s wait. Tighten to 30s for smoke so the test can
+# observe a real graceful exit window without masking a hang.
 
 log "waiting for /api/v1/health on $LOCAL_BASE"
 if wait_for_health "$LOCAL_BASE" 90; then

--- a/smoke/local/07-xxe.sh
+++ b/smoke/local/07-xxe.sh
@@ -46,12 +46,25 @@ csrf=$(csrf_from_jar "$LOCAL_BASE" "$JAR")
 XXE_URL="http://${GATEWAY}:${HOST_PORT}/feed.xml"
 note "submitting XXE feed: $XXE_URL"
 
-code=$(curl -s -o /dev/null -w '%{http_code}' \
-    -b "$JAR" \
-    -X POST "$LOCAL_BASE/api/v1/feeds" \
-    -H "Content-Type: application/json" \
-    -H "X-CSRF-Token: $csrf" \
-    -d "{\"sourceUrl\":\"$XXE_URL\"}")
+# /api/v1/feeds is rate-limited by flask-limiter; earlier tests in the same
+# run can exhaust the per-minute quota, in which case the limiter returns
+# 429 before the parser ever sees the body and the XXE defense isn't
+# actually exercised. Retry once after waiting long enough for the limiter
+# window to clear so we hit the real parser path.
+post_xxe() {
+    curl -s -o /dev/null -w '%{http_code}' \
+        -b "$JAR" \
+        -X POST "$LOCAL_BASE/api/v1/feeds" \
+        -H "Content-Type: application/json" \
+        -H "X-CSRF-Token: $csrf" \
+        -d "{\"sourceUrl\":\"$XXE_URL\"}"
+}
+code=$(post_xxe)
+if [ "$code" = "429" ]; then
+    note 'rate-limited on first attempt; waiting 65s for limiter window to clear'
+    sleep 65
+    code=$(post_xxe)
+fi
 
 # Expect 400/422 (rejected at parse). 201 would mean XXE was processed.
 assert_in "$code" "400 422" "XXE feed rejected (got $code)"

--- a/smoke/local/11-lockout.sh
+++ b/smoke/local/11-lockout.sh
@@ -13,11 +13,24 @@ TEST_NAME="T11-lockout" source "$SCRIPT_DIR/../lib/common.sh"
 # path end-to-end here.
 note 'private-IP lockout exclusion covered by tests/unit/test_auth_lockout.py'
 
-# 2) Public IP path: 5 wrong from 203.0.113.5. /auth/login is capped at
-# 3/min by flask-limiter, so we pace the attempts 22s apart to stay under
-# the rate limit while still accumulating lockout-counter hits.
+# 2) Public IP path: 5 wrong from a real public IP.
+#
+# IMPORTANT: do NOT use RFC 5737 documentation ranges (192.0.2.0/24,
+# 198.51.100.0/24, 203.0.113.0/24) here. Python stdlib `ipaddress`
+# classifies all of those as `is_private=True` per RFC 6890, so the
+# lockout machinery (`utils.validation.is_public_ip_for_lockout`)
+# refuses to count failures against them and this test silently
+# never trips the threshold.
+#
+# Cloudflare 1.1.1.1 is `is_private=False`, well-known, and the
+# isolated smoke container never actually contacts it -- the IP is
+# only used as a spoofed X-Forwarded-For value.
+#
+# /auth/login is capped at 3/min by flask-limiter, so we pace the
+# attempts 22s apart to stay under the rate limit while still
+# accumulating lockout-counter hits.
 # Total: 5 * 22s + 22s pause = ~132s. Slow but reliable.
-SPOOF="203.0.113.5"
+SPOOF="1.1.1.1"
 for i in $(seq 1 5); do
     curl -s -o /dev/null -X POST "$LOCAL_BASE/api/v1/auth/login" \
         -H "Content-Type: application/json" \

--- a/smoke/local/13-backup.sh
+++ b/smoke/local/13-backup.sh
@@ -21,12 +21,42 @@ else
     fail_step 'backup file empty'
 fi
 
-# Validate it's an SQLite file (header bytes "SQLite format 3\0")
-header=$(head -c 16 "$OUT" 2>/dev/null | tr -d '\0' || true)
-if printf '%s' "$header" | grep -q 'SQLite format 3'; then
-    pass_step 'backup file is a valid SQLite database'
+# Validate the backup format. With MINUSPOD_MASTER_PASSPHRASE set in the
+# smoke env, the backup endpoint emits an encrypted envelope starting with
+# magic bytes "MPBK01\x00". Without the passphrase it ships raw SQLite
+# (header "SQLite format 3\x00"). Accept either, and if encrypted, exercise
+# the standalone decrypter end-to-end so the test catches a broken envelope.
+magic=$(head -c 7 "$OUT" 2>/dev/null | od -An -c | tr -d ' \n')
+if printf '%s' "$magic" | grep -q '^SQLitef'; then
+    pass_step 'backup file is a plaintext SQLite database (no MASTER_PASSPHRASE)'
+elif printf '%s' "$magic" | grep -q '^MPBK01'; then
+    pass_step 'backup file is a MPBK01 encrypted envelope (MASTER_PASSPHRASE set)'
+
+    # Decrypt round-trip. Needs the container's per-instance salt; the
+    # standalone decrypter pulls it from any SQLite file from the same
+    # instance, including a copy of the live DB.
+    SALT_DB="$RESULTS_DIR/T13-salt.db"
+    DECRYPTED="$RESULTS_DIR/T13-backup-decrypted.db"
+    rm -f "$SALT_DB" "$DECRYPTED"
+    if docker cp "$LOCAL_CONTAINER:/app/data/podcast.db" "$SALT_DB" 2>/dev/null; then
+        if MINUSPOD_MASTER_PASSPHRASE="${MINUSPOD_MASTER_PASSPHRASE:-smoke-test-passphrase}" \
+                python3 "$REPO_ROOT/scripts/decrypt_backup_standalone.py" \
+                    --salt-db "$SALT_DB" "$OUT" "$DECRYPTED" >/dev/null 2>&1; then
+            d_header=$(head -c 16 "$DECRYPTED" 2>/dev/null | tr -d '\0' || true)
+            if printf '%s' "$d_header" | grep -q 'SQLite format 3'; then
+                pass_step 'MPBK01 envelope decrypts to a valid SQLite database'
+            else
+                fail_step "decrypted file is not SQLite (header: $d_header)"
+            fi
+        else
+            fail_step 'standalone decrypter failed'
+        fi
+    else
+        skip_step 'docker cp of /app/data/podcast.db failed; cannot exercise decrypt round-trip'
+    fi
+    rm -f "$SALT_DB" "$DECRYPTED"
 else
-    fail_step "backup file not SQLite (header: $header)"
+    fail_step "backup file has unknown magic (first 7 bytes: $magic)"
 fi
 
 dump_local_logs

--- a/smoke/remote/01-health.sh
+++ b/smoke/remote/01-health.sh
@@ -19,10 +19,21 @@ try:
 except Exception:
     print("")' 2>/dev/null || true)
 note "remote version: $ver"
-if [ "$ver" = "2.0.0" ]; then
-    pass_step 'remote reports version 2.0.0'
+# Accept any non-empty SemVer. Hardcoding a specific value here made the
+# remote smoke fail on every release. Tie this to a specific version only
+# when smoke is run as a post-deploy gate (set SMOKE_EXPECT_VERSION).
+if [ -n "${SMOKE_EXPECT_VERSION:-}" ]; then
+    if [ "$ver" = "${SMOKE_EXPECT_VERSION}" ]; then
+        pass_step "remote reports version ${SMOKE_EXPECT_VERSION}"
+    else
+        fail_step "remote version mismatch: got '$ver', expected '${SMOKE_EXPECT_VERSION}'"
+    fi
 elif [ -n "$ver" ]; then
-    fail_step "remote version mismatch: got '$ver', expected 2.0.0"
+    if printf '%s' "$ver" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
+        pass_step "remote reports SemVer version: $ver"
+    else
+        fail_step "remote version is not SemVer: '$ver'"
+    fi
 else
     skip_step 'could not determine remote version (auth or endpoint shape)'
 fi

--- a/smoke/run-all.sh
+++ b/smoke/run-all.sh
@@ -21,6 +21,13 @@ export RESULTS_DIR
 
 MODE="${1:-all}"
 
+# Wipe prior per-test result files so accumulated lines from earlier runs
+# can't pollute the new SUMMARY.md. SUMMARY.md itself and any non-.txt
+# artifacts (e.g. container logs) are preserved.
+if [ "${SMOKE_PRESERVE_RESULTS:-0}" != "1" ]; then
+    rm -f "$RESULTS_DIR"/*.txt
+fi
+
 run_script() {
     local script="$1"
     echo
@@ -66,7 +73,7 @@ esac
 # Build SUMMARY.md
 SUMMARY="$RESULTS_DIR/SUMMARY.md"
 {
-    echo "# MinusPod 2.0.0 smoke results"
+    echo "# MinusPod smoke results"
     echo
     echo "Generated: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
     echo


### PR DESCRIPTION
## Summary

First slice of the smoke-test coverage expansion. Phase A is independent of PR #232 (audit-cleanup) — it fixes pre-existing smoke harness issues that have nothing to do with 2.4.9. Phase B (coverage of 2.4.9's new security and code surface) waits for #232 to merge.

### Harness
- `run-all.sh`: wipe `smoke/results/*.txt` at the start of each run so prior failures don't bleed into the new `SUMMARY.md`. `SMOKE_PRESERVE_RESULTS=1` opts out. Header no longer hardcodes "MinusPod 2.0.0".
- `00-setup.sh`: skip `docker pull` when `IMAGE` is already local (lets us smoke locally-built images). Set `GUNICORN_GRACEFUL_TIMEOUT=30` / `GUNICORN_TIMEOUT=60` so T17-shutdown's 90s wait can observe a graceful exit (prod default is 330s).

### Test fixes
| Test | Bug | Fix |
|---|---|---|
| T01-health (remote) | hardcoded `expected 2.0.0` failed every release | accept any SemVer; set `SMOKE_EXPECT_VERSION=X.Y.Z` to lock to a specific version when smoke runs as a post-deploy gate |
| T07-xxe | flask-limiter 429 fired before the parser; XXE defense never actually exercised | retry once after a 65s sleep to clear the limiter window |
| T11-lockout | `203.0.113.5` is `is_private=True` per Python stdlib (RFC 6890 reads RFC 5737 doc ranges as private); `is_public_ip_for_lockout` never counted failures | replaced with `1.1.1.1`; documented the trap |
| T13-backup | smoke env sets `MINUSPOD_MASTER_PASSPHRASE` → backup is encrypted `MPBK01` envelope, not raw SQLite | detect both formats; if encrypted, run `scripts/decrypt_backup_standalone.py` round-trip (docker cp salt → decrypt → verify SQLite magic). Now tests the encryption round-trip end-to-end. |

### Fixtures scaffold
- `smoke/fixtures/README.md`, `tiny-feed.xml` (deterministic GUID so reimport doesn't duplicate), `generate-tiny-episode.sh` (calls ffmpeg for 5s of silence). MP3 is not committed; generator runs on demand.

Used by upcoming Phase B+ tests (artwork validation, RSS public paths, pattern correction lifecycle).

## Test plan
- [x] `bash -n` clean on every touched script.
- [ ] Full smoke re-run after this merges (deferred to Phase B so we exercise 2.4.9 endpoints).
- [ ] CI green on this PR.

## Phases roadmap
- **Phase A** (this PR): existing fail fixes + harness hygiene + fixtures scaffold
- Phase B: 2.4.9 security additions (session rotation, CSRF on logout, JSON CSP, SECRET_KEY fail-loud)
- Phase C: Pattern system end-to-end (correction lifecycle, community submission, import modes, split/merge/protect)
- Phase D: Settings system (stage tunables, provider rotation, webhook CRUD, per-section round-trips)
- Phase E: Episode processing (reprocess+skip_patterns, cancel, retry, queue serialization, peaks, transcript-span)
- Phase F: Search / History / Networks / Docs / openapi.yaml
- Phase G: Playwright UI assertions (SSE event handling, AdReviewModal flow, mobile nav close-on-route)