### PR TITLE
docs: document 2.4.20 features (text-mode, detection window, structural 429)

### DIFF
--- a/docs/api-and-webhooks.md
+++ b/docs/api-and-webhooks.md
@@ -67,6 +67,7 @@ Configure webhooks in **Settings > Webhooks** in the web UI, or via the REST API
 | `Episode Processed` | Episode completes processing successfully |
 | `Episode Failed` | Episode reaches permanently failed status |
 | `Auth Failure` | LLM provider returns 401/403 (rate-limited to one per 5 minutes) |
+| `Rate Limit Structural` | A single detection-window request exceeds the provider's per-minute token cap (rate-limited to one per 5 minutes). Retrying will not help; the operator needs to shrink the detection window or move to a higher tier. |
 
 ### Template Variables
 
@@ -74,7 +75,7 @@ Custom payload templates are Jinja2 strings rendered against these variables:
 
 | Variable | Type | Description |
 |---|---|---|
-| `event` | string | `Episode Processed`, `Episode Failed`, or `Auth Failure` |
+| `event` | string | `Episode Processed`, `Episode Failed`, `Auth Failure`, or `Rate Limit Structural` |
 | `timestamp` | string | ISO 8601 UTC timestamp |
 | `podcast.name` | string | Podcast title (falls back to slug if unavailable) |
 | `podcast.slug` | string | Feed slug |
@@ -102,6 +103,19 @@ Custom payload templates are Jinja2 strings rendered against these variables:
 | `model` | string | Model that failed authentication |
 | `error_message` | string | Error details from the provider |
 | `status_code` | int/null | HTTP status code (401 or 403) |
+
+**Rate Limit Structural events use a different payload:**
+
+| Variable | Type | Description |
+|---|---|---|
+| `event` | string | `Rate Limit Structural` |
+| `timestamp` | string | ISO 8601 UTC timestamp |
+| `provider` | string | LLM provider name |
+| `model` | string | Model that returned the 429 |
+| `limit` | int | The provider's per-minute token cap |
+| `used` | int | Tokens already consumed in the current minute |
+| `requested` | int | Tokens this request asked for (greater than `limit` means the request structurally cannot fit) |
+| `error_message` | string | Raw error details from the provider |
 
 ### Default Payloads
 
@@ -171,6 +185,21 @@ When no custom template is configured, MinusPod sends these JSON payloads.
   "model": "claude-sonnet-4-20250514",
   "error_message": "Invalid API key provided",
   "status_code": 401
+}
+```
+
+**Rate Limit Structural:**
+
+```json
+{
+  "event": "Rate Limit Structural",
+  "timestamp": "2026-04-12T00:15:42Z",
+  "provider": "groq",
+  "model": "llama-3.3-70b-versatile",
+  "limit": 6000,
+  "used": 2400,
+  "requested": 8500,
+  "error_message": "rate_limit_exceeded: Request too large for model on tokens per minute"
 }
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,7 +24,7 @@ Customize ad detection in Settings:
 - **Chapters Model** - Model for chapter generation (a small model like Haiku works well here)
 - **Audio Bitrate** - Output bitrate for processed audio (default 128k)
 - **System Prompts** - Customizable prompts for first pass and verification detection
-- **LLM Tunables (per stage)** - See below
+- **LLM Tunables** - See below
 
 ### Tuning LLM behavior per stage
 
@@ -57,6 +57,19 @@ Every tunable has a matching env var (`DETECTION_TEMPERATURE`, `VERIFICATION_MAX
 #### Ollama context window
 
 Ollama truncates prompts that exceed its context window without telling you. The default is often 2048 tokens, too small for a full-transcript pass, and detection fails silently. When the active provider is Ollama, Settings exposes a **Context window (num_ctx)** field; set it to your model's trained context (8192 or higher on most modern models). Env-var alias: `OLLAMA_NUM_CTX`.
+
+#### Detection window geometry
+
+Long episodes are chunked into overlapping windows before being sent to the detection LLM. These controls are global rather than per-stage, and sit above the per-stage controls:
+
+| Control | Range | Default | Notes |
+|---|---|---|---|
+| Window size | 120-1800 seconds | 600s | How much audio each detection request covers. Lower values reduce tokens per request and help small local models or low-tier provider plans stay under per-minute caps. |
+| Window overlap | 0-1770 seconds | 180s | Trailing overlap between consecutive windows so an ad straddling a boundary is still visible in the next window. Must be strictly less than window size. |
+
+API: `PUT /api/v1/settings` accepts `windowSizeSeconds` and `windowOverlapSeconds`. Cross-field validation rejects `overlap >= size` with a 400. The reset-to-default buttons in the UI clear the stored value so the built-in defaults apply on the next episode; no restart needed.
+
+When the provider returns a 429 because a single window's request exceeds the per-minute token cap, MinusPod flags the episode with a `Rate Limit Structural` error and fires the matching webhook (see [API & Webhooks](api-and-webhooks.md#events)). Lower **Window size** here, or move to a higher provider tier; the retry loop won't eventually succeed because the request itself is too big.
 
 ### VAD Gap Detector (advanced)
 

--- a/docs/web-interface.md
+++ b/docs/web-interface.md
@@ -21,7 +21,7 @@ The server includes a web-based management UI at `/ui/`:
 - Real-time status bar showing processing progress across all pages
 - OPML export with original or ad-free (modified) feed URLs
 - Global Defaults group in settings (Auto-Process, Max Feed Episodes, Only Expose Processed) that every feed inherits, with per-feed overrides on each feed's settings page
-- Webhook notifications for processed episodes and auth failures
+- Webhook notifications for processed episodes, permanent failures, auth failures, and structural rate-limit hits
 - Podcast search via PodcastIndex.org
 - Multiple dark themes (Tokyo Night, Dracula, Catppuccin, Nord, Gruvbox, Solarized, and more) with light/dark toggle
 - Installable as Progressive Web App (PWA)
@@ -53,7 +53,16 @@ On desktop you get `Space` for play/pause, arrow keys to nudge the focused pin, 
 
 ### Adding a New Ad
 
-If the detector missed one, click `+ Add new ad` from the episode page header or from the same button inside the editor modal. The editor opens in create mode against the original (pre-cut) audio so you hear exactly what the listener would have heard: enter start and end timestamps or drag the pins on the waveform, pick a sponsor from the autocomplete or type a new one, and the text template auto-populates from the transcript span between your bounds. Submitting creates a new pattern with `created_by='user'` and writes a `'create'` correction so the pattern matcher picks it up on future episodes. The Patterns page tags manually created patterns with a `Manual` badge and adds an Origin filter (All / Auto / Manual).
+If the detector missed one, click `+ Add new ad` from the episode page header or from the same button inside the editor modal. The editor opens in create mode against the original (pre-cut) audio so you hear exactly what the listener would have heard.
+
+The modal has two input modes, toggled by a tab strip at the top:
+
+- **By audio** (default): enter start and end timestamps or drag the pins on the waveform. The text template auto-populates from the transcript span between your bounds.
+- **By text**: the original transcript renders with word-level Whisper timestamps. Select a span of text in the browser; the resolved word boundaries populate the start/end timestamps and the template. A search box with `N of M` navigation jumps between matches. The selected text stays highlighted on mobile too, so the selection is visible after the keyboard closes.
+
+Switching tabs preserves your selection, so you can refine bounds in either view. Pick a sponsor from the autocomplete or type a new one. The optional Reason field is available in both modes.
+
+Submitting creates a new pattern with `created_by='user'` and writes a `'create'` correction so the pattern matcher picks it up on future episodes. The Patterns page tags manually created patterns with a `Manual` badge and adds an Origin filter (All / Auto / Manual).
 
 ### Screenshots
 


### PR DESCRIPTION
## Summary

PR #254 (v2.4.20) updated `openapi.yaml` and `CHANGELOG.md`, but the human-readable docs under `docs/` were left stale. This is a docs-only chore PR; no version bump.

- `docs/api-and-webhooks.md` - adds `Rate Limit Structural` to the events table, the template-variables list, a dedicated payload-variables table, and a default JSON example matching the actual `fire_structural_rate_limit_event` context (provider/model/limit/used/requested/error_message/timestamp).
- `docs/configuration.md` - drops "(per stage)" from the LLM Tunables heading (window is global), adds a "Detection window geometry" subsection covering `windowSizeSeconds`/`windowOverlapSeconds`, the cross-field validator, the reset-to-default UI, and a forward link to the structural rate-limit webhook.
- `docs/web-interface.md` - documents the `By audio` / `By text` tabs in Add new ad, the search box with N-of-M navigation, and the mobile selection persistence; updates the webhook-coverage bullet so all four event types are listed.

## Test plan

- [ ] CI green
- [ ] Reviewer skims diff; the additions match the surrounding voice and stay concrete