### PR TITLE
feat(infra): multi-arch arm64 CPU image via GitHub Actions (closes #256)

### DIFF
--- a/.github/workflows/cpu-image.yml
+++ b/.github/workflows/cpu-image.yml
@@ -1,0 +1,143 @@
+name: CPU image (multi-arch)
+
+# Builds and publishes ttlequals0/minuspod:<version>-cpu as a multi-arch
+# manifest (linux/amd64 + linux/arm64). The amd64 leg runs on the standard
+# GitHub-hosted runner; the arm64 leg runs on the free native arm64 runner
+# (no QEMU). A final job merges both arch-specific digests into a single
+# manifest list and tags it. Trigger is manual only - releases drive this
+# from the user side, not every commit.
+#
+# Requires repo secrets DOCKERHUB_USERNAME and DOCKERHUB_TOKEN.
+#
+# The GPU image (ttlequals0/minuspod:<version>, :latest) is still built
+# locally via the /build-and-push skill; only the CPU variant is here
+# because NVIDIA's arm64 CUDA images target Jetson, not generic arm servers.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (matches version.py, e.g. 2.4.21). Pushed as :<version>-cpu."
+        required: true
+        type: string
+      promote_cpu_tag:
+        description: "Also tag and push as :cpu (post-merge floating tag)."
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cpu-image-${{ inputs.version }}
+  cancel-in-progress: false
+
+env:
+  REGISTRY_IMAGE: ttlequals0/minuspod
+
+jobs:
+  build:
+    name: Build ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch_id: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch_id: arm64
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
+
+      - name: Docker Hub login
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
+        with:
+          context: .
+          file: ./Dockerfile.cpu
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=cpu-${{ matrix.arch_id }}
+          cache-to: type=gha,scope=cpu-${{ matrix.arch_id }},mode=max
+
+      - name: Export digest
+        env:
+          ARCH_ID: ${{ matrix.arch_id }}
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p /tmp/digests
+          echo "$IMAGE_DIGEST" > "/tmp/digests/$ARCH_ID"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5.0.0
+        with:
+          name: digest-${{ matrix.arch_id }}
+          path: /tmp/digests/${{ matrix.arch_id }}
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge manifest
+    runs-on: ubuntu-latest
+    needs: build
+    env:
+      VERSION: ${{ inputs.version }}
+      PROMOTE_CPU_TAG: ${{ inputs.promote_cpu_tag }}
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@2b3aff260ed2e3b2c3b5fa0d5e0d0c6a3a06af0c  # v5.0.0
+        with:
+          path: /tmp/digests
+          pattern: digest-*
+          merge-multiple: false
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
+
+      - name: Docker Hub login
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create version-cpu manifest list
+        working-directory: /tmp/digests
+        run: |
+          set -euo pipefail
+          AMD64_DIGEST=$(cat digest-amd64/amd64)
+          ARM64_DIGEST=$(cat digest-arm64/arm64)
+          echo "amd64 digest: $AMD64_DIGEST"
+          echo "arm64 digest: $ARM64_DIGEST"
+          docker buildx imagetools create \
+            -t "${REGISTRY_IMAGE}:${VERSION}-cpu" \
+            "${REGISTRY_IMAGE}@${AMD64_DIGEST}" \
+            "${REGISTRY_IMAGE}@${ARM64_DIGEST}"
+
+      - name: Promote :cpu floating tag
+        if: ${{ inputs.promote_cpu_tag }}
+        working-directory: /tmp/digests
+        run: |
+          set -euo pipefail
+          AMD64_DIGEST=$(cat digest-amd64/amd64)
+          ARM64_DIGEST=$(cat digest-arm64/arm64)
+          docker buildx imagetools create \
+            -t "${REGISTRY_IMAGE}:cpu" \
+            "${REGISTRY_IMAGE}@${AMD64_DIGEST}" \
+            "${REGISTRY_IMAGE}@${ARM64_DIGEST}"
+
+      - name: Inspect resulting manifest
+        run: |
+          docker buildx imagetools inspect "${REGISTRY_IMAGE}:${VERSION}-cpu"

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,10 +1,14 @@
 # =============================================================================
 # CPU-only variant of MinusPod (issue #184).
 #
-# Not published to Docker Hub. Build locally:
-#   docker build --platform=linux/amd64 -f Dockerfile.cpu -t minuspod-cpu:local .
+# Published to Docker Hub as a multi-arch manifest (linux/amd64 + linux/arm64,
+# issue #256). Built by .github/workflows/cpu-image.yml on workflow_dispatch.
+# To build locally for the host arch:
+#   docker build -f Dockerfile.cpu -t minuspod-cpu:local .
 # Or with compose:
 #   docker compose -f docker-compose.cpu.yml up -d --build
+# To build for a different arch via QEMU:
+#   docker buildx build --platform=linux/arm64 -f Dockerfile.cpu -t minuspod-cpu:arm64 --load .
 #
 # MAINTENANCE CONTRACT (mirror from Dockerfile when touched):
 #   - Frontend builder stage (verbatim).

--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -23,7 +23,10 @@ services:
     # build:
     #   context: .
     #   dockerfile: Dockerfile.cpu
-    platform: linux/amd64
+    # No `platform:` pin - the CPU image is published as a multi-arch
+    # manifest (linux/amd64 + linux/arm64). Docker picks the matching
+    # variant automatically. Add `platform: linux/amd64` here only if you
+    # need to force amd64 emulation on an arm64 host.
     # The container ships a non-root `minuspod` user at UID/GID 1000
     # (entrypoint.sh drops root via setpriv after fixing volume ownership).
     # Override here to pin a specific APP_UID/APP_GID if your volume is

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -55,7 +55,7 @@ Access the web UI at `http://localhost:8000/ui/` to add and manage feeds.
 
 ### CPU-only image (no GPU)
 
-No NVIDIA GPU? Pull the CPU variant. It drops the CUDA runtime layer and the bundled NVIDIA Python wheels; the image is around 3 GB instead of ~16 GB.
+No NVIDIA GPU? Pull the CPU variant. It drops the CUDA runtime layer and the bundled NVIDIA Python wheels; the image is around 3 GB instead of ~16 GB. The CPU image is published as a multi-arch manifest covering `linux/amd64` and `linux/arm64`, so Docker on the puller's machine picks the right architecture automatically. The GPU image stays amd64-only.
 
 Reuse the same `.env` and `data/` directory as the Quick Start, then:
 
@@ -65,7 +65,7 @@ docker compose -f docker-compose.cpu.yml up -d
 
 That pulls `ttlequals0/minuspod:cpu` (the floating CPU tag). To pin a specific release, set `MINUSPOD_VERSION=2.0.21-cpu` in your `.env`. The `:latest` tag always points at the GPU image; CPU users should track `:cpu` or a versioned `-cpu` tag.
 
-Local CPU transcription with `faster-whisper` is slow. For anything beyond a quick test, offload Whisper to a remote API in your `.env`:
+Local CPU transcription with `faster-whisper` is slow on amd64 and slower on arm64. For anything beyond a quick test, offload Whisper to a remote API in your `.env`:
 
 ```
 WHISPER_BACKEND=openai-api


### PR DESCRIPTION
## Summary

Adds linux/arm64 to the published CPU image so users on Raspberry Pi 5, Ampere, Graviton, M-series Macs, and other arm64 hosts can run MinusPod without docker-compose's amd64 emulation. GPU image stays amd64-only (NVIDIA's arm64 CUDA images target Jetson, not generic arm servers).

Closes #256.

## Build pipeline

CPU build moves to a new GitHub Actions workflow that uses the free native runners: `ubuntu-latest` for amd64 and `ubuntu-24.04-arm` for arm64. Each leg builds and pushes its arch by digest; a third job merges the digests into a manifest list and tags it as `:<version>-cpu`, with an optional `:cpu` floating-tag promotion. No QEMU; both legs run natively.

GPU build path is unchanged: still `/build-and-push` locally, still amd64-only, still pushed before the CPU workflow is dispatched. The new split between local (GPU) and Actions (CPU) is documented in `CLAUDE.md` (Image variants table).

Trigger: `gh workflow run cpu-image.yml -f version=2.4.21` after the GPU image lands. Add `-f promote_cpu_tag=true` to also move the floating `:cpu` tag.

## Why no requirements.txt changes

`pip-compile --generate-hashes` already emits hashes for every available wheel per pinned version, so the existing lockfile is multi-arch by default. Verified with `uv pip install --dry-run --python-platform aarch64-manylinux_2_28 --python <3.11 venv> -r requirements.txt`: all 88 packages plus torch 2.6.0+cpu and torchaudio 2.6.0 resolve against the existing pins. The only sdist that builds from source on either arch is `sgmllib3k` (pure Python, feedparser transitive).

## What's in the diff

- `.github/workflows/cpu-image.yml`: new `workflow_dispatch` workflow with `version` and `promote_cpu_tag` inputs. Pins all action SHAs in line with the rest of the repo. User inputs flow through `env:` before any shell interpolation, per the security-reminder hook.
- `Dockerfile.cpu`: header comment drops the `--platform=linux/amd64` hint and documents the multi-arch publish path plus the buildx cross-arch escape hatch.
- `docker-compose.cpu.yml`: removed `platform: linux/amd64`. Docker auto-picks the matching arch from the manifest list. `docker-compose.yml` (GPU) keeps its amd64 pin.
- `docs/installation.md`: note that the CPU image is multi-arch; note that faster-whisper CPU is slow on amd64 and slower on arm64, reinforcing the remote-Whisper escape hatch.

## Verification

- Dry-run install for aarch64-manylinux_2_28 against `requirements.txt`: pass, 88 packages.
- PyTorch CDN: `torch-2.6.0+cpu-cp311-cp311-manylinux_2_28_aarch64.whl` confirmed present.
- Local QEMU buildx build of `Dockerfile.cpu` for `linux/arm64`: in progress at time of PR open; will update once it completes. The Actions native-arm64 leg is the real verification; QEMU is just a local sanity probe.

## Test plan

- [ ] CI green
- [ ] Reviewer skims `.github/workflows/cpu-image.yml`; confirms the env-var pattern around `inputs.version` is consistent across both run-steps
- [ ] After merge: dispatch the workflow against the merged main with `version=<next-release>`; confirm both arch legs go green and the resulting manifest list lists both `linux/amd64` and `linux/arm64`