### PR TITLE
fix(ci): correct download-artifact SHA in cpu-image workflow

### DIFF
--- a/.github/workflows/cpu-image.yml
+++ b/.github/workflows/cpu-image.yml
@@ -41,7 +41,7 @@ jobs:
     name: Build ${{ matrix.platform }}
     runs-on: ${{ matrix.runner }}
     strategy:
-      fail-fast: false  # let the surviving arch finish so its digest isn't orphaned
+      fail-fast: false  # let the surviving leg finish; its digest is still uploaded for inspection on partial failure
       matrix:
         include:
           - platform: linux/amd64
@@ -78,6 +78,11 @@ jobs:
           ARCH_ID: ${{ matrix.arch_id }}
           IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
         run: |
+          set -euo pipefail
+          if [ -z "$IMAGE_DIGEST" ]; then
+            echo "build-push-action produced no digest output" >&2
+            exit 1
+          fi
           mkdir -p /tmp/digests
           echo "$IMAGE_DIGEST" > "/tmp/digests/$ARCH_ID"
 

--- a/.github/workflows/cpu-image.yml
+++ b/.github/workflows/cpu-image.yml
@@ -98,7 +98,7 @@ jobs:
       PROMOTE_CPU_TAG: ${{ inputs.promote_cpu_tag }}
     steps:
       - name: Download digests
-        uses: actions/download-artifact@2b3aff260ed2e3b2c3b5fa0d5e0d0c6a3a06af0c  # v5.0.0
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0  # v5.0.0
         with:
           path: /tmp/digests
           pattern: digest-*

--- a/.github/workflows/cpu-image.yml
+++ b/.github/workflows/cpu-image.yml
@@ -41,7 +41,7 @@ jobs:
     name: Build ${{ matrix.platform }}
     runs-on: ${{ matrix.runner }}
     strategy:
-      fail-fast: true
+      fail-fast: false  # let the surviving arch finish so its digest isn't orphaned
       matrix:
         include:
           - platform: linux/amd64
@@ -113,31 +113,25 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Create version-cpu manifest list
+      - name: Create manifest list
         working-directory: /tmp/digests
         run: |
           set -euo pipefail
           AMD64_DIGEST=$(cat digest-amd64/amd64)
           ARM64_DIGEST=$(cat digest-arm64/arm64)
-          echo "amd64 digest: $AMD64_DIGEST"
-          echo "arm64 digest: $ARM64_DIGEST"
+          TAGS=(-t "${REGISTRY_IMAGE}:${VERSION}-cpu")
+          if [ "$PROMOTE_CPU_TAG" = "true" ]; then
+            TAGS+=(-t "${REGISTRY_IMAGE}:cpu")
+          fi
           docker buildx imagetools create \
-            -t "${REGISTRY_IMAGE}:${VERSION}-cpu" \
-            "${REGISTRY_IMAGE}@${AMD64_DIGEST}" \
-            "${REGISTRY_IMAGE}@${ARM64_DIGEST}"
-
-      - name: Promote :cpu floating tag
-        if: ${{ inputs.promote_cpu_tag }}
-        working-directory: /tmp/digests
-        run: |
-          set -euo pipefail
-          AMD64_DIGEST=$(cat digest-amd64/amd64)
-          ARM64_DIGEST=$(cat digest-arm64/arm64)
-          docker buildx imagetools create \
-            -t "${REGISTRY_IMAGE}:cpu" \
+            "${TAGS[@]}" \
             "${REGISTRY_IMAGE}@${AMD64_DIGEST}" \
             "${REGISTRY_IMAGE}@${ARM64_DIGEST}"
 
       - name: Inspect resulting manifest
         run: |
+          set -euo pipefail
           docker buildx imagetools inspect "${REGISTRY_IMAGE}:${VERSION}-cpu"
+          if [ "$PROMOTE_CPU_TAG" = "true" ]; then
+            docker buildx imagetools inspect "${REGISTRY_IMAGE}:cpu"
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **CPU image now ships as a multi-arch manifest covering `linux/amd64` and `linux/arm64` (issue #256).** Users on Raspberry Pi 5, Ampere, Graviton, M-series Macs, and other arm64 hosts can pull `ttlequals0/minuspod:<version>-cpu` or `:cpu` without docker-compose's amd64 emulation; Docker auto-selects the matching variant at pull time. GPU image (`Dockerfile`, `:<version>`, `:latest`) stays amd64-only because NVIDIA's arm64 CUDA images target Jetson, not generic arm64 cloud hosts.
+- **CPU image build moves to a GitHub Actions workflow.** `.github/workflows/cpu-image.yml` runs the amd64 leg on `ubuntu-latest` and the arm64 leg on the free native `ubuntu-24.04-arm` runner (no QEMU), then merges both arch-specific digests into a single manifest list. Trigger: `gh workflow run cpu-image.yml -f version=<version>` after the GPU image lands; add `-f promote_cpu_tag=true` to also move the floating `:cpu` tag. Requires repo secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`. The local `/build-and-push` flow stays as GPU-only.
+- **`docker-compose.cpu.yml` no longer pins `platform: linux/amd64`.** Docker now picks the matching arch from the published manifest list. Re-add the pin only to force amd64 emulation on an arm64 host.
+
 ## [2.4.20] - 2026-05-18
 
 ### Fixed


### PR DESCRIPTION
## Summary

The download-artifact SHA in #257 was a typo - the value I committed didn't resolve to any real revision, so the merge job in the first dispatched run failed with:

> Unable to resolve action \`actions/download-artifact@2b3aff...\`, unable to find version \`2b3aff...\`

Both arch build legs succeeded (run 26074537378). Only the merge job, which is the one that calls download-artifact, hit the error.

Real v5.0.0 SHA is \`634f93cb2916e3fdff6788551b99b062d0335ce0\`. Paired with the existing upload-artifact v5.0.0 already in the workflow.

## Test plan

- [ ] CI green
- [ ] After merge: re-dispatch \`cpu-image.yml -f version=2.4.20-multiarch-test\` and confirm the merge job completes