### PR TITLE
ci: split community-pattern validation so fork PRs can be commented

### DIFF
--- a/.github/workflows/comment-community-patterns.yml
+++ b/.github/workflows/comment-community-patterns.yml
@@ -1,0 +1,62 @@
+name: Comment Community Pattern Results
+
+# Runs in the base repo's context (not the fork's), so GITHUB_TOKEN
+# can be granted pull_request write scope to post the validation
+# report back to a fork PR. The companion validate-community-patterns
+# workflow runs read-only on the PR itself and uploads the report as
+# an artifact this workflow then downloads.
+on:
+  workflow_run:
+    workflows: ["Community Pattern Validation"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  comment:
+    name: Post validation report to PR
+    runs-on: ubuntu-latest
+    # Only act on PR-triggered runs from this repo's workflow.
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Download validation report
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0  # v5.0.0
+        with:
+          name: pattern-validation-report
+          path: /tmp/pattern-validation
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Post comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const commentPath = '/tmp/pattern-validation/comment.md';
+            const prNumberPath = '/tmp/pattern-validation/pr_number.txt';
+            if (!fs.existsSync(commentPath) || !fs.existsSync(prNumberPath)) {
+              core.info('Validation report artifact missing expected files; nothing to post.');
+              return;
+            }
+            const body = fs.readFileSync(commentPath, 'utf8').trim();
+            if (!body) {
+              core.info('Validation report is empty; nothing to post.');
+              return;
+            }
+            const prNumber = parseInt(
+              fs.readFileSync(prNumberPath, 'utf8').trim(),
+              10,
+            );
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              core.setFailed('pr_number.txt did not contain a valid PR number');
+              return;
+            }
+            await github.rest.issues.createComment({
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body,
+            });
+            core.info(`Posted validation report to PR #${prNumber}.`);

--- a/.github/workflows/validate-community-patterns.yml
+++ b/.github/workflows/validate-community-patterns.yml
@@ -6,9 +6,13 @@ on:
     paths:
       - 'patterns/community/**'
 
+# Fork-PR safety: this workflow runs with the PR's token, which is
+# read-only when the PR comes from a fork. We do NOT request write
+# scopes here. The companion workflow comment-community-patterns.yml
+# runs on workflow_run from the base repo and is responsible for
+# posting the validation report back to the PR.
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   validate:
@@ -55,30 +59,40 @@ jobs:
           CHANGED_FILES: ${{ steps.changed.outputs.files }}
         run: |
           set +e
+          mkdir -p /tmp/pattern-validation
           python -m src.tools.community_pattern_validator \
             --pr-files $CHANGED_FILES \
-            --comment-output /tmp/comment.md \
-            --status-output /tmp/status.txt
+            --comment-output /tmp/pattern-validation/comment.md \
+            --status-output /tmp/pattern-validation/status.txt
           echo "exit=$?" >> "$GITHUB_OUTPUT"
 
-      - name: Post results comment
+      - name: Emit report to job summary
         if: always() && steps.changed.outputs.files != ''
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        run: |
+          if [ -f /tmp/pattern-validation/comment.md ]; then
+            cat /tmp/pattern-validation/comment.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Record PR number for comment workflow
+        if: always() && steps.changed.outputs.files != ''
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          mkdir -p /tmp/pattern-validation
+          echo "$PR_NUMBER" > /tmp/pattern-validation/pr_number.txt
+
+      - name: Upload validation report
+        if: always() && steps.changed.outputs.files != ''
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5.0.0
         with:
-          script: |
-            const fs = require('fs');
-            const path = '/tmp/comment.md';
-            if (!fs.existsSync(path)) return;
-            const body = fs.readFileSync(path, 'utf8');
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body,
-            });
+          name: pattern-validation-report
+          path: /tmp/pattern-validation/
+          if-no-files-found: error
+          retention-days: 7
 
       - name: Fail job on rejection
         if: steps.changed.outputs.files != '' && steps.validate.outputs.exit != '0'
         run: |
           echo "Community pattern validation rejected one or more files."
+          echo "See the job summary or PR comment for details."
           exit 1

--- a/src/tools/community_pattern_validator.py
+++ b/src/tools/community_pattern_validator.py
@@ -257,7 +257,8 @@ def validate_doc(
     result.sponsor_match = _classify_sponsor(doc.get('sponsor') or '', seed)
     if result.sponsor_match == 'unknown':
         result.warnings.append(
-            f'sponsor "{doc.get("sponsor")}" not in seed list (triage required)'
+            f'new sponsor "{doc.get("sponsor")}" -- not yet in seed list '
+            '(informational; community submissions can introduce new sponsors)'
         )
 
     if result.status == 'reject':
@@ -358,8 +359,9 @@ def render_markdown_comment(results: List[ValidationResult]) -> str:
     if warned:
         lines.append(f'### Warnings ({len(warned)})')
         lines.append(
-            f'Variant suggestions ({dedupe_link}) and unknown-sponsor flags '
-            f'({sponsor_link}) are advisory -- the maintainer decides during review.'
+            f'Variant suggestions ({dedupe_link}) are advisory -- the '
+            f'maintainer decides during review. New sponsors are expected '
+            f'and welcome; see {sponsor_link} if you want to canonicalize.'
         )
         lines.append('')
         for r in warned:


### PR DESCRIPTION
## Summary

PR #289 surfaced a CI failure that isn't a real test failure: the
`validate-community-patterns` workflow runs with the PR's
`GITHUB_TOKEN`, which is read-only when the PR comes from a fork. The
final step in the job tries to POST a comment with the validation
report and gets `403 Resource not accessible by integration`. The job
ends red even though the validator ran correctly.

This change splits the work using the standard fork-PR commenting
pattern:

- `validate-community-patterns.yml` keeps running on `pull_request`
  with read-only permissions. It runs the validator, emits the report
  to `$GITHUB_STEP_SUMMARY`, uploads the report as the
  `pattern-validation-report` artifact, and exits non-zero on
  rejection so the PR check stays red when the patterns are wrong.
- `comment-community-patterns.yml` (new) triggers on `workflow_run`,
  runs in the base repo's context with `pull_request: write`,
  downloads the artifact via `actions/download-artifact@v5.0.0` using
  `run-id` + `github-token`, reads the PR number from
  `pr_number.txt`, and posts the comment via `github.rest.issues.createComment`.

## What this means for PR #289

After this lands on `main`, the next pattern-validation run on PR #289
(either a new push or a re-run from the Actions tab) will pick up the
new workflow. The validate job will still go red because two of the
five submitted patterns are legitimately broken (multi-sponsor block
on `spectrum-business-*.json`, JSON parse error on `virgin-voyages-*.json`),
but the comment with the explanation will actually land on the PR.

## Test plan

- [ ] CI green on this PR (the new workflow needs `main` to take
      effect, but the YAML must still parse and the validate job
      shouldn't change behavior for non-pattern PRs).
- [ ] After merge, the next validate run on PR #289 (or a fresh test
      PR that touches `patterns/community/`) actually leaves a comment
      with the report, with no 403 in the run logs.