### PR TITLE
fix(ci): community pattern validator runs even when PR base is stale

### DIFF
--- a/.github/workflows/validate-community-patterns.yml
+++ b/.github/workflows/validate-community-patterns.yml
@@ -22,7 +22,12 @@ jobs:
       - name: Checkout PR
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          fetch-depth: 2
+          # Need full history so the diff against pull_request.base.sha
+          # works even after main has advanced past the PR's recorded
+          # base. A shallow clone fails with "bad object <sha>" when the
+          # base commit is not in the local pack, and the resulting
+          # empty change list silently skips validation.
+          fetch-depth: 0
 
       - name: List changed JSON files under patterns/community/
         id: changed
@@ -30,9 +35,14 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          set -e
-          changed=$(git diff --diff-filter=AM --name-only "$BASE_SHA" "$HEAD_SHA" \
-            | grep -E '^patterns/community/.+\.json$' \
+          set -euo pipefail
+          # Diff failures must abort the job -- we previously masked them
+          # with `|| true` on the pipeline, which let an unreachable base
+          # SHA produce an empty changed list and a misleading green run.
+          git diff --diff-filter=AM --name-only "$BASE_SHA" "$HEAD_SHA" > /tmp/changed-raw.txt
+          # Filtering can legitimately return zero matches; only `grep`'s
+          # exit code 1 here is allowed to roll up to an empty result.
+          changed=$(grep -E '^patterns/community/.+\.json$' /tmp/changed-raw.txt \
             | grep -v 'patterns/community/index.json' \
             | tr '\n' ' ' || true)
           echo "files=$changed" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Why

While testing the new filename-mismatch checks (from #294) against PR #292, I noticed the validator workflow reported "pass" on the re-run even though I had local proof that 7 files in that PR should be rejected. Reading the workflow logs revealed:

```
BASE_SHA: 57fd44e81d398311aaf7621e8d066495465bb2a6
HEAD_SHA: e4d66f087414e4168c468a0aef54d81a78b95568
fatal: bad object 57fd44e81d398311aaf7621e8d066495465bb2a6
Changed files:
```

`57fd44e8` is an older main commit (the main HEAD as of PR #292's last sync). After 2.5.32 and #294 merged, that commit moved out of the shallow pack `fetch-depth: 2` pulls. The `git diff` failed, the surrounding `|| true` on the pipeline swallowed the error, the changed-files list came back empty, every subsequent step was gated on `if: steps.changed.outputs.files != ''`, and the job exited 0 -- a false green.

## What changes

`.github/workflows/validate-community-patterns.yml`:

- `fetch-depth: 2` -> `fetch-depth: 0` so the base SHA is always reachable. The job runs in ~20 seconds today; the heavier clone adds maybe 10-15 seconds.
- Split the `git diff` out of the surrounding pipeline so a future fetch / diff failure aborts the job loudly instead of producing the same silent-skip pattern. `|| true` stays on the `grep` step where a zero-match result is legitimate.
- `set -e` -> `set -euo pipefail` for the same reason.

## What does not change

- Workflow trigger surface (`pull_request` on `patterns/community/**`) and permissions are unchanged.
- The validator itself is untouched.
- No code in `src/` or `tests/`.
- No version bump.

## Test plan

- [ ] Workflow YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/validate-community-patterns.yml'))"`)
- [ ] Once this merges, close+reopen PR #292 to confirm the validator actually runs and surfaces the 7 filename mismatches and the vanta truncation warning
