### PR TITLE
fix(manifest): stop regenerate-manifest committing timestamp-only diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`src/tools/generate_manifest.py` no longer rewrites `published_at` on no-op runs.** `build_manifest` stamped the current UTC time on every invocation, so the regenerate-manifest workflow's `git diff --quiet` was never quiet and it committed a timestamp-only change even when no pattern content changed (surfaced on PR #299). `main()` now reuses the prior timestamp when re-rendering the manifest with it reproduces the on-disk `index.json` byte-for-byte (`reuse_published_at`) -- the same rendered-bytes comparison the workflow's `git diff` makes, so a true no-op stays byte-identical and the commit step is skipped, while any real content change still bumps the timestamp.
+
 ## [2.5.34] - 2026-05-29
 
 ### Added

--- a/src/tools/generate_manifest.py
+++ b/src/tools/generate_manifest.py
@@ -8,9 +8,11 @@ local testing or recovery from a workflow failure:
 
 Pattern files live at `patterns/community/<sponsor>-<uuid>.json`. The
 manifest is a single document that embeds every pattern inline so the
-client fetches everything in one request. `published_at` is bumped to
-the current UTC time; `manifest_version` and `vocabulary_version` are
-constants that bump only when the format changes.
+client fetches everything in one request. `published_at` is bumped to the
+current UTC time only when the rendered manifest actually changes -- a no-op
+run reuses the prior timestamp so the regenerate-manifest workflow's
+`git diff --quiet` stays quiet and skips a spurious commit. `manifest_version`
+and `vocabulary_version` are constants that bump only when the format changes.
 """
 from __future__ import annotations
 
@@ -80,13 +82,14 @@ def _load_pattern_files(directory: Path) -> List[Dict[str, Any]]:
 
 def build_manifest(patterns: List[Dict[str, Any]]) -> Dict[str, Any]:
     """Build the manifest document from the loaded pattern dicts."""
-    entries = []
-    for p in patterns:
-        entries.append({
+    entries = [
+        {
             'community_id': p['community_id'],
             'version': int(p.get('version') or 1),
             'data': p,
-        })
+        }
+        for p in patterns
+    ]
     return {
         'manifest_version': MANIFEST_VERSION,
         'published_at': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
@@ -95,12 +98,39 @@ def build_manifest(patterns: List[Dict[str, Any]]) -> Dict[str, Any]:
     }
 
 
+def _render(manifest: Dict[str, Any]) -> str:
+    """Serialize the manifest exactly as it is written to disk."""
+    return json.dumps(manifest, indent=2) + '\n'
+
+
+def reuse_published_at(manifest: Dict[str, Any], existing_text: str | None) -> Dict[str, Any]:
+    """Reuse the prior `published_at` when nothing but the timestamp changed.
+
+    `existing_text` is the on-disk index.json verbatim. If re-rendering the new
+    manifest with the prior timestamp reproduces that text byte-for-byte, only
+    the timestamp would have changed, so we keep the old value. The comparison
+    is on rendered bytes -- the same thing the regenerate-manifest workflow's
+    `git diff --quiet` checks -- so a true no-op stays quiet and skips the
+    spurious timestamp-only commit. Any real content change re-renders
+    differently and the fresh timestamp stands.
+    """
+    if not existing_text:
+        return manifest
+    try:
+        previous = json.loads(existing_text)
+    except json.JSONDecodeError:
+        return manifest
+    prev_published = previous.get('published_at')
+    if not isinstance(prev_published, str):
+        return manifest
+    candidate = {**manifest, 'published_at': prev_published}
+    return candidate if _render(candidate) == existing_text else manifest
+
+
 def write_manifest(manifest: Dict[str, Any], path: Path) -> None:
     """Write the manifest atomically to `path`, preserving a trailing newline."""
     tmp = path.with_suffix(path.suffix + '.tmp')
-    with tmp.open('w', encoding='utf-8') as fh:
-        json.dump(manifest, fh, indent=2)
-        fh.write('\n')
+    tmp.write_text(_render(manifest), encoding='utf-8')
     tmp.replace(path)
 
 
@@ -110,8 +140,14 @@ def main() -> int:
         print(f'ERROR: {directory} does not exist', file=sys.stderr)
         return 1
     patterns = _load_pattern_files(directory)
-    manifest = build_manifest(patterns)
     target = directory / 'index.json'
+    existing_text: str | None = None
+    if target.exists():
+        try:
+            existing_text = target.read_text(encoding='utf-8')
+        except OSError as e:
+            print(f'WARN: ignoring unreadable {target.name}: {e}', file=sys.stderr)
+    manifest = reuse_published_at(build_manifest(patterns), existing_text)
     write_manifest(manifest, target)
     print(
         f'Wrote {target.relative_to(_REPO_SRC.parent)} '

--- a/tests/unit/test_generate_manifest.py
+++ b/tests/unit/test_generate_manifest.py
@@ -6,7 +6,12 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
 
-from tools.generate_manifest import _load_pattern_files, build_manifest  # noqa: E402
+from tools.generate_manifest import (  # noqa: E402
+    _load_pattern_files,
+    _render,
+    build_manifest,
+    reuse_published_at,
+)
 
 
 def _write(path: Path, doc):
@@ -52,6 +57,58 @@ def test_bundle_file_flattens_into_manifest(tmp_path):
     manifest = build_manifest(patterns)
     manifest_ids = {entry['community_id'] for entry in manifest['patterns']}
     assert manifest_ids == {'flat-1', 'b-1', 'b-2'}
+
+
+def test_published_at_preserved_when_render_unchanged():
+    patterns = [{
+        'community_id': 'x-1',
+        'version': 1,
+        'sponsor': 'A',
+        'submitted_at': '2026-01-01T00:00:00Z',
+        'text_template': 'one',
+    }]
+    existing = build_manifest(patterns)
+    existing['published_at'] = '2020-01-01T00:00:00Z'
+    existing_text = _render(existing)
+    rebuilt = reuse_published_at(build_manifest(patterns), existing_text)
+    assert rebuilt['published_at'] == '2020-01-01T00:00:00Z'
+    # The whole point: re-rendering reproduces the on-disk bytes exactly.
+    assert _render(rebuilt) == existing_text
+
+
+def test_published_at_bumped_when_content_changes():
+    base = [{
+        'community_id': 'x-1',
+        'version': 1,
+        'sponsor': 'A',
+        'submitted_at': '2026-01-01T00:00:00Z',
+        'text_template': 'one',
+    }]
+    existing = build_manifest(base)
+    existing['published_at'] = '2020-01-01T00:00:00Z'
+    existing_text = _render(existing)
+    changed = base + [{
+        'community_id': 'x-2',
+        'version': 1,
+        'sponsor': 'B',
+        'submitted_at': '2026-01-02T00:00:00Z',
+        'text_template': 'two',
+    }]
+    rebuilt = reuse_published_at(build_manifest(changed), existing_text)
+    assert rebuilt['published_at'] != '2020-01-01T00:00:00Z'
+
+
+def test_reuse_published_at_ignores_unreadable_existing():
+    patterns = [{
+        'community_id': 'x-1',
+        'version': 1,
+        'sponsor': 'A',
+        'submitted_at': '2026-01-01T00:00:00Z',
+        'text_template': 'one',
+    }]
+    manifest = build_manifest(patterns)
+    assert reuse_published_at(manifest, None) is manifest
+    assert reuse_published_at(manifest, 'not json {') is manifest
 
 
 def test_bundle_with_missing_community_id_is_skipped(tmp_path, capsys):


### PR DESCRIPTION
Reported on #299: the regenerate-manifest workflow auto-commits on every push to main even when no pattern content changed.

## Root cause

`build_manifest` in `src/tools/generate_manifest.py` stamped `published_at = datetime.now(...)` on every run. The workflow guards its commit with `git diff --quiet patterns/community/index.json`, but the timestamp always differed so the guard never held, and it committed a `chore: regenerate community pattern manifest [skip ci]` change on every push.

## Fix

`main()` now reuses the prior `published_at` when re-rendering the manifest with it reproduces the on-disk `index.json` byte-for-byte (`reuse_published_at`). That comparison is on rendered bytes, the same thing the workflow's `git diff` checks, so a true no-op produces a byte-identical file and the commit is skipped. Any real content change re-renders differently and the fresh timestamp stands.

Comparing rendered bytes rather than parsed dicts avoids the object-vs-bytes mismatch: Python `==` is order-insensitive and treats `1 == 1.0` as equal, while `json.dump` is order- and type-faithful.

No consumer depends on `published_at` advancing. `community_sync` reconciles by per-entry `community_id` + `version`, and the frontend reads only `manifest_version`.

## Tests

- `test_published_at_preserved_when_render_unchanged`: no-op reuses the timestamp and re-renders byte-identical.
- `test_published_at_bumped_when_content_changes`: a content change bumps the timestamp.
- `test_reuse_published_at_ignores_unreadable_existing`: a missing or non-JSON existing file falls back to a fresh stamp.

Full suite: 1519 passed, 4 skipped. Locally, two back-to-back `python -m tools.generate_manifest` runs leave `git diff --quiet patterns/community/index.json` clean.

Version bump is left to the release step (matching the #297 -> #298 flow).
