### PR TITLE
fix(community): drop ShipStation intro variant flagged as truncated

### DIFF
--- a/patterns/community/shipstation-9d8a3bf8.json
+++ b/patterns/community/shipstation-9d8a3bf8.json
@@ -3,8 +3,7 @@
   "text_template": "Support for Today Explained comes from ShipStation When your company is growing fast order fulfillment can make or break your success That where ShipStation comes in says ShipStation ShipStation says their intelligence platform helps take the pressure off by bringing order management rate shopping warehouse systems and powerful analytics into one place With ShipStation everything you need to manage getting orders to customers is in one place You can connect to over 200 sales channels and instead of five to seven disconnected tools you got one ShipStation says they can share tracking details to reduce customer service inquiries by up to 12%. While their returns management gives you insight into what's coming back and why, their analytics show where you're saving, where you can optimize. They also say they can select the best carrier, find competitive rates, print labels in bulk, so much more. You can try ShipStation free for 60 days with full access to all features. No credit card needed. Go to ShipStation.com and use code TODAY for 60 days free. 60 days gives you plenty of time to see exactly how much you can save. and how much time and money you're saving on every shipment. That's ShipStation.com code today. ShipStation.com code today.",
   "intro_variants": [
     "Support for Today Explained comes from ShipStation",
-    "Support for JXplained comes from ShipStation",
-    "When your company is growing fast order fulfillment can make or break your success. That where ShipStation comes in"
+    "Support for JXplained comes from ShipStation"
   ],
   "outro_variants": [
     "That's ShipStation.com code today. ShipStation.com code today."


### PR DESCRIPTION
Cleans up the one non-blocking warning left from #305.

`intro_variants[2]` of `shipstation-9d8a3bf8.json` ("...That where ShipStation comes in") ended on a hanging preposition, which the validator's truncation heuristic flags. It was also the weakest of the three intros (ASR-garbled "That where"), so I dropped it. The two "Support for <show> comes from ShipStation" intros and the outro are unchanged, and `text_template` is untouched.

Validator now reports only the informational "new sponsor" notice for ShipStation.