### PR TITLE
benchmark: --snapshot prompt pinning + report rankings rework (F0.5 + tiers)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- LLM benchmark: `benchmark run --snapshot <file>` and `benchmark report --snapshot <file>` pin the system prompt to a frozen file instead of the live `get_static_system_prompt()`. This decouples the stored corpus from the production `SEED_SPONSORS` list -- editing the sponsor list (or the prompt prose) no longer changes the prompt hashes and forces a full re-run. With no flag the live prompt is used as before. `benchmark dump-prompt <file>` writes the current live prompt to a file to seed a snapshot. The report's Run Metadata section records which prompt produced the run (`live` or `snapshot:<name>`) with a sha256 prefix.
+
+### Changed
+
+- LLM benchmark report: the TL;DR rankings (Best Accuracy, Best Value, Best Free-Tier) now lead with F0.5 instead of F1. MinusPod cuts the segments it flags, so a false positive (cutting real content) is worse than a false negative (leaving an ad in); F0.5 weights precision 2x recall to match. Best Accuracy and Best Free-Tier add a 95% confidence interval per model and group models into tiers by a paired one-sided t-test against the tier leader, so the top cluster that trades wins across the 12-episode corpus reads as one tier rather than a false strict order. Raw F1, precision, and recall stay as columns. Models are flagged (not reordered) for low JSON compliance (`brittle JSON`, < 0.90) or a failed no-ad negative control.
+
 ### Security
 
 - **Pattern import replace-mode is now atomic.** A failure partway through a `mode=replace` import could permanently wipe the entire `ad_patterns` table, because the delete/create DB helpers committed individually and defeated the route's rollback. The import now runs as a single transaction through non-committing primitives, so a mid-import failure leaves every existing pattern intact.

--- a/benchmarks/llm/src/benchmark/cli.py
+++ b/benchmarks/llm/src/benchmark/cli.py
@@ -43,6 +43,14 @@ def _root() -> Path:
     return Path(__file__).resolve().parents[2]
 
 
+def _resolve_prompt(snapshot: Optional[Path]) -> tuple[str, str]:
+    try:
+        return parsing.resolve_system_prompt(snapshot)
+    except (FileNotFoundError, ValueError) as e:
+        typer.echo(f"error: {e}", err=True)
+        raise typer.Exit(1)
+
+
 @app.command()
 def capture(
     episode_url: str = typer.Option(..., "--episode-url", help="MinusPod UI URL of the episode to capture"),
@@ -153,10 +161,15 @@ def run(
     force: bool = typer.Option(False, "--force"),
     dry_run: bool = typer.Option(False, "--dry-run"),
     no_report_on_failure: bool = typer.Option(False, "--no-report-on-failure"),
+    snapshot: Optional[Path] = typer.Option(
+        None, "--snapshot",
+        help="Frozen system-prompt file to use instead of the live prompt (decouples the corpus from SEED_SPONSORS edits).",
+    ),
 ) -> None:
     """Auto-fill all gaps in calls.jsonl, then regenerate report."""
     _setup_logging()
     cfg = _load(config_path)
+    system_prompt, prompt_source = _resolve_prompt(snapshot)
     episodes = [corpus_mod.load_episode(cfg.corpus.path / e) for e in corpus_mod.list_episodes(cfg.corpus.path)]
     if not episodes:
         typer.echo("no corpus episodes; run `benchmark capture` first", err=True)
@@ -174,11 +187,11 @@ def run(
             paths.calls_jsonl.unlink()
 
     if dry_run:
-        units, skipped = _preview(cfg, episodes, paths=paths)
+        units, skipped = _preview(cfg, episodes, paths=paths, system_prompt=system_prompt)
         typer.echo(f"dry-run: {len(units)} calls would execute, {skipped} skipped (already done)")
         raise typer.Exit(0)
 
-    stats = asyncio.run(runner_mod.run(cfg, episodes, paths=paths, pricing_snapshot=snap, include_errored=retry_errors))
+    stats = asyncio.run(runner_mod.run(cfg, episodes, paths=paths, pricing_snapshot=snap, system_prompt=system_prompt, include_errored=retry_errors))
     typer.echo(f"run complete: total={stats.total_units} skipped={stats.skipped} completed={stats.completed} errored={stats.errored}")
 
     if stats.errored and no_report_on_failure:
@@ -195,6 +208,7 @@ def run(
         pricing_snapshot=snap,
         output_path=output,
         assets_dir=assets,
+        prompt_source=prompt_source,
     )
     typer.echo(f"report written: {output}")
 
@@ -202,10 +216,15 @@ def run(
 @app.command()
 def report(
     config_path: Path = typer.Option(Path("benchmark.toml"), "--config"),
+    snapshot: Optional[Path] = typer.Option(
+        None, "--snapshot",
+        help="Label the report with this prompt file; pass the same snapshot used for `run` so the footer matches the stored calls.",
+    ),
 ) -> None:
     """Regenerate results/report.md from existing calls.jsonl."""
     _setup_logging()
     cfg = _load(config_path)
+    _, prompt_source = _resolve_prompt(snapshot)
     episodes = [corpus_mod.load_episode(cfg.corpus.path / e) for e in corpus_mod.list_episodes(cfg.corpus.path)]
     paths = runner_mod.RunPaths.for_root(_root() / "results")
     snap = pricing.latest_snapshot(_root() / "data" / "pricing_snapshots") or pricing.fetch_current()
@@ -219,8 +238,20 @@ def report(
         pricing_snapshot=snap,
         output_path=output,
         assets_dir=assets,
+        prompt_source=prompt_source,
     )
     typer.echo(f"report written: {output}")
+
+
+@app.command()
+def dump_prompt(
+    output: Path = typer.Argument(..., help="File to write the current live system prompt to"),
+) -> None:
+    """Freeze the current live system prompt to a file for use with `run --snapshot`."""
+    text = parsing.get_static_system_prompt()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(text)
+    typer.echo(f"wrote prompt snapshot: {output} ({len(text)} chars)")
 
 
 @app.command()
@@ -243,8 +274,7 @@ def archive() -> None:
     typer.echo(f"archived to {dst_dir}")
 
 
-def _preview(cfg, episodes, *, paths):
-    system_prompt = parsing.get_static_system_prompt()
+def _preview(cfg, episodes, *, paths, system_prompt):
     hashes = precompute_prompt_hashes(cfg, episodes, system_prompt=system_prompt)
     completed, _ = scan_calls(paths.calls_jsonl)
     units, skipped = build_work_list(cfg, episodes, completed=completed, prompt_hashes=hashes)

--- a/benchmarks/llm/src/benchmark/metrics.py
+++ b/benchmarks/llm/src/benchmark/metrics.py
@@ -52,6 +52,13 @@ class AccuracyResult:
         p, r = self.precision, self.recall
         return 2 * p * r / (p + r) if (p + r) > 0 else 0.0
 
+    def fbeta(self, beta: float) -> float:
+        """F-beta. beta<1 weights precision over recall (beta=0.5 -> precision 2x)."""
+        p, r = self.precision, self.recall
+        b2 = beta * beta
+        denom = b2 * p + r
+        return (1 + b2) * p * r / denom if denom > 0 else 0.0
+
 
 @dataclass
 class BoundaryError:

--- a/benchmarks/llm/src/benchmark/parsing.py
+++ b/benchmarks/llm/src/benchmark/parsing.py
@@ -6,6 +6,9 @@ puts ``src/`` (the parent MinusPod tree) on the path.
 """
 from __future__ import annotations
 
+import hashlib
+from pathlib import Path
+
 from ad_detector import (  # type: ignore[import-not-found]
     extract_json_ads_array,
     parse_ads_from_response,
@@ -20,4 +23,28 @@ __all__ = [
     "get_static_system_prompt",
     "format_window_prompt",
     "deduplicate_window_ads",
+    "resolve_system_prompt",
 ]
+
+
+def resolve_system_prompt(snapshot: Path | None) -> tuple[str, str]:
+    """Resolve the system prompt for a run and a label for the report.
+
+    ``None`` returns the live prompt from ``get_static_system_prompt()``; a path
+    returns the file's verbatim text (a frozen prompt that live SEED_SPONSORS
+    edits no longer touch). The label carries the first 8 hex of the prompt's
+    sha256 for traceability, and uses the file name only -- never the path -- so
+    a committed report leaks nothing local.
+    """
+    if snapshot is None:
+        text = get_static_system_prompt()
+        source = "live"
+    else:
+        if not snapshot.is_file():
+            raise FileNotFoundError(f"snapshot prompt not found: {snapshot}")
+        text = snapshot.read_text()
+        if not text.strip():
+            raise ValueError(f"snapshot prompt is empty: {snapshot}")
+        source = f"snapshot:{snapshot.name}"
+    sha8 = hashlib.sha256(text.encode()).hexdigest()[:8]
+    return text, f"{source} (sha256:{sha8})"

--- a/benchmarks/llm/src/benchmark/report.py
+++ b/benchmarks/llm/src/benchmark/report.py
@@ -40,6 +40,7 @@ class ModelEpisodeStats:
     model: str
     episode_id: str
     trial_f1s: list[float] = field(default_factory=list)
+    trial_f05s: list[float] = field(default_factory=list)
     trial_precisions: list[float] = field(default_factory=list)
     trial_recalls: list[float] = field(default_factory=list)
     trial_tps: list[int] = field(default_factory=list)
@@ -57,6 +58,7 @@ class ModelEpisodeStats:
 class ModelStats:
     model: str
     f1_per_episode: dict[str, float] = field(default_factory=dict)
+    f05_per_episode: dict[str, float] = field(default_factory=dict)
     f1_stdev_per_episode: dict[str, float] = field(default_factory=dict)
     precision_per_episode: dict[str, float] = field(default_factory=dict)
     recall_per_episode: dict[str, float] = field(default_factory=dict)
@@ -98,6 +100,9 @@ class ModelStats:
     over_1024_count: int = 0
     salvaged_count: int = 0
     avg_f1: float = 0.0
+    avg_f05: float = 0.0
+    avg_precision: float = 0.0
+    avg_recall: float = 0.0
     mean_f1_stdev: float = 0.0
 
     @property
@@ -151,6 +156,7 @@ def render(
     pricing_snapshot: pricing.PricingSnapshot,
     output_path: Path,
     assets_dir: Path,
+    prompt_source: str = "live",
 ) -> None:
     raw_calls = list(read_jsonl(calls_path))
     if not raw_calls:
@@ -191,7 +197,7 @@ def render(
     sections += [
         _render_methodology(cfg, episodes, pricing_snapshot=pricing_snapshot),
         _render_transcript_source(),
-        _render_run_metadata(calls, pricing_snapshot=pricing_snapshot, raw_calls=raw_calls),
+        _render_run_metadata(calls, pricing_snapshot=pricing_snapshot, raw_calls=raw_calls, prompt_source=prompt_source),
     ]
 
     body = "\n\n".join(s for s in sections if s) + "\n"
@@ -354,6 +360,7 @@ def _aggregate(
             truth_ranges = [(ad.start, ad.end) for ad in ep.truth.ads]
             r = metrics.match_predictions(flat_preds, truth_ranges, threshold=DEFAULT_IOU_THRESHOLD)
             stats.trial_f1s.append(r.f1)
+            stats.trial_f05s.append(r.fbeta(0.5))
             stats.trial_precisions.append(r.precision)
             stats.trial_recalls.append(r.recall)
             stats.trial_tps.append(r.true_positives)
@@ -393,6 +400,8 @@ def _aggregate(
             if s.trial_f1s:
                 ms.f1_per_episode[ep_id] = statistics.fmean(s.trial_f1s)
                 ms.f1_stdev_per_episode[ep_id] = metrics.trial_stdev(s.trial_f1s)
+            if s.trial_f05s:
+                ms.f05_per_episode[ep_id] = statistics.fmean(s.trial_f05s)
             if s.trial_precisions:
                 ms.precision_per_episode[ep_id] = statistics.fmean(s.trial_precisions)
             if s.trial_recalls:
@@ -432,6 +441,10 @@ def _aggregate(
         ms.salvaged_count = method_counts[model].get("json_object_single_ad_truncated", 0)
         f1s = list(ms.f1_per_episode.values())
         ms.avg_f1 = statistics.fmean(f1s) if f1s else 0.0
+        f05s = list(ms.f05_per_episode.values())
+        ms.avg_f05 = statistics.fmean(f05s) if f05s else 0.0
+        ms.avg_precision = statistics.fmean(ms.precision_per_episode.values()) if ms.precision_per_episode else 0.0
+        ms.avg_recall = statistics.fmean(ms.recall_per_episode.values()) if ms.recall_per_episode else 0.0
         stdevs = list(ms.f1_stdev_per_episode.values())
         ms.mean_f1_stdev = statistics.fmean(stdevs) if stdevs else 0.0
         counts = json_format_counts_per_model[model]
@@ -495,52 +508,163 @@ def _percentile(sorted_values: list[int], p: int) -> float:
     return sorted_values[lo] + (sorted_values[hi] - sorted_values[lo]) * (k - lo)
 
 
+# 95% t critical values by degrees of freedom, two-sided and one-sided.
+# Beyond df=30, fall back to the normal-approximation z (1.960 / 1.645).
+_T_CRIT = {
+    "two": {
+        1: 12.706, 2: 4.303, 3: 3.182, 4: 2.776, 5: 2.571, 6: 2.447, 7: 2.365,
+        8: 2.306, 9: 2.262, 10: 2.228, 11: 2.201, 12: 2.179, 13: 2.160, 14: 2.145,
+        15: 2.131, 16: 2.120, 17: 2.110, 18: 2.101, 19: 2.093, 20: 2.086, 21: 2.080,
+        22: 2.074, 23: 2.069, 24: 2.064, 25: 2.060, 26: 2.056, 27: 2.052, 28: 2.048,
+        29: 2.045, 30: 2.042,
+    },
+    "one": {
+        1: 6.314, 2: 2.920, 3: 2.353, 4: 2.132, 5: 2.015, 6: 1.943, 7: 1.895,
+        8: 1.860, 9: 1.833, 10: 1.812, 11: 1.796, 12: 1.782, 13: 1.771, 14: 1.761,
+        15: 1.753, 16: 1.746, 17: 1.740, 18: 1.734, 19: 1.729, 20: 1.725, 21: 1.721,
+        22: 1.717, 23: 1.714, 24: 1.711, 25: 1.708, 26: 1.706, 27: 1.703, 28: 1.701,
+        29: 1.699, 30: 1.697,
+    },
+}
+
+
+def _t_crit(df: int, *, two_sided: bool) -> float:
+    table = _T_CRIT["two" if two_sided else "one"]
+    return table.get(df, 1.960 if two_sided else 1.645)
+
+
+def _ci_half_width(values: list[float]) -> float:
+    """95% CI half-width of the mean across episodes (t-based). 0.0 if < 2 points."""
+    n = len(values)
+    if n < 2:
+        return 0.0
+    return _t_crit(n - 1, two_sided=True) * metrics.trial_stdev(values) / math.sqrt(n)
+
+
+def _sig_worse(leader: dict[str, float], model: dict[str, float]) -> bool:
+    """Paired one-sided t-test (95%): is `model` significantly worse than
+    `leader` across the episodes they share? Models are scored on the same
+    episodes, so the per-episode difference cancels shared episode difficulty
+    and is far less noisy than each model's own spread. Two models that trade
+    wins across episodes (mean difference near zero) are NOT separated; a model
+    that is consistently below the leader is. Ties / < 2 shared episodes -> not
+    worse (same tier)."""
+    eps = [e for e in leader if e in model]
+    diffs = [leader[e] - model[e] for e in eps]
+    n = len(diffs)
+    if n < 2:
+        return False
+    mean_d = statistics.fmean(diffs)
+    if mean_d <= 0:
+        return False
+    sd = statistics.stdev(diffs)
+    if sd == 0:
+        return True  # strictly worse on every shared episode
+    t = mean_d / (sd / math.sqrt(n))
+    return t > _t_crit(n - 1, two_sided=False)
+
+
+def _tier_label(index: int) -> str:
+    """0->A, 25->Z, 26->AA, 27->AB ... spreadsheet-style so the label never
+    overflows past 'Z' into punctuation (a literal '|' would break the table)."""
+    label = ""
+    index += 1
+    while index > 0:
+        index, rem = divmod(index - 1, 26)
+        label = chr(ord("A") + rem) + label
+    return label
+
+
+def _assign_tiers(ranked: list[ModelStats]) -> list[str]:
+    """ranked sorted by avg_f05 descending. A model joins the current tier
+    unless it is significantly worse (paired, per-episode) than that tier's
+    leader, in which case it opens a new tier and becomes its leader."""
+    tiers: list[str] = []
+    leader: dict[str, float] | None = None
+    idx = -1
+    for s in ranked:
+        if leader is None or _sig_worse(leader, s.f05_per_episode):
+            idx += 1
+            leader = s.f05_per_episode
+        tiers.append(_tier_label(idx))
+    return tiers
+
+
+def _reliability_flags(s: ModelStats) -> str:
+    """Flags that caveat a ranking without reordering it."""
+    flags: list[str] = []
+    if s.json_compliance_mean < 0.90:
+        flags.append("(!) brittle JSON")
+    if s.no_ad_pass and not all(s.no_ad_pass.values()):
+        flags.append("(!) fails no-ad control")
+    return " ".join(flags)
+
+
 def _render_tldr(stats: dict[str, ModelStats], episodes: list[Episode]) -> str:
-    accuracy_rows = sorted(stats.values(), key=lambda s: _avg_f1(s), reverse=True)
+    cis = {s.model: _ci_half_width(list(s.f05_per_episode.values())) for s in stats.values()}
+
+    accuracy_rows = sorted(stats.values(), key=lambda s: s.avg_f05, reverse=True)
+    acc_tiers = _assign_tiers(accuracy_rows)
     paid_rows = [s for s in stats.values() if s.total_episode_cost > 0]
     free_rows = [s for s in stats.values() if s.total_episode_cost == 0]
-    value_rows = sorted(paid_rows, key=lambda s: _avg_f1(s) / s.total_episode_cost, reverse=True)
-    free_by_f1 = sorted(free_rows, key=lambda s: _avg_f1(s), reverse=True)
+    value_rows = sorted(paid_rows, key=lambda s: s.avg_f05 / s.total_episode_cost, reverse=True)
+    free_by_f05 = sorted(free_rows, key=lambda s: s.avg_f05, reverse=True)
 
-    lines = ["## TL;DR", "", "### Best Accuracy (F1 @ IoU >= 0.5)", ""]
-    lines.append("All models ranked by F1 against human-verified ground truth. Cost includes free-tier models (shown at $0.00).")
-    lines.append("")
-    lines.append("| Rank | Model | F1 | F1 stdev | Cost / episode | p50 latency | JSON compliance | JSON mode |")
-    lines.append("|------|-------|----|----------|----------------|-------------|-----------------|-----------|")
-    for i, s in enumerate(accuracy_rows, 1):
-        lines.append(
-            f"| {i} | `{s.model}` | {_avg_f1(s):.3f} | {s.mean_f1_stdev:.3f} | ${s.total_episode_cost:.4f} | "
-            f"{s.p50_call_latency_ms / 1000:.1f}s | {s.json_compliance_mean:.2f} | {s.json_format_primary} |"
-        )
-
-    lines += ["", "### Best Value (F1 per dollar)", ""]
+    lines = ["## TL;DR", "", "### Best Accuracy (F0.5 @ IoU >= 0.5)", ""]
     lines.append(
-        "Paid-tier only. Free-tier models are excluded here because F1 / 0 is undefined; "
-        "they are ranked separately under Best Free-Tier below."
+        "Models ranked by F0.5 (precision weighted 2x recall) against human-verified ground truth. "
+        "MinusPod cuts the segments it flags, so cutting real content (a false positive) is worse than "
+        "leaving an ad in (a false negative), and F0.5 penalizes it more. A model shares the tier above it "
+        "unless it scores consistently lower across the same episodes (paired one-sided t-test, 95%); models "
+        "that trade wins episode to episode share a tier, so order within a tier is not meaningful on this "
+        f"{sum(1 for e in episodes if not e.truth.is_no_ad_episode)}-episode corpus. Flags caveat a model "
+        "without changing its rank. Cost includes free-tier models (shown at $0.00)."
     )
     lines.append("")
-    lines.append("| Rank | Model | F1/$ | F1 | Cost / episode |")
-    lines.append("|------|-------|------|----|----------------|")
-    for i, s in enumerate(value_rows, 1):
+    lines.append("| Tier | Model | F0.5 | 95% CI | Precision | Recall | F1 | Cost / episode | p50 latency | JSON compliance | Flags |")
+    lines.append("|------|-------|------|--------|-----------|--------|----|----------------|-------------|-----------------|-------|")
+    for tier, s in zip(acc_tiers, accuracy_rows):
         lines.append(
-            f"| {i} | `{s.model}` | {_avg_f1(s) / s.total_episode_cost:.2f} | "
-            f"{_avg_f1(s):.3f} | ${s.total_episode_cost:.4f} |"
+            f"| {tier} | `{s.model}` | {s.avg_f05:.3f} | +/-{cis[s.model]:.3f} | "
+            f"{s.avg_precision:.3f} | {s.avg_recall:.3f} | {s.avg_f1:.3f} | "
+            f"${s.total_episode_cost:.4f} | {s.p50_call_latency_ms / 1000:.1f}s | "
+            f"{s.json_compliance_mean:.2f} | {_reliability_flags(s)} |"
         )
 
-    if free_by_f1:
-        lines += ["", "### Best Free-Tier (F1)", ""]
+    lines += ["", "### Best Value (F0.5 per dollar)", ""]
+    lines.append(
+        "Paid-tier only, ranked by F0.5 per dollar. Free-tier models are excluded here because F0.5 / 0 is "
+        "undefined; they are ranked separately under Best Free-Tier below. No confidence tiers on this table -- "
+        "a point ratio does not group cleanly -- but the reliability flags still apply."
+    )
+    lines.append("")
+    lines.append("| Rank | Model | F0.5/$ | F0.5 | F1 | Cost / episode | Flags |")
+    lines.append("|------|-------|--------|------|----|----------------|-------|")
+    for i, s in enumerate(value_rows, 1):
         lines.append(
-            "Models that came back at $0.00 cost. F1 / $ is undefined for these, so they are ranked by F1 alone. "
-            "Free-tier eligibility on OpenRouter depends on the attribution headers wired into the benchmark "
-            "(`HTTP-Referer`, `X-Title`); a model showing as free here may bill on your own deployment if those headers are missing."
+            f"| {i} | `{s.model}` | {s.avg_f05 / s.total_episode_cost:.2f} | {s.avg_f05:.3f} | "
+            f"{s.avg_f1:.3f} | ${s.total_episode_cost:.4f} | {_reliability_flags(s)} |"
+        )
+
+    if free_by_f05:
+        free_tiers = _assign_tiers(free_by_f05)
+        lines += ["", "### Best Free-Tier (F0.5)", ""]
+        lines.append(
+            "Models that came back at $0.00 cost, ranked by F0.5 with the same CI and flags as Best Accuracy. "
+            "Tiers are computed within the free-tier set against its own leader, so a tier letter here is not "
+            "comparable to the same letter in Best Accuracy. Free-tier eligibility on OpenRouter depends on the "
+            "attribution headers wired into the "
+            "benchmark (`HTTP-Referer`, `X-Title`); a model showing as free here may bill on your own deployment "
+            "if those headers are missing."
         )
         lines.append("")
-        lines.append("| Rank | Model | F1 | F1 stdev | p50 latency | JSON compliance | JSON mode |")
-        lines.append("|------|-------|----|----------|-------------|-----------------|-----------|")
-        for i, s in enumerate(free_by_f1, 1):
+        lines.append("| Tier | Model | F0.5 | 95% CI | Precision | Recall | F1 | p50 latency | JSON compliance | Flags |")
+        lines.append("|------|-------|------|--------|-----------|--------|----|-------------|-----------------|-------|")
+        for tier, s in zip(free_tiers, free_by_f05):
             lines.append(
-                f"| {i} | `{s.model}` | {_avg_f1(s):.3f} | {s.mean_f1_stdev:.3f} | "
-                f"{s.p50_call_latency_ms / 1000:.1f}s | {s.json_compliance_mean:.2f} | {s.json_format_primary} |"
+                f"| {tier} | `{s.model}` | {s.avg_f05:.3f} | +/-{cis[s.model]:.3f} | "
+                f"{s.avg_precision:.3f} | {s.avg_recall:.3f} | {s.avg_f1:.3f} | "
+                f"{s.p50_call_latency_ms / 1000:.1f}s | {s.json_compliance_mean:.2f} | {_reliability_flags(s)} |"
             )
 
     return "\n".join(lines)
@@ -704,7 +828,7 @@ def _render_charts_section() -> str:
         "### Cost vs F1 (Pareto)\n\n"
         "Each model is one colored point. Lower-left is unhelpful (expensive, inaccurate). Upper-left is the sweet spot (accurate, cheap). The legend below the chart shows each model's color next to its F1 and cost-per-episode.\n\n"
         "![Cost vs F1 by model](report_assets/pareto.svg)\n\n"
-        "Source data: [Best Accuracy](#best-accuracy-f1--iou--05), [Best Value](#best-value-f1-per-dollar), [Best Free-Tier](#best-free-tier-f1)\n\n"
+        "Source data: [Best Accuracy](#best-accuracy-f05--iou--05), [Best Value](#best-value-f05-per-dollar), [Best Free-Tier](#best-free-tier-f05)\n\n"
         "### JSON schema compliance\n\n"
         "Fraction of each model's responses that parsed as a clean JSON array. 1.0 means every response came back exactly as requested; lower numbers mean the parser had to recover from markdown fences, object wrappers, or extra fields.\n\n"
         "![JSON compliance per model](report_assets/compliance.svg)\n\n"
@@ -1045,6 +1169,7 @@ def _render_run_metadata(
     *,
     pricing_snapshot: pricing.PricingSnapshot,
     raw_calls: list[dict] | None = None,
+    prompt_source: str = "live",
 ) -> str:
     total_calls = len(calls)
     successful = sum(1 for c in calls if not c.get("error"))
@@ -1066,6 +1191,7 @@ def _render_run_metadata(
         f"- Failed: {failed}",
         f"- Lifetime actual spend (sum of at-runtime costs, includes superseded rows): ${lifetime_actual:.4f}",
         f"- Active pricing snapshot: {pricing_snapshot.captured_at}",
+        f"- System prompt: {prompt_source}",
     ]
     return "\n".join(lines)
 

--- a/benchmarks/llm/src/benchmark/runner.py
+++ b/benchmarks/llm/src/benchmark/runner.py
@@ -155,9 +155,9 @@ async def run(
     *,
     paths: RunPaths,
     pricing_snapshot: pricing.PricingSnapshot,
+    system_prompt: str,
     include_errored: bool = False,
 ) -> RunStats:
-    system_prompt = parsing.get_static_system_prompt()
     prompt_hashes = precompute_prompt_hashes(cfg, episodes, system_prompt=system_prompt)
 
     completed, err_keys = scan_calls(paths.calls_jsonl)

--- a/benchmarks/llm/tests/test_prompt_source.py
+++ b/benchmarks/llm/tests/test_prompt_source.py
@@ -1,0 +1,97 @@
+"""Snapshot system-prompt resolution, hash decoupling, report note, dump-prompt."""
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+from typer.testing import CliRunner
+
+from benchmark import cli, parsing, report
+from benchmark.runner import precompute_prompt_hashes
+
+
+def test_resolve_live_default(monkeypatch):
+    monkeypatch.setattr(parsing, "get_static_system_prompt", lambda: "LIVE PROMPT")
+    text, label = parsing.resolve_system_prompt(None)
+    assert text == "LIVE PROMPT"
+    sha8 = hashlib.sha256(b"LIVE PROMPT").hexdigest()[:8]
+    assert label == f"live (sha256:{sha8})"
+
+
+def test_resolve_snapshot_reads_verbatim(tmp_path):
+    p = tmp_path / "2026-06-02.txt"
+    body = "FROZEN PROMPT\nwith sponsors baked in\n"
+    p.write_text(body)
+    text, label = parsing.resolve_system_prompt(p)
+    assert text == body
+    sha8 = hashlib.sha256(body.encode()).hexdigest()[:8]
+    assert label == f"snapshot:2026-06-02.txt (sha256:{sha8})"
+
+
+def test_resolve_snapshot_label_omits_path(tmp_path):
+    sub = tmp_path / "deep" / "nested"
+    sub.mkdir(parents=True)
+    p = sub / "frozen.txt"
+    p.write_text("x")
+    _, label = parsing.resolve_system_prompt(p)
+    assert "snapshot:frozen.txt" in label
+    assert str(sub) not in label
+
+
+def test_resolve_missing_file_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        parsing.resolve_system_prompt(tmp_path / "nope.txt")
+
+
+def test_resolve_empty_file_raises(tmp_path):
+    p = tmp_path / "empty.txt"
+    p.write_text("   \n")
+    with pytest.raises(ValueError):
+        parsing.resolve_system_prompt(p)
+
+
+def test_snapshot_changes_hashes(minimal_cfg, make_episode):
+    """Different system prompt -> different prompt hashes, so snapshot and live
+    rows never collide in dedup (the whole point of decoupling)."""
+    eps = [make_episode("ep-1", n_windows=2)]
+    live = precompute_prompt_hashes(minimal_cfg, eps, system_prompt="LIVE")
+    snap = precompute_prompt_hashes(minimal_cfg, eps, system_prompt="FROZEN")
+    assert live.keys() == snap.keys()
+    assert all(live[k] != snap[k] for k in live)
+
+
+def test_run_metadata_includes_prompt_source(pricing_snapshot):
+    calls = [{"error": None, "total_cost_usd_at_runtime": 0.0}]
+    out = report._render_run_metadata(
+        calls, pricing_snapshot=pricing_snapshot,
+        prompt_source="snapshot:2026-06-02.txt (sha256:a1b2c3d4)",
+    )
+    assert "- System prompt: snapshot:2026-06-02.txt (sha256:a1b2c3d4)" in out
+
+
+def test_run_metadata_defaults_to_live(pricing_snapshot):
+    calls = [{"error": None, "total_cost_usd_at_runtime": 0.0}]
+    out = report._render_run_metadata(calls, pricing_snapshot=pricing_snapshot)
+    assert "- System prompt: live" in out
+
+
+def test_dump_prompt_writes_file(tmp_path):
+    runner = CliRunner()
+    out = tmp_path / "snap" / "prompt.txt"
+    result = runner.invoke(cli.app, ["dump-prompt", str(out)])
+    assert result.exit_code == 0, result.output
+    assert out.is_file()
+    assert out.read_text().strip()
+    assert "wrote prompt snapshot" in result.output
+
+
+def test_run_dry_run_rejects_missing_snapshot(tmp_path):
+    from tests.test_cli import write_minimal_config
+    cfg = write_minimal_config(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app,
+        ["run", "--config", str(cfg), "--dry-run", "--snapshot", str(tmp_path / "nope.txt")],
+    )
+    assert result.exit_code == 1
+    assert "snapshot prompt not found" in (result.stderr or result.output)

--- a/benchmarks/llm/tests/test_report.py
+++ b/benchmarks/llm/tests/test_report.py
@@ -110,8 +110,8 @@ def test_json_format_summary_classifies_native_prompt_inject_mixed():
     assert pct == 0.01
 
 
-def test_tldr_table_includes_f1_stdev_and_json_mode(tmp_path, minimal_cfg, make_episode, pricing_snapshot):
-    """Best Accuracy table renders the F1 stdev and JSON mode columns."""
+def test_tldr_table_columns_and_json_mode_telemetry(tmp_path, minimal_cfg, make_episode, pricing_snapshot):
+    """Best Accuracy table renders the F0.5 tier columns; per-model detail shows JSON mode."""
     ep = make_episode(n_windows=1)
     calls = tmp_path / "calls.jsonl"
     # Two trials on `m1` (one native, one prompt_injection) -> mixed.
@@ -132,8 +132,9 @@ def test_tldr_table_includes_f1_stdev_and_json_mode(tmp_path, minimal_cfg, make_
         output_path=out, assets_dir=tmp_path / "assets",
     )
     text = out.read_text()
-    assert "F1 stdev" in text
-    assert "JSON mode" in text
+    # Best Accuracy table now leads with F0.5 + paired-tier columns.
+    assert "### Best Accuracy (F0.5 @ IoU >= 0.5)" in text
+    assert "| Tier | Model | F0.5 | 95% CI | Precision | Recall | F1 |" in text
     # Per-model detail block surfaces the native percent + call count.
     assert "JSON mode: mixed" in text
     assert "50% native" in text

--- a/benchmarks/llm/tests/test_tldr_ranking.py
+++ b/benchmarks/llm/tests/test_tldr_ranking.py
@@ -1,0 +1,133 @@
+"""F0.5 headline metric, cross-episode CI, tier grouping, reliability flags."""
+from __future__ import annotations
+
+import math
+
+from benchmark import report
+from benchmark.metrics import AccuracyResult
+from benchmark.report import ModelStats, _assign_tiers, _ci_half_width, _reliability_flags, _render_tldr, _sig_worse, _tier_label
+
+
+def _mr(tp, fp, fn):
+    return AccuracyResult(iou_threshold=0.5, true_positives=tp, false_positives=fp, false_negatives=fn, matches=[])
+
+
+def test_fbeta_equals_f1_at_beta_1():
+    r = _mr(8, 2, 4)
+    assert math.isclose(r.fbeta(1.0), r.f1, rel_tol=1e-9)
+
+
+def test_fbeta_half_favors_precision():
+    # precision 0.8 > recall 0.667 -> F0.5 should sit above F1
+    r = _mr(8, 2, 4)
+    assert r.precision > r.recall
+    assert r.fbeta(0.5) > r.f1
+
+
+def test_fbeta_half_below_f1_when_recall_dominates():
+    r = _mr(8, 4, 2)  # precision 0.667 < recall 0.8
+    assert r.fbeta(0.5) < r.f1
+
+
+def test_ci_half_width_zero_for_under_two_points():
+    assert _ci_half_width([]) == 0.0
+    assert _ci_half_width([0.8]) == 0.0
+
+
+def test_ci_half_width_matches_t_formula():
+    vals = [0.6, 0.8, 1.0]
+    got = _ci_half_width(vals)
+    expected = report._T_CRIT["two"][2] * 0.2 / math.sqrt(3)  # stdev of [.6,.8,1.0] = 0.2, df=2
+    assert math.isclose(got, expected, rel_tol=1e-9)
+
+
+def _epd(vals):
+    return {f"e{i}": v for i, v in enumerate(vals)}
+
+
+def test_tier_label_never_overflows_past_z():
+    assert _tier_label(0) == "A"
+    assert _tier_label(25) == "Z"
+    assert _tier_label(26) == "AA"
+    assert _tier_label(27) == "AB"
+    # No tier index ever yields a markdown-breaking '|' or other punctuation.
+    assert all(c.isalpha() for i in range(200) for c in _tier_label(i))
+
+
+def test_sig_worse_false_when_trading_wins():
+    # model wins some episodes, loses others -> mean diff ~0 -> not separable
+    leader = _epd([0.8, 0.6, 0.9, 0.7, 0.85, 0.65])
+    model = _epd([0.7, 0.7, 0.8, 0.8, 0.75, 0.75])
+    assert _sig_worse(leader, model) is False
+
+
+def test_sig_worse_true_when_consistently_lower():
+    leader = _epd([0.80, 0.85, 0.90, 0.75, 0.82, 0.78])
+    model = _epd([0.50, 0.55, 0.60, 0.45, 0.52, 0.48])
+    assert _sig_worse(leader, model) is True
+
+
+def test_sig_worse_false_for_too_few_shared_episodes():
+    assert _sig_worse(_epd([0.8]), _epd([0.2])) is False
+
+
+def _ms(model, eps):
+    s = ModelStats(model=model)
+    s.f05_per_episode = _epd(eps)
+    s.avg_f05 = sum(eps) / len(eps)
+    return s
+
+
+def test_assign_tiers_paired_groups_close_separates_far():
+    leader = _ms("leader", [0.80, 0.85, 0.90, 0.75, 0.82, 0.78])
+    close = _ms("close", [0.79, 0.80, 0.91, 0.74, 0.80, 0.81])   # trades wins, ~tied
+    far = _ms("far", [0.40, 0.45, 0.50, 0.38, 0.42, 0.41])       # consistently lower
+    ranked = sorted([leader, close, far], key=lambda s: s.avg_f05, reverse=True)
+    assert _assign_tiers(ranked) == ["A", "A", "B"]
+
+
+def _stats(model, *, f05, eps, prec, rec, f1, cost, compliance, no_ad_ok=True):
+    s = ModelStats(model=model)
+    s.avg_f05 = f05
+    s.f05_per_episode = {f"e{i}": v for i, v in enumerate(eps)}
+    s.precision_per_episode = {f"e{i}": prec for i in range(len(eps))}
+    s.recall_per_episode = {f"e{i}": rec for i in range(len(eps))}
+    s.avg_precision = prec
+    s.avg_recall = rec
+    s.avg_f1 = f1
+    s.total_episode_cost = cost
+    s.json_compliance_mean = compliance
+    s.no_ad_pass = {"nad": no_ad_ok}
+    return s
+
+
+def test_reliability_flags():
+    clean = _stats("clean", f05=0.8, eps=[0.8], prec=0.8, rec=0.8, f1=0.8, cost=1.0, compliance=1.0)
+    brittle = _stats("brittle", f05=0.8, eps=[0.8], prec=0.8, rec=0.8, f1=0.8, cost=1.0, compliance=0.6)
+    fails_ctrl = _stats("fc", f05=0.8, eps=[0.8], prec=0.8, rec=0.8, f1=0.8, cost=1.0, compliance=1.0, no_ad_ok=False)
+    assert _reliability_flags(clean) == ""
+    assert "brittle JSON" in _reliability_flags(brittle)
+    assert "fails no-ad control" in _reliability_flags(fails_ctrl)
+
+
+class _Ep:
+    class _T:
+        is_no_ad_episode = False
+    truth = _T()
+
+
+def test_render_tldr_uses_f05_tiers_and_flags():
+    stats = {
+        "brittle-top": _stats("brittle-top", f05=0.82, eps=[0.80, 0.82, 0.84], prec=0.9, rec=0.7, f1=0.79, cost=1.2, compliance=0.60),
+        "clean-2": _stats("clean-2", f05=0.81, eps=[0.79, 0.81, 0.83], prec=0.85, rec=0.78, f1=0.81, cost=1.1, compliance=1.0),
+        "weak": _stats("weak", f05=0.40, eps=[0.38, 0.40, 0.42], prec=0.45, rec=0.35, f1=0.40, cost=0.0, compliance=0.5),
+    }
+    out = _render_tldr(stats, [_Ep(), _Ep()])
+    assert "### Best Accuracy (F0.5 @ IoU >= 0.5)" in out
+    assert "### Best Value (F0.5 per dollar)" in out
+    assert "### Best Free-Tier (F0.5)" in out
+    assert "| Tier | Model | F0.5 | 95% CI | Precision | Recall | F1 |" in out
+    # brittle-top ranks first by F0.5 but carries the flag
+    assert "brittle JSON" in out
+    # the free-tier model (cost 0) appears in its own section
+    assert "weak" in out.split("### Best Free-Tier")[1]


### PR DESCRIPTION
## What

Two changes to the LLM benchmark.

### 1. `--snapshot` prompt pinning

- `benchmark run --snapshot <file>` and `benchmark report --snapshot <file>` pin the system prompt to a frozen file instead of the live `get_static_system_prompt()`.
- `benchmark dump-prompt <file>` writes the current live prompt to a file to seed a snapshot.
- With no flag, the live prompt is used as before.

**Why:** the benchmark hashes the live production prompt into every call's dedup key, so editing the production sponsor list (or prompt prose) changes every hash and forces a full re-run of the stored corpus. A frozen snapshot decouples the corpus from those edits. The report's Run Metadata records which prompt produced the run (`live` or `snapshot:<name>`) with a sha256 prefix.

### 2. Report TL;DR rankings rework

The three TL;DR rankings (Best Accuracy, Best Value, Best Free-Tier) now lead with **F0.5** instead of F1.

- **F0.5** weights precision 2x recall. The app cuts the segments it flags, so a false positive (cutting real show content) is a worse failure than a false negative (leaving an ad in).
- **95% confidence interval** per model (across episodes) added to Best Accuracy and Best Free-Tier.
- **Tiers** group models by a paired one-sided t-test against the tier leader, so the top cluster that trades wins across the corpus reads as one tier rather than a false strict 1-2-3 order.
- Raw **F1, precision, recall** remain as columns.
- **Reliability flags** (no reorder): `brittle JSON` for compliance < 0.90, `fails no-ad control` for a false positive on a no-ad negative-control episode.

## Tests

160 passing. New: `test_prompt_source.py`, `test_tldr_ranking.py`. Updated: `test_report.py` for the new TL;DR columns.

## Scope

Code, tests, and CHANGELOG only. The regenerated corpus data and report artifacts are a separate data update and are not part of this PR.