### PR TITLE
docs: OMP_NUM_THREADS tuning for hybrid Intel CPUs (#333)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,11 @@ WHISPER_DEVICE=cuda
 # WHISPER_API_MODEL=whisper-large-v3-turbo
 # WHISPER_DEVICE=cpu
 
+# Optional: local CPU transcription tuning on hybrid Intel CPUs (12th gen and newer).
+# Cap OpenMP threads to your performance-core count so work stays off the E-cores.
+# See docs/installation.md for P-core pinning. No effect with a remote Whisper API.
+# OMP_NUM_THREADS=8
+
 # =================================================================
 # Server Configuration
 # =================================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Documentation
+
+- Documented `OMP_NUM_THREADS` for local CPU transcription on hybrid Intel CPUs (issue #333). On 12th gen and newer Intel chips the default OpenMP thread pool spreads `faster-whisper` work across the slow E-cores and thrashes the cache; capping `OMP_NUM_THREADS` to the performance-core count, and optionally pinning the container to P-cores with `--cpuset-cpus` (Docker) or `CPUSetCPUs=` (Podman), removes the bottleneck. Added an `OMP_NUM_THREADS` row to `docs/environment-variables.md`, a commented example in `.env.example`, and an "Intel hybrid CPU tuning" section to `docs/installation.md`. No code change; the value is read by CTranslate2 because MinusPod leaves `cpu_threads` at its default.
+
 ## [2.7.5] - 2026-06-05
 
 ### Added

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -72,6 +72,7 @@ Grouped by how often you'll touch them. **Standard** is what a typical deploymen
 | `GUNICORN_GRACEFUL_TIMEOUT` | `330` | Seconds between SIGTERM and SIGKILL on shutdown. |
 | `SECRET_KEY` | _(auto-generated)_ | Flask session signing key. If unset, a random value is generated on first boot and persisted at `$DATA_DIR/.secret_key`. Set explicitly only for multi-instance deployments sharing a session store. Rotating invalidates all existing sessions. |
 | `SESSION_LIFETIME_HOURS` | `24` | How long authenticated sessions stay valid, in hours. |
+| `OMP_NUM_THREADS` | _(library default)_ | Caps OpenMP threads for local `faster-whisper` CPU transcription. On hybrid Intel CPUs the default can push work onto the slow E-cores and thrash the cache; set it to your performance-core count (more threads is not faster). No effect with a remote Whisper API or on GPU. See [Installation](installation.md#intel-hybrid-cpu-tuning-optional). |
 
 ### Optional
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -76,6 +76,36 @@ WHISPER_API_MODEL=whisper-large-v3-turbo
 
 Groq, OpenAI, or a self-hosted whisper.cpp server (see `docker-compose.whisper.yml`) all work here.
 
+### Intel hybrid CPU tuning (optional)
+
+Modern Intel CPUs (12th gen and newer) split their cores into fast P-cores and slow E-cores. The thread pool behind `faster-whisper` is not aware of that split, so on a hybrid chip the work can land on the slow E-cores and thrash the shared cache. Capping the thread count and keeping the work on the P-cores can make a big difference: one user reported a 30-minute episode dropping from roughly 20 minutes to under a minute on an i7-13620H. More threads is not automatically faster, so match the count to your hardware rather than maxing it.
+
+Two knobs, smallest change first:
+
+1. Cap the OpenMP thread pool to your P-core count. This alone removes the oversubscription:
+
+   ```bash
+   docker run -e OMP_NUM_THREADS=8 ... ttlequals0/minuspod:cpu
+   ```
+
+2. Pin the container to the P-cores so the scheduler cannot push work onto E-cores. Find the P-core ids with `lscpu --all --extended` (the higher-clocked cores), then:
+
+   ```bash
+   # Docker
+   docker run -e OMP_NUM_THREADS=8 --cpuset-cpus=0-11 ... ttlequals0/minuspod:cpu
+   ```
+
+   ```ini
+   # Podman Quadlet (minuspod.container)
+   [Container]
+   Environment=OMP_NUM_THREADS=8
+   CPUSetCPUs=0-11
+   ```
+
+   If you would rather bind threads than restrict the cgroup, `OMP_PROC_BIND=close` with `OMP_PLACES=cores` does the same job.
+
+Match `OMP_NUM_THREADS` and the cpuset range to your own chip; the values above are for a 6 P-core part with 12 P-threads. The payoff depends on the CPU and model size, so treat the numbers above as one data point rather than a promise. For sustained transcription, a remote Whisper API is still the better answer.
+
 <details>
 <summary>Build the CPU image locally</summary>
 


### PR DESCRIPTION
## Summary

Documents `OMP_NUM_THREADS` for local `faster-whisper` CPU transcription (issue #333). On hybrid Intel CPUs the default thread count can land work on the slow E-cores and thrash the cache; capping it to the performance-core count, and optionally pinning to P-cores with `--cpuset-cpus` (Docker) or `CPUSetCPUs=` (Podman), removes the bottleneck.

- `OMP_NUM_THREADS` row added to `docs/environment-variables.md`
- commented example in `.env.example`
- "Intel hybrid CPU tuning" section in `docs/installation.md`

No code change. `OMP_NUM_THREADS` already takes effect because MinusPod builds `WhisperModel` without `cpu_threads`, so it stays at the default of 0, which defers to the env var.

## Verification

Confirmed in the `2.7.5-cpu` image. Transcribing a 21.75 min episode (`tiny`/int8) on an 8-core host: OMP=1 -> 64s, OMP=4 -> 28s, default -> 27s, OMP=8 -> 120s. The knob is honored and thread count strongly affects speed; more is not faster. Could not reproduce the reporter's hybrid 10x here: this host has no P/E split, so there are no E-cores to avoid.

Docs only: no version bump, no image rebuild, no deploy. `tsc` and `pytest` (1578 passed) green as a guard.
