### PR TITLE
feat: allow configurable internal port via MINUSPOD_PORT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,10 @@ WHISPER_DEVICE=cuda
 # =================================================================
 BASE_URL=http://localhost:8000
 
+# Internal listen port. Default 8000. Useful for host networking or running
+# multiple instances on one host. Ignored when GUNICORN_BIND is set.
+# MINUSPOD_PORT=8000
+
 # Retention period in minutes (legacy, prefer Settings UI)
 # RETENTION_PERIOD=1440
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -129,7 +129,7 @@ EXPOSE 8000
 
 # Health check - verify the app is responding
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 --start-period=30s \
-  CMD curl -f http://localhost:8000/api/v1/health || exit 1
+  CMD curl -f http://localhost:${MINUSPOD_PORT:-8000}/api/v1/health || exit 1
 
 # Run the application via entrypoint
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -158,7 +158,7 @@ EXPOSE 8000
 
 # Health check - verify the app is responding
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 --start-period=30s \
-  CMD curl -f http://localhost:8000/api/v1/health || exit 1
+  CMD curl -f http://localhost:${MINUSPOD_PORT:-8000}/api/v1/health || exit 1
 
 # Run the application via entrypoint
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -33,7 +33,7 @@ services:
     # owned by a different user -- e.g. `user: "2000:2000"`.
     # user: "1000:1000"
     ports:
-      - "8000:8000"
+      - "${MINUSPOD_PORT:-8000}:${MINUSPOD_PORT:-8000}"
     volumes:
       - ./data:/app/data
       # Optional: Custom assets directory for replacement audio
@@ -67,6 +67,9 @@ services:
       # Server Configuration
       # =================================================================
       - BASE_URL=${BASE_URL:-http://localhost:8000}
+      # Internal listen port. Default 8000. Useful for host networking or
+      # running multiple instances. Ignored when GUNICORN_BIND is set.
+      - MINUSPOD_PORT=${MINUSPOD_PORT:-8000}
 
       # =================================================================
       # 2.0.0+ Security (defaults shown; override via .env when needed)
@@ -94,7 +97,7 @@ services:
       - MINUSPOD_TRUSTED_PROXY_COUNT=${MINUSPOD_TRUSTED_PROXY_COUNT:-0}
 
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/health"]
+      test: ["CMD-SHELL", "curl -f http://localhost:$${MINUSPOD_PORT:-8000}/api/v1/health || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -106,7 +109,7 @@ services:
         max-file: "3"
     restart: unless-stopped
     expose:
-      - "8000"
+      - "${MINUSPOD_PORT:-8000}"
     security_opt:
       - "no-new-privileges:true"
     cap_drop:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     # to use the image default (1000:1000).
     # user: "1000:1000"
     ports:
-      - "8000:8000"
+      - "${MINUSPOD_PORT:-8000}:${MINUSPOD_PORT:-8000}"
     volumes:
       - ./data:/app/data
       # Optional: Custom assets directory for replacement audio
@@ -46,6 +46,9 @@ services:
       # Server Configuration
       # =================================================================
       - BASE_URL=${BASE_URL:-http://localhost:8000}
+      # Internal listen port. Default 8000. Useful for host networking or
+      # running multiple instances. Ignored when GUNICORN_BIND is set.
+      - MINUSPOD_PORT=${MINUSPOD_PORT:-8000}
 
       # =================================================================
       # 2.0.0+ Security (defaults shown; override via .env when needed)
@@ -84,7 +87,7 @@ services:
       # - RETENTION_PERIOD=${RETENTION_PERIOD:-1440}
 
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/health"]
+      test: ["CMD-SHELL", "curl -f http://localhost:$${MINUSPOD_PORT:-8000}/api/v1/health || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -103,7 +106,7 @@ services:
         max-file: "3"
     restart: unless-stopped
     expose:
-      - "8000"
+      - "${MINUSPOD_PORT:-8000}"
     security_opt:
       - "no-new-privileges:true"
     cap_drop:

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -67,6 +67,7 @@ Grouped by how often you'll touch them. **Standard** is what a typical deploymen
 | `APP_UID` | `1000` | UID gunicorn runs as inside the container. Override to match host volume ownership. |
 | `APP_GID` | `1000` | GID counterpart to `APP_UID`. |
 | `GUNICORN_BIND` | `0.0.0.0:8000` | Listen address. Accepts a comma-separated list for multiple sockets. For dual-stack on rootless Podman, use `[::]:8000` -- one IPv6 wildcard also accepts IPv4 when the kernel keeps `bindv6only=0` (the default). Do not list both `0.0.0.0:8000` and `[::]:8000` on such a kernel; the second bind fails with `EADDRINUSE` and gunicorn exits. |
+| `MINUSPOD_PORT` | `8000` | Port for the default listen address (`0.0.0.0:$MINUSPOD_PORT`). Handy for `network_mode: host` or running several instances on one host without a port-mapping conflict. Ignored when `GUNICORN_BIND` is set, which takes precedence. The container `EXPOSE` stays at `8000` (build-time metadata only); the actual listen port follows this var. |
 | `GUNICORN_WORKERS` | `2` | Worker count. Lower means single-threaded UI blocking during RSS refresh; higher multiplies per-worker rate-limit counters (when using `memory://`). |
 | `GUNICORN_TIMEOUT` | `600` | Per-request hard timeout. |
 | `GUNICORN_GRACEFUL_TIMEOUT` | `330` | Seconds between SIGTERM and SIGKILL on shutdown. |

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -11,9 +11,9 @@ import logging
 import os
 import sys
 
-
+_app_port = os.environ.get("MINUSPOD_PORT", "8000")
 _env_bind = os.environ.get("GUNICORN_BIND", "")
-bind = [b.strip() for b in _env_bind.split(",") if b.strip()] or ["0.0.0.0:8000"]
+bind = [b.strip() for b in _env_bind.split(",") if b.strip()] or [f"0.0.0.0:{_app_port}"]
 workers = int(os.environ.get("GUNICORN_WORKERS", "2"))
 threads = int(os.environ.get("GUNICORN_THREADS", "8"))
 timeout = int(os.environ.get("GUNICORN_TIMEOUT", "600"))


### PR DESCRIPTION
### Description
This allows users to dynamically configure the internal listening port of the MinusPod web server using the `MINUSPOD_PORT` environment variable.

### Motivation
While standard bridge port-mapping (`-p host:container`) suffices for many environments, configuring the internal port natively is highly useful for specific setups. Specifically, this helps:
1. **Host Networking Layering (`network_mode: host`):** Vital for rootless Podman deployment strategies or direct host-network routing configurations where binding conflicts on port `8000` would otherwise crash the container.
2. **Multi-Instance Isolation:** Running multiple separate instances of MinusPod concurrently in a shared host network namespace.

### Backward Compatibility
This modification implements an explicit environment fallback pattern (`os.environ.get("MINUSPOD_PORT", "8000")`). If the variable is left unset by an operator, the server gracefully defaults to `0.0.0.0:8000`. Existing installations will not experience breaking changes. Advanced dual-stack behaviors tied to `GUNICORN_BIND` remain prioritized.