### PR TITLE
docs: link community patterns page from README (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Documentation
+
+- Linked the community pattern set (`patterns/README.md`) directly from the README documentation table (#354).
+
 ## [2.7.8] - 2026-06-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Access the web UI at `http://localhost:8000/ui/` to add and manage feeds.
 | [Installation & Upgrading](docs/installation.md) | Requirements, quick start, CPU image, upgrading to 2.0.0+ |
 | [Web Interface](docs/web-interface.md) | Management UI, ad editor workflow, screenshots |
 | [Configuration & Experiments](docs/configuration.md) | Settings, per-stage LLM tuning, VAD gap detector, ad reviewer, community patterns |
+| [Community Patterns](patterns/README.md) | Crowdsourced ad pattern set: opt-in manifest sync, file format, and how to contribute |
 | [Environment Variables](docs/environment-variables.md) | Every env var, grouped by how often you touch it |
 | [LLM Providers](docs/llm-providers.md) | Claude Code wrapper, Ollama, OpenRouter, recommended models, pricing |
 | [Whisper / Transcription](docs/transcription.md) | GPU compute types, whisper.cpp, Groq, OpenAI Whisper, timeouts |


### PR DESCRIPTION
## Summary

Adds a direct row to the README documentation table pointing at `patterns/README.md`, so the crowdsourced community pattern set is discoverable from the main README instead of only being mentioned inside the configuration docs.

Prompted by #354, where the page had to be linked by hand in a comment.

## Changes

- `README.md`: new "Community Patterns" row in the documentation table.
- `CHANGELOG.md`: note under Unreleased.

Docs only, no version bump.