### PR TITLE
ci: guard the CPU image build against a version/code mismatch

### DIFF
--- a/.github/workflows/cpu-image.yml
+++ b/.github/workflows/cpu-image.yml
@@ -53,6 +53,24 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
+      # Guard against publishing a mislabeled image: the checkout builds
+      # whatever ref the dispatch ran on (main by default), independent of the
+      # `version` input. If they disagree, the build was dispatched against a
+      # ref that does not contain the code for that version (e.g. pre-merge
+      # from main). Fail before any push.
+      - name: Verify version.py matches the dispatched version
+        env:
+          EXPECTED: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          ACTUAL=$(sed -nE 's/^__version__ = "([^"]+)"$/\1/p' version.py)
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo "Refusing to build: version.py is '$ACTUAL' but the workflow was dispatched for '$EXPECTED'." >&2
+            echo "The checkout ref does not contain the code for $EXPECTED. Re-dispatch with --ref <branch-or-tag> whose version.py == $EXPECTED (e.g. the release branch, or main after merge)." >&2
+            exit 1
+          fi
+          echo "version.py == $EXPECTED; ok to build."
+
       - name: Set up Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 


### PR DESCRIPTION
## Summary

The CPU image workflow tags the image from the `version` input but checks out whatever ref it was dispatched on (main by default), so the two can disagree. Dispatching `version=2.8.11` from main while main is still 2.8.10 would publish `2.8.11-cpu` built from 2.8.10 code. I hit this during the 2.8.11 release and worked around it with `--ref`.

This adds a guard step right after checkout that reads `version.py` and fails before any build or push when it does not match the dispatched version, with a message pointing at `--ref`. Both arch legs check, so a mismatch can never publish.

No version bump or changelog entry: this is CI tooling only and does not change the published image or app behavior.

## Test

- YAML parses; guard logic verified locally (matching version builds, mismatched version refuses)
- Injection-safe: the version input is read through `env`, not interpolated into the shell