### PR TITLE
docs: OpenVINO Intel GPU transcription guide, accuracy audit, drop 2.0 upgrade notes

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -41,7 +41,7 @@ curl http://localhost:8000/api/v1/health
         "database": true,
         "storage": true
     },
-    "version": "2.4.9"
+    "version": "2.8.13"
 }
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,12 +5,13 @@ Full documentation for MinusPod. Start with the [project README](../README.md) f
 ## Contents
 
 - [How It Works & Detection Pipeline](how-it-works.md) - the transcription -> detection -> cut pipeline, verification pass, sliding windows, processing queue, validation, pattern learning, audio analysis
-- [Installation & Upgrading](installation.md) - requirements, quick start, CPU-only image, upgrading to 2.0.0+
+- [Installation](installation.md) - requirements, quick start, CPU-only image, Intel hybrid CPU tuning
 - [Web Interface](web-interface.md) - the management UI, ad editor workflow, screenshots
 - [Configuration & Experiments](configuration.md) - settings, per-stage LLM tuning, VAD gap detector, provider keys, ad reviewer, community patterns
 - [Environment Variables](environment-variables.md) - every env var, grouped by how often you touch it
 - [LLM Providers](llm-providers.md) - Claude Code wrapper, Ollama (local/cloud), OpenRouter, recommended models, pricing
 - [Whisper / Transcription](transcription.md) - GPU compute types, whisper.cpp, Groq, OpenAI Whisper, language, timeouts
+- [Intel GPU Transcription (OpenVINO)](transcription-openvino.md) - offload Whisper to an Intel GPU via OpenVINO Model Server
 - [Finding Feeds & Usage](feeds-and-usage.md) - podcast search, finding RSS feeds, Audiobookshelf
 - [API & Webhooks](api-and-webhooks.md) - REST endpoints, webhook events, payload templates, signing
 - [Security, Storage & Custom Assets](security-and-storage.md) - remote access, login lockout, backups, custom ad markers

--- a/docs/api-and-webhooks.md
+++ b/docs/api-and-webhooks.md
@@ -8,6 +8,8 @@
 
 REST API available at `/api/v1/`. Interactive docs at `/api/v1/docs`. Full specification: [`openapi.yaml`](../openapi.yaml).
 
+Write requests (`POST`, `PUT`, `DELETE`) require an `X-CSRF-Token` header matching the `minuspod_csrf` cookie. The built-in UI sends it for you; an external client has to read that cookie and echo it back on each write.
+
 Key endpoints:
 - `GET /api/v1/health` - Readiness check (database, storage); returns 503 if either is down
 - `GET /api/v1/health/live` - Liveness probe (process up); always 200, safe for frequent polling
@@ -17,12 +19,13 @@ Key endpoints:
 - `GET /api/v1/feeds/export-opml?mode=original|modified` - Export feeds as OPML (original or ad-free URLs)
 - `GET /api/v1/podcast-search?q=query` - Search podcasts via PodcastIndex.org
 - `GET /api/v1/feeds/{slug}/episodes` - List episodes (supports `sort_by`, `sort_dir`, `status` filter, pagination)
-- `POST /api/v1/feeds/{slug}/episodes/bulk` - Bulk episode actions (process, reprocess, reprocess_full, delete)
+- `POST /api/v1/feeds/{slug}/episodes/bulk` - Bulk episode actions (process, reprocess, reprocess_full, reprocess_llm, delete)
 - `GET /api/v1/feeds/{slug}/episodes/{id}` - Get episode detail with ad markers and transcript
-- `POST /api/v1/feeds/{slug}/episodes/{id}/reprocess` - Force reprocess (supports `mode`: reprocess/full)
+- `POST /api/v1/feeds/{slug}/episodes/{id}/reprocess` - Force reprocess (supports `mode`: reprocess/full/llm; `llm` re-runs ad detection on the existing transcript without re-transcribing)
 - `POST /api/v1/feeds/{slug}/episodes/{id}/cancel` - Cancel processing for a stuck episode
 - `POST /api/v1/feeds/{slug}/episodes/{id}/regenerate-chapters` - Regenerate chapter markers
 - `POST /api/v1/feeds/{slug}/reprocess-all` - Batch reprocess all episodes
+- `GET /api/v1/feeds/{slug}/ad-distribution` - Histogram of where ads have historically been cut across the feed's episodes, with learned prior zones. Informational; powers the feed detail Ad Distribution panel and is independent of the learned-positions experiment toggle.
 - `POST /api/v1/feeds/{slug}/episodes/{id}/retry-ad-detection` - Retry ad detection only
 - `POST /api/v1/feeds/{slug}/episodes/{id}/corrections` - Submit ad corrections
 - `GET /api/v1/patterns` - List ad patterns (filter by scope)

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -6,7 +6,7 @@
 
 ## Environment Variables
 
-Grouped by how often you'll touch them. **Standard** is what a typical deployment sets; **Security** is the 2.0.0+ hardening surface; **Advanced** are tuning knobs for edge cases; **Optional** are opt-in features.
+Grouped by how often you'll touch them. **Standard** is what a typical deployment sets; **Security** is the hardening surface; **Advanced** are tuning knobs for edge cases; **Optional** are opt-in features.
 
 ### Standard
 
@@ -59,8 +59,6 @@ Grouped by how often you'll touch them. **Standard** is what a typical deploymen
 |----------|---------|-------------|
 | `PROCESSING_SOFT_TIMEOUT` | `3600` | Seconds before a stuck job is auto-cleared. Seeds fresh installs; runtime value lives in Settings > Transcription. |
 | `PROCESSING_HARD_TIMEOUT` | `7200` | Seconds before the processing lock is force-released. Must exceed the soft timeout. |
-| `AD_DETECTION_MAX_TOKENS` | `4096` | Max tokens for LLM ad detection responses. |
-| `REVIEW_MAX_TOKENS` | `4096` | Max tokens for the opt-in ad reviewer's per-ad JSON response. |
 | `MINUSPOD_MAX_ARTWORK_BYTES` | `5242880` (5 MB) | Cap on podcast artwork download size. Clamped to `[65536, 52428800]`. |
 | `MINUSPOD_MAX_RSS_BYTES` | `209715200` (200 MB) | Cap on RSS response body size. Floor is 1 MB. |
 | `RATE_LIMIT_STORAGE_URI` | `memory://` | Flask-limiter storage backend. Default is per-worker; set to `redis://host:6379` + run a Redis sidecar for exact declared limits across workers. |
@@ -74,6 +72,21 @@ Grouped by how often you'll touch them. **Standard** is what a typical deploymen
 | `SECRET_KEY` | _(auto-generated)_ | Flask session signing key. If unset, a random value is generated on first boot and persisted at `$DATA_DIR/.secret_key`. Set explicitly only for multi-instance deployments sharing a session store. Rotating invalidates all existing sessions. |
 | `SESSION_LIFETIME_HOURS` | `24` | How long authenticated sessions stay valid, in hours. |
 | `OMP_NUM_THREADS` | _(library default)_ | Caps OpenMP threads for local `faster-whisper` CPU transcription. On hybrid Intel CPUs the default can push work onto the slow E-cores and thrash the cache; set it to your performance-core count (more threads is not faster). No effect with a remote Whisper API or on GPU. See [Installation](installation.md#intel-hybrid-cpu-tuning-optional). |
+
+#### LLM stage tunables
+
+Every per-stage LLM control in Settings > Ad Detection has a matching env var: the setting key in uppercase. Set one to pin the control (the UI renders it read-only with a note); unset it to hand control back to the stored value. Defaults match the pre-tunable behavior, so an unset variable changes nothing. Annotated list in [`.env.example`](../.env.example); behavior detail in [Configuration](configuration.md#env-var-overrides).
+
+The stage prefixes are `DETECTION_`, `VERIFICATION_`, `REVIEWER_`, `CHAPTER_BOUNDARY_`, and `CHAPTER_TITLE_`. Each takes the same four suffixes:
+
+| Suffix | Type | Range / values |
+|--------|------|----------------|
+| `_TEMPERATURE` | float | 0.0 - 2.0 |
+| `_MAX_TOKENS` | int | 128 - 32768 |
+| `_REASONING_BUDGET` | int | 1024 - 65536 (Anthropic extended thinking) |
+| `_REASONING_LEVEL` | enum | `none`, `low`, `medium`, `high` (non-Anthropic providers) |
+
+So `DETECTION_TEMPERATURE`, `VERIFICATION_MAX_TOKENS`, `REVIEWER_REASONING_LEVEL`, and so on. Two legacy names still resolve: `AD_DETECTION_MAX_TOKENS` (alias of `DETECTION_MAX_TOKENS`) and `REVIEW_MAX_TOKENS` (alias of `REVIEWER_MAX_TOKENS`).
 
 ### Optional
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,4 +1,4 @@
-# Installation & Upgrading
+# Installation
 
 [< Docs index](README.md) | [Project README](../README.md)
 
@@ -63,7 +63,7 @@ Reuse the same `.env` and `data/` directory as the Quick Start, then:
 docker compose -f docker-compose.cpu.yml up -d
 ```
 
-That pulls `ttlequals0/minuspod:cpu` (the floating CPU tag). To pin a specific release, set `MINUSPOD_VERSION=2.0.21-cpu` in your `.env`. The `:latest` tag always points at the GPU image; CPU users should track `:cpu` or a versioned `-cpu` tag.
+That pulls `ttlequals0/minuspod:cpu` (the floating CPU tag). To pin a specific release, set `MINUSPOD_VERSION=2.8.13-cpu` in your `.env`. The `:latest` tag always points at the GPU image; CPU users should track `:cpu` or a versioned `-cpu` tag.
 
 Local CPU transcription with `faster-whisper` is slow on amd64 and slower on arm64. For anything beyond a quick test, offload Whisper to a remote API in your `.env`:
 
@@ -116,26 +116,6 @@ docker compose -f docker-compose.cpu.yml up -d --build
 ```
 
 </details>
-
-## Upgrading to 2.0.0+
-
-2.0.0 is a security hardening release. A `docker pull && restart` on a 1.x data volume boots without config changes, but several defaults tightened so a few setups need env-var tweaks. Full detail in [`CHANGELOG.md`](../CHANGELOG.md).
-
-**Likely to bite you if you do nothing:**
-
-- **Plain HTTP:** `SESSION_COOKIE_SECURE` now defaults to `true`, so browsers drop the session cookie. Login looks like it works then the next request is anonymous. Set `SESSION_COOKIE_SECURE=false` if you're not on HTTPS.
-- **Behind a reverse proxy (Cloudflare, cloudflared, nginx, Traefik):** set `MINUSPOD_TRUSTED_PROXY_COUNT=1`. Without it, login lockout and per-IP rate limits silently never fire. The container sees the proxy hop instead of the client. A startup WARN flags it. Full impact in `Remote Access / Security > Client IP for login lockout`.
-- **External API clients** (cron scripts, homegrown tools, third-party integrations): every `POST` / `PUT` / `DELETE` on `/api/v1/*` now needs an `X-CSRF-Token` header matching the `minuspod_csrf` cookie. The built-in UI handles it; raw curl scripts have to echo the cookie.
-- **`/docs` and `/openapi.yaml` bookmarks / health checks:** moved to `/api/v1/docs` and `/api/v1/openapi.yaml`. The old paths return 404.
-- **OpenAI-compatible provider relying on the `ANTHROPIC_API_KEY` fallback:** that fallback is gone. Set `OPENAI_API_KEY` explicitly or ad detection 401s. A startup WARN fires when the old shape is detected.
-
-**Quieter changes worth knowing:**
-
-- `SESSION_COOKIE_SAMESITE` now `Strict`. Flip to `Lax` only if a specific cross-site integration breaks.
-- Frontend and API must share an origin (`flask-cors` was removed). Put them behind the same reverse proxy.
-- Password minimum is now 12 characters. Existing hashes verify fine; the next password change picks up the new minimum.
-- Saving provider keys via `PUT /api/v1/settings/ad-detection` returns 409 unless `MINUSPOD_MASTER_PASSPHRASE` is set. Existing plaintext keys keep working; the setting endpoint refuses to write a new secret in cleartext.
-- Container runs as UID 1000. First boot chowns the data volume in place. Override with `APP_UID` / `APP_GID` or bypass with `docker run --user <N>` if the host volume belongs to a different UID.
 
 ---
 

--- a/docs/security-and-storage.md
+++ b/docs/security-and-storage.md
@@ -17,14 +17,14 @@ The docker-compose includes an optional Cloudflare tunnel service for secure rem
 The tunnel exposes the admin interface to the public internet. Without all of these set, anyone who reaches the tunnel URL can hit unauthenticated paths and attempt to log in:
 
 1. Set a password via Settings > Security (or seed with `APP_PASSWORD`).
-2. `SESSION_COOKIE_SECURE=true` (default in 2.0.0+).
+2. `SESSION_COOKIE_SECURE=true` (the default).
 3. `MINUSPOD_MASTER_PASSPHRASE` set so provider API keys are encrypted at rest.
 4. Cloudflare WAF rule blocking `/ui` and `/api` (see below). The docs and OpenAPI spec live under `/api/v1/docs` and `/api/v1/openapi.yaml`, so they're already covered by the `/api` block.
 5. `MINUSPOD_TRUSTED_PROXY_COUNT=1` so login lockout keys on the real client IP, not the tunnel loopback.
 
 ### Client IP for login lockout
 
-The 2.0.0+ login lockout feature (5 fails / 15 min / 15 min block) keys on `request.remote_addr`. Depending on how traffic reaches the container, that address may or may not be the real client:
+The login lockout feature (5 fails / 15 min / 15 min block) keys on `request.remote_addr`. Depending on how traffic reaches the container, that address may or may not be the real client:
 
 - Direct exposure (no proxy, ports published): `remote_addr` is the client. No config needed.
 - Docker with published ports and no reverse proxy: `remote_addr` is the Docker bridge gateway; lockout will not fire. A startup WARN surfaces this. Deploy behind a proxy or switch to `network_mode: host`.
@@ -51,7 +51,7 @@ Operator checklist:
 - `MINUSPOD_ENABLE_HSTS=true` once the deployment is HTTPS-only.
 - WAF block on `/ui` and `/api`. Public feed paths must stay reachable: `/<slug>`, `/episodes/<slug>/<episode>.mp3`, `.vtt`, `/chapters.json`, and `/api/v1/feeds/<slug>/artwork`.
 
-2.0.0+ ships the rest by default: CSRF, login lockout, SSRF guards, artwork magic-number validation, XXE defense, baseline security headers, non-root container, rate limits on destructive endpoints. See [`CHANGELOG.md`](../CHANGELOG.md) for the full list.
+MinusPod ships the rest by default: CSRF, login lockout, SSRF guards, artwork magic-number validation, XXE defense, baseline security headers, non-root container, rate limits on destructive endpoints. See [`CHANGELOG.md`](../CHANGELOG.md) for the full list.
 
 **Cloudflare WAF example.** Allow only Pocket Casts on the feed host, block admin paths:
 

--- a/docs/transcription-openvino.md
+++ b/docs/transcription-openvino.md
@@ -56,12 +56,14 @@ If there is no `render` group, use the device's own group: `stat -c "%g" /dev/dr
 
 **Startup order.** Because the transcriber joins MinusPod's network namespace, MinusPod has to come up first. `depends_on` handles ordering; `restart: on-failure` covers the case where the transcriber starts before MinusPod has bound its socket.
 
+**Podman.** These image names assume Docker Hub. On Podman, prefix them with `docker.io/` (for example `docker.io/openvino/model_server:latest-gpu`). Rootless Podman also remaps UIDs and GIDs, so `user: "0:0"` is the reliable choice there.
+
 ### Other networking options
 
 If a shared namespace does not fit your setup, drop `network_mode` and pick one:
 
 1. **Shared bridge network.** Put both containers on the same Docker network and reach the transcriber by name: `http://minuspod-transcriber:8001/v3`.
-2. **Published port.** Publish the transcriber's port (`ports: ["8001:8001"]`) and point MinusPod at the host's LAN address: `http://your-host-ip:8001/v3`.
+2. **Published port.** Publish the transcriber's port (`ports: ["8001:8001"]`) and point MinusPod at the host's LAN address: `http://your-host-ip:8001/v3`. The transcriber can run on a separate machine from MinusPod this way.
 
 ## 2. Port conflict
 
@@ -73,7 +75,7 @@ OVMS can auto-download a model on startup, but that mode rewrites your config on
 
 ### Step 1: pull the model once
 
-This downloads the pre-quantized `whisper-large-v3-turbo` weights (~1.6 GB) into `./openvino/models`, builds the repository layout, and exits without starting the server. With the GPU doing the work you are not limited to the tiny or small models.
+This downloads the pre-quantized `whisper-large-v3-turbo` weights (~1.6 GB) from Hugging Face into `./openvino/models`, builds the repository layout, and exits without starting the server. With the GPU doing the work you are not limited to the tiny or small models.
 
 ```bash
 docker run --rm -it \

--- a/docs/transcription-openvino.md
+++ b/docs/transcription-openvino.md
@@ -1,0 +1,193 @@
+# Intel GPU Transcription (OpenVINO)
+
+[< Docs index](README.md) | [Project README](../README.md)
+
+---
+
+This guide offloads Whisper transcription to an Intel GPU using [OpenVINO Model Server](https://docs.openvino.ai/2025/model-server/ovms_what_is_openvino_model_server.html) (OVMS) running alongside the MinusPod CPU image. MinusPod talks to it as a remote OpenAI-compatible Whisper backend, so the heavy transcription work lands on the GPU instead of pinning every CPU core.
+
+It applies to the **CPU image** on an Intel host with a capable integrated or discrete GPU (roughly 6th-gen / 2015 and newer; 11th-gen and newer perform best). It does not apply to the NVIDIA GPU image, which already uses local CUDA. There is no local OpenVINO device path inside MinusPod itself; OVMS runs as a separate container and MinusPod reaches it over HTTP.
+
+This setup was contributed and tested on Intel hardware by @upmcplanetracker in [issue #364](https://github.com/ttlequals0/MinusPod/issues/364).
+
+## How it fits together
+
+- A sidecar container runs `openvino/model_server:latest-gpu` with the host Intel GPU passed through.
+- OVMS serves Whisper at an OpenAI-compatible endpoint (`/v3/audio/transcriptions`).
+- MinusPod's Transcription backend points at that endpoint. MinusPod appends `/audio/transcriptions` to the base URL you configure, so the base URL ends in `/v3`.
+- A custom MediaPipe graph turns on word-level timestamps, which MinusPod needs for precise ad boundary detection.
+
+## 1. Compose setup
+
+Add a transcriber service next to your existing `minuspod` service in `docker-compose.cpu.yml` (the CPU compose file lives at [`docker-compose.cpu.yml`](../docker-compose.cpu.yml)):
+
+```yaml
+  minuspod-transcriber:
+    image: openvino/model_server:latest-gpu
+    container_name: minuspod-transcriber
+    hostname: minuspod-transcriber
+    # Share minuspod's network namespace so the two talk over loopback
+    network_mode: "container:minuspod"
+    devices:
+      - /dev/dri:/dev/dri          # pass through the Intel GPU
+    user: "0:0"                     # root: simplest path to the GPU and bind mount
+    volumes:
+      - ./openvino/models:/models:rw
+    command:
+      --config_path /models/config.json
+      --rest_port 8001              # MinusPod already uses 8000 in this namespace
+    environment:
+      - TZ=America/New_York         # set your timezone
+    restart: on-failure
+    depends_on:
+      - minuspod
+```
+
+**Container name.** `network_mode: "container:minuspod"` resolves by container name, and the shipped `docker-compose.cpu.yml` does not set one (Compose auto-generates something like `<project>-minuspod-1`). Add `container_name: minuspod` to the `minuspod` service so the reference resolves, or use one of the [other networking options](#other-networking-options) below.
+
+**GPU access.** Running the sidecar as root (`user: "0:0"`) is the simplest way to give it both the GPU and the bind-mounted model directory, and it matches the setup tested in issue #364. To run non-root instead, drop `user` and add the host's `render` group so the container can reach `/dev/dri`:
+
+```yaml
+    group_add:
+      - "993"   # GID from: getent group render | cut -d: -f3
+```
+
+If there is no `render` group, use the device's own group: `stat -c "%g" /dev/dri/render* | head -n1`. Going non-root also means the pulled model files must be readable by that user, so run the pull step below as the same user (`-u $(id -u):$(id -g)`) rather than as root.
+
+**Startup order.** Because the transcriber joins MinusPod's network namespace, MinusPod has to come up first. `depends_on` handles ordering; `restart: on-failure` covers the case where the transcriber starts before MinusPod has bound its socket.
+
+### Other networking options
+
+If a shared namespace does not fit your setup, drop `network_mode` and pick one:
+
+1. **Shared bridge network.** Put both containers on the same Docker network and reach the transcriber by name: `http://minuspod-transcriber:8001/v3`.
+2. **Published port.** Publish the transcriber's port (`ports: ["8001:8001"]`) and point MinusPod at the host's LAN address: `http://your-host-ip:8001/v3`.
+
+## 2. Port conflict
+
+Both MinusPod (gunicorn) and OVMS default to port 8000. In a shared network namespace they share one loopback interface, so OVMS would fail to bind with `Address already in use`. The `--rest_port 8001` flag above moves OVMS off 8000. If 8001 is also taken, pick another free port and use the same number in the MinusPod settings later.
+
+## 3. Pull the model and enable word timestamps
+
+OVMS can auto-download a model on startup, but that mode rewrites your config on every boot. To keep word timestamps locked on, pull the model once, then serve it through a fixed config that points at a custom graph.
+
+### Step 1: pull the model once
+
+This downloads the pre-quantized `whisper-large-v3-turbo` weights (~1.6 GB) into `./openvino/models`, builds the repository layout, and exits without starting the server. With the GPU doing the work you are not limited to the tiny or small models.
+
+```bash
+docker run --rm -it \
+  --user 0:0 \
+  --device /dev/dri \
+  -v ./openvino/models:/models:rw \
+  openvino/model_server:latest-gpu \
+  --pull \
+  --source_model OpenVINO/whisper-large-v3-turbo-int8-ov \
+  --model_repository_path /models \
+  --task speech2text \
+  --target_device GPU \
+  --overwrite_models
+```
+
+### Step 2: write the server config
+
+Create `./openvino/models/config.json`. The `name` is the friendly alias MinusPod will send as the model; `base_path` points at the custom graph directory:
+
+```json
+{
+    "model_config_list": [
+        {
+            "config": {
+                "name": "whisper-large-v3-turbo",
+                "base_path": "whisper-word-ts"
+            }
+        }
+    ]
+}
+```
+
+### Step 3: write the custom graph
+
+Create the graph directory and file:
+
+```bash
+mkdir -p ./openvino/models/whisper-word-ts
+```
+
+Put this in `./openvino/models/whisper-word-ts/graph.pbtxt`. The `enable_word_timestamps: true` line is the part that matters for MinusPod:
+
+```protobuf
+# Custom graph - word timestamps on for MinusPod ad-boundary cutting
+input_stream: "HTTP_REQUEST_PAYLOAD:input"
+output_stream: "HTTP_RESPONSE_PAYLOAD:output"
+node {
+    name: "whisper-large-v3-turbo"
+    calculator: "S2tCalculator"
+    input_side_packet: "STT_NODE_RESOURCES:s2t_servable"
+    input_stream: "LOOPBACK:loopback"
+    input_stream: "HTTP_REQUEST_PAYLOAD:input"
+    output_stream: "LOOPBACK:loopback"
+    output_stream: "HTTP_RESPONSE_PAYLOAD:output"
+    input_stream_info: {
+        tag_index: 'LOOPBACK:0',
+        back_edge: true
+    }
+    node_options: {
+        [type.googleapis.com / mediapipe.S2tCalculatorOptions]: {
+            models_path: "/models/OpenVINO/whisper-large-v3-turbo-int8-ov"
+            target_device: "GPU"
+            plugin_config: '{"NUM_STREAMS":"1"}'
+            enable_word_timestamps: true
+        }
+    }
+    input_stream_handler {
+        input_stream_handler: "SyncSetInputStreamHandler",
+        options {
+            [mediapipe.SyncSetInputStreamHandlerOptions.ext] {
+                sync_set {
+                    tag_index: "LOOPBACK:0"
+                }
+            }
+        }
+    }
+}
+```
+
+`models_path` points at the weights `--pull` downloaded in Step 1. Because the server runs with `--config_path`, it reads this graph verbatim and skips the auto-download wrapper.
+
+### Step 4: start the transcriber
+
+```bash
+docker compose -f docker-compose.cpu.yml up -d
+```
+
+Check `docker compose logs minuspod-transcriber`. A healthy start ends with the server reporting the `whisper-large-v3-turbo` model available and the REST endpoint listening on port 8001.
+
+## 4. Point MinusPod at it
+
+In the MinusPod web UI, open **Settings**, expand **Transcription**, and set:
+
+1. **Backend:** Remote API (OpenAI-compatible).
+2. **API Base URL:** `http://127.0.0.1:8001/v3` (for the shared-namespace setup above; use the bridge or host-IP address if you chose a different networking option).
+3. **Model Name:** `whisper-large-v3-turbo` (the alias from `config.json`).
+4. **Skip FLAC Compression:** ON. MinusPod compresses chunks to FLAC by default to keep uploads small for cloud APIs. OVMS expects raw WAV and has no FLAC decoder in its audio pipeline, so transcription fails unless this is on.
+
+Save. The same fields can be set with `WHISPER_BACKEND`, `WHISPER_API_BASE_URL`, `WHISPER_API_MODEL`, and `SKIP_FLAC_COMPRESSION` on first boot, but the UI is the runtime source of truth.
+
+## 5. Verify the GPU is doing the work
+
+Install Intel's GPU monitor on the host:
+
+```bash
+# Debian / Ubuntu
+sudo apt update && sudo apt install intel-gpu-tools
+
+# Fedora / RHEL
+sudo dnf install intel-gpu-tools
+```
+
+Run `sudo intel_gpu_top`, then reprocess an episode from the MinusPod dashboard. You will see a short `ffmpeg` CPU spike while the audio is sliced, then the `ovms` process drives the Render/3D engine toward 80-100%. That confirms the Intel GPU is running the Whisper passes with word timestamps, not the CPU.
+
+---
+
+[< Docs index](README.md) | [Project README](../README.md)

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -87,6 +87,10 @@ WHISPER_DEVICE=cpu
 
 > **Linux users:** Replace `host.docker.internal` with your host IP, or add `extra_hosts: ["host.docker.internal:host-gateway"]` to your Docker service definition.
 
+### Intel GPU (OpenVINO Model Server)
+
+On an Intel host with a capable integrated or discrete GPU, you can offload transcription to the GPU instead of the CPU. OpenVINO Model Server runs Whisper as a remote OpenAI-compatible backend with word-level timestamps, which keeps the CPU image's transcription from pinning every core. See the dedicated [Intel GPU Transcription (OpenVINO)](transcription-openvino.md) guide for the full setup.
+
 ### Groq
 
 [Groq](https://groq.com) offers fast cloud-based whisper transcription:

--- a/docs/web-interface.md
+++ b/docs/web-interface.md
@@ -10,9 +10,11 @@ The server includes a web-based management UI at `/ui/`:
 
 - Dashboard with feed artwork and episode counts
 - Add feeds by RSS URL with optional episode cap
-- Feed management: refresh, delete, copy URLs, set network override, per-feed episode cap
+- Feed management: refresh, delete, copy URLs, editable display title, set network override, per-feed episode cap, per-feed transcription language override
+- Feed detail page groups its controls into collapsible sections (feed settings, tags, ad distribution) so the page stays scannable
+- Ad Distribution panel on the feed detail page: a histogram of where ads have historically been cut across the feed, with learned prior zones marked
 - Episode discovery: all episodes surface on refresh, process any episode from the feed detail page
-- Bulk actions: select multiple episodes to process, reprocess, reprocess (full), or delete
+- Bulk actions: select multiple episodes to process, reprocess, reprocess (full), reprocess (LLM-only, re-detect on the existing transcript), or delete
 - Sort by publish date, episode number, or creation date; paginated (25/50/100/500 per page)
 - Pattern management: view and manage cross-episode ad patterns with sponsor names
 - Sponsor management: view, add, edit, and remove sponsors, each with its linked-pattern count, created and last-matched dates, and tags; plus a tab for name normalization rules

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1147,7 +1147,7 @@ paths:
       summary: Force reprocess an episode (legacy)
       description: |
         Legacy reprocess endpoint. Prefer `/episodes/{slug}/{episode_id}/reprocess`,
-        which supports `mode=reprocess` and `mode=full`.
+        which supports `mode=reprocess`, `mode=full`, and `mode=llm`.
       operationId: reprocessEpisodeLegacy
       parameters:
         - $ref: '#/components/parameters/slug'


### PR DESCRIPTION
## What this does

Three docs-only changes. No code, no version bump, no image build.

### New: Intel GPU transcription via OpenVINO

Adds `docs/transcription-openvino.md`, a setup guide for offloading Whisper to an Intel GPU using OpenVINO Model Server as a remote OpenAI-compatible backend. Linked from the transcription page and the docs index.

Sourced from the community write-up in #364 (contributed and tested on Intel hardware by @upmcplanetracker). I validated it against the official OpenVINO Model Server docs and the MinusPod code, and made two corrections to the original:

- Documents that `network_mode: "container:minuspod"` needs `container_name: minuspod`, which the shipped `docker-compose.cpu.yml` does not set, so a stock setup would fail to resolve the reference.
- Uses the all-root config the contributor actually tested (`user: "0:0"` for both the pull and the serve), with the non-root render-group approach as a documented alternative. The earlier mixed approach risked a permission mismatch between the pulled model files and the serving user.

### Docs accuracy and completeness audit

Checked the docs against the code and CHANGELOG at 2.8.13:

- `api-and-webhooks.md`: added the `llm` reprocess mode, the `reprocess_llm` bulk action, the `GET /feeds/{slug}/ad-distribution` endpoint, and the CSRF header requirement for write requests.
- `web-interface.md`: added editable feed titles, per-feed transcription language, the ad-distribution panel, and the collapsible feed-settings layout.
- `environment-variables.md`: documented the per-stage LLM tunables (`DETECTION_*`, `VERIFICATION_*`, and so on) and folded in the two legacy aliases that were floating in the Advanced table.
- Fixed stale version examples: `2.4.9` to `2.8.13` in `DEPLOYMENT.md`, `2.0.21-cpu` to `2.8.13-cpu` in `installation.md`.
- `openapi.yaml`: corrected the legacy reprocess endpoint description to include `mode=llm`. The ad-distribution path and the canonical reprocess mode enum were already present and accurate.

### Removed 1.x to 2.0 upgrade content

All users are off 1.x, so the migration framing is obsolete. Removed the "Upgrading to 2.0.0+" section from `installation.md` and the `2.0.0+` qualifiers across `README.md`, `environment-variables.md`, and `security-and-storage.md`. The one piece of still-current guidance that lived only in that section (the CSRF header requirement) moved to `api-and-webhooks.md`, so nothing was lost. Left `podcasting-2.0.md` alone, since that "2.0" is the Podcast Namespace spec, not a MinusPod version.

## Testing

Docs-only. Verified that all relative links and anchors resolve, `openapi.yaml` still parses, and the audit fixes match the code (`csrf.py`, `episodes.py`, `feeds.py`, `config.py`). The OpenVINO steps cannot be run here without Intel GPU hardware; they rest on the official-docs and code validation above plus the contributor's tested-on-hardware report in #364.

Closes #364.
