### PR TITLE
feat(scripts): standalone faster-whisper API server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,7 +37,8 @@ ANTHROPIC_API_KEY=sk-ant-your-key-here
 WHISPER_MODEL=small
 WHISPER_DEVICE=cuda
 
-# Option 2: OpenAI-compatible Whisper API (Groq, OpenAI, whisper.cpp)
+# Option 2: OpenAI-compatible Whisper API (Groq, OpenAI, whisper.cpp,
+# or the self-hosted faster-whisper server in scripts/whisper-api-faster/)
 # WHISPER_BACKEND=openai-api
 # WHISPER_API_BASE_URL=https://api.groq.com/openai/v1
 # WHISPER_API_KEY=your-whisper-api-key

--- a/scripts/whisper-api-faster/README.md
+++ b/scripts/whisper-api-faster/README.md
@@ -75,8 +75,16 @@ Environment variables (set in the unit file or shell):
 |---|---|---|
 | `WHISPER_MODEL` | `large-v3` | Any faster-whisper model id |
 | `WHISPER_PORT` | `8090` | Listen port |
+| `WHISPER_HOST` | `0.0.0.0` | Bind address; set `127.0.0.1` to restrict to localhost |
 | `WHISPER_DEVICE` | `cuda` | Set to `cpu` for CPU-only hosts |
 | `WHISPER_COMPUTE_TYPE` | `float16` | Use `int8` for CPU, `float16`/`int8_float16` for GPU |
+| `WHISPER_API_KEY` | _(unset)_ | When set, requests must send `Authorization: Bearer <key>` |
+
+> **Security:** this server binds `0.0.0.0` by default and performs GPU-backed
+> work, so an open port is an unauthenticated compute endpoint. Whenever the
+> port is reachable beyond the host, set `WHISPER_API_KEY` (the server checks it
+> with a constant-time compare) and point the MinusPod client's `WHISPER_API_KEY`
+> at the same value, and/or restrict the bind with `WHISPER_HOST=127.0.0.1`.
 
 ## Point MinusPod at it
 

--- a/scripts/whisper-api-faster/README.md
+++ b/scripts/whisper-api-faster/README.md
@@ -1,0 +1,106 @@
+# Whisper Transcription API (faster-whisper)
+
+A standalone OpenAI-compatible `/v1/audio/transcriptions` server backed by
+[faster-whisper](https://github.com/SYSTRAN/faster-whisper). Designed to be
+run on a separate GPU host and pointed at by MinusPod via the `openai-api`
+whisper backend.
+
+## Why this exists (vs. `docker-compose.whisper.yml`)
+
+The repo already ships `docker-compose.whisper.yml`, which runs **whisper.cpp**
+inside Docker. This script is an alternative for hosts that already have a
+Python/CUDA toolchain and want a thin Flask wrapper around faster-whisper —
+typically a beefy LXC or VM with NVIDIA passthrough that serves multiple
+consumers.
+
+## What MinusPod requires
+
+MinusPod's transcriber posts with `response_format=verbose_json` and expects
+the response to contain `segments[]` with per-segment timing, plus
+`words[]` inside each segment for precise ad-boundary detection. This server
+returns exactly that shape.
+
+If you're writing your own Whisper backend, the minimum response is:
+
+```json
+{
+  "text": "full transcript",
+  "language": "en",
+  "segments": [
+    {
+      "id": 0,
+      "start": 1.81,
+      "end": 4.97,
+      "text": " A-Cast powers the world's best podcasts.",
+      "words": [
+        { "word": " A-Cast", "start": 1.81, "end": 2.10 },
+        ...
+      ]
+    }
+  ]
+}
+```
+
+Returning `200 OK` with an empty `segments[]` (or rejecting `verbose_json`
+with `400`) will cause MinusPod's transcriber to silently abort the chunk
+without a useful error message.
+
+## Install
+
+On a host with an NVIDIA GPU and CUDA drivers:
+
+```bash
+sudo mkdir -p /opt/whisper-api
+sudo cp whisper_api.py requirements.txt /opt/whisper-api/
+sudo python3 -m venv /opt/whisper-api/venv
+sudo /opt/whisper-api/venv/bin/pip install --upgrade pip
+sudo /opt/whisper-api/venv/bin/pip install -r /opt/whisper-api/requirements.txt
+sudo cp whisper-api.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now whisper-api
+```
+
+Verify:
+
+```bash
+curl http://localhost:8090/health
+# {"status":"ok","model":"large-v3"}
+```
+
+## Configuration
+
+Environment variables (set in the unit file or shell):
+
+| Variable | Default | Notes |
+|---|---|---|
+| `WHISPER_MODEL` | `large-v3` | Any faster-whisper model id |
+| `WHISPER_PORT` | `8090` | Listen port |
+| `WHISPER_DEVICE` | `cuda` | Set to `cpu` for CPU-only hosts |
+| `WHISPER_COMPUTE_TYPE` | `float16` | Use `int8` for CPU, `float16`/`int8_float16` for GPU |
+
+## Point MinusPod at it
+
+In MinusPod's `.env`:
+
+```
+WHISPER_BACKEND=openai-api
+WHISPER_API_BASE_URL=http://<host>:8090/v1
+WHISPER_API_MODEL=whisper-large-v3
+WHISPER_API_KEY=
+```
+
+MinusPod's `model` field is ignored by this server — it always uses
+`WHISPER_MODEL` from the environment. Set `WHISPER_API_MODEL` to anything;
+it's just included in the multipart form for OpenAI-API compatibility.
+
+## Troubleshooting
+
+- **Transcription chunks fail with no log detail in MinusPod**: hit the
+  endpoint directly with `response_format=verbose_json` and confirm the
+  shape includes `segments[]` and `words[]`. MinusPod swallows 4xx
+  responses without logging the body (see `_transcribe_via_api` in
+  `src/transcriber.py`).
+- **CUDA OOM at startup**: switch to `WHISPER_COMPUTE_TYPE=int8_float16` or
+  a smaller model.
+- **CPU-only host**: set `WHISPER_DEVICE=cpu` and `WHISPER_COMPUTE_TYPE=int8`.
+  Throughput will be ~10× slower than GPU; consider `large-v3-turbo` instead.

--- a/scripts/whisper-api-faster/requirements.txt
+++ b/scripts/whisper-api-faster/requirements.txt
@@ -1,0 +1,6 @@
+flask==3.1.3
+faster-whisper==1.2.1
+ctranslate2==4.7.1
+tokenizers==0.23.1
+onnxruntime==1.25.1
+av==17.0.1

--- a/scripts/whisper-api-faster/whisper-api.service
+++ b/scripts/whisper-api-faster/whisper-api.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Whisper Transcription API (faster-whisper)
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/opt/whisper-api
+Environment="WHISPER_MODEL=large-v3"
+Environment="WHISPER_PORT=8090"
+Environment="WHISPER_DEVICE=cuda"
+Environment="WHISPER_COMPUTE_TYPE=float16"
+ExecStart=/opt/whisper-api/venv/bin/python3 /opt/whisper-api/whisper_api.py
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=120
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/whisper-api-faster/whisper-api.service
+++ b/scripts/whisper-api-faster/whisper-api.service
@@ -8,8 +8,13 @@ User=root
 WorkingDirectory=/opt/whisper-api
 Environment="WHISPER_MODEL=large-v3"
 Environment="WHISPER_PORT=8090"
+Environment="WHISPER_HOST=0.0.0.0"
 Environment="WHISPER_DEVICE=cuda"
 Environment="WHISPER_COMPUTE_TYPE=float16"
+# Strongly recommended whenever the port is reachable beyond this host:
+# require a bearer token (must match the WHISPER_API_KEY the MinusPod client
+# sends). Leave unset only on a fully trusted/private network.
+# Environment="WHISPER_API_KEY=change-me"
 ExecStart=/opt/whisper-api/venv/bin/python3 /opt/whisper-api/whisper_api.py
 Restart=always
 RestartSec=5

--- a/scripts/whisper-api-faster/whisper_api.py
+++ b/scripts/whisper-api-faster/whisper_api.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""
+Whisper Transcription API — OpenAI-compatible /v1/audio/transcriptions endpoint
+backed by faster-whisper.
+
+Designed to be deployed standalone (systemd unit, container, or `python3
+whisper_api.py`) and pointed at by MinusPod via the `openai-api` whisper
+backend. Returns OpenAI-shaped `verbose_json` (text + segments + per-segment
+word timings), which MinusPod requires for precise ad-boundary detection.
+
+Configuration via environment variables:
+  WHISPER_MODEL         (default: large-v3)
+  WHISPER_PORT          (default: 8090)
+  WHISPER_DEVICE        (default: cuda)
+  WHISPER_COMPUTE_TYPE  (default: float16; use int8 for CPU)
+"""
+
+import os
+import tempfile
+from pathlib import Path
+
+from flask import Flask, request, jsonify
+from faster_whisper import WhisperModel
+
+app = Flask(__name__)
+
+MODEL_SIZE = os.environ.get("WHISPER_MODEL", "large-v3")
+PORT = int(os.environ.get("WHISPER_PORT", 8090))
+DEVICE = os.environ.get("WHISPER_DEVICE", "cuda")
+COMPUTE_TYPE = os.environ.get("WHISPER_COMPUTE_TYPE", "float16")
+
+print(f"Loading Whisper {MODEL_SIZE} on {DEVICE} ({COMPUTE_TYPE})...", flush=True)
+model = WhisperModel(MODEL_SIZE, device=DEVICE, compute_type=COMPUTE_TYPE)
+print("Model ready", flush=True)
+
+
+@app.route("/health", methods=["GET"])
+def health():
+    return jsonify({"status": "ok", "model": MODEL_SIZE})
+
+
+@app.route("/v1/audio/transcriptions", methods=["POST"])
+@app.route("/v1/audio/transcribe", methods=["POST"])
+def transcribe():
+    """
+    OpenAI-compatible transcription endpoint.
+    POST multipart/form-data with:
+      - file: audio file (wav, mp3, m4a, flac, ogg, webm, mp4)
+      - language: optional ISO 639-1 language code (e.g. "en")
+      - response_format: json | verbose_json | text | srt | vtt (default: json)
+      - temperature: float 0-1 (default: 0)
+      - prompt: optional text prompt to guide transcription
+
+    `verbose_json` is required by MinusPod and emits per-segment `words[]`
+    timing alongside `segments[]` and top-level `text`.
+    """
+    if "file" not in request.files:
+        return jsonify({"error": "No file provided"}), 400
+
+    audio_file = request.files["file"]
+    language = request.form.get("language", None)
+    response_format = request.form.get("response_format", "json")
+    temperature = float(request.form.get("temperature", 0.0))
+    prompt = request.form.get("prompt", "")
+
+    suffix = Path(audio_file.filename).suffix if audio_file.filename else ".wav"
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+        audio_file.save(tmp)
+        tmp_path = tmp.name
+
+    try:
+        segments, info = model.transcribe(
+            tmp_path,
+            language=language,
+            temperature=temperature,
+            initial_prompt=prompt if prompt else None,
+            beam_size=5,
+            vad_filter=True,
+            word_timestamps=True,
+        )
+
+        if response_format in ("json", "verbose_json"):
+            text_parts = []
+            seg_list = []
+            include_words = (response_format == "verbose_json")
+            for seg in segments:
+                text_parts.append(seg.text)
+                entry = {
+                    "id": len(seg_list),
+                    "start": round(seg.start, 3),
+                    "end": round(seg.end, 3),
+                    "text": seg.text,
+                }
+                if include_words and getattr(seg, "words", None):
+                    entry["words"] = [
+                        {"word": w.word, "start": round(w.start, 3), "end": round(w.end, 3)}
+                        for w in seg.words
+                    ]
+                seg_list.append(entry)
+
+            full_text = "".join(text_parts).strip()
+            return jsonify({
+                "text": full_text,
+                "segments": seg_list,
+                "language": info.language,
+            })
+
+        elif response_format == "text":
+            full_text = "".join([s.text for s in segments]).strip()
+            return full_text, 200, {"Content-Type": "text/plain; charset=utf-8"}
+
+        elif response_format == "srt":
+            lines = []
+            for i, seg in enumerate(segments, 1):
+                start = _srt_time(seg.start)
+                end = _srt_time(seg.end)
+                lines.append(f"{i}\n{start} --> {end}\n{seg.text.strip()}\n")
+            return "\n".join(lines), 200, {"Content-Type": "text/plain; charset=utf-8"}
+
+        elif response_format == "vtt":
+            lines = ["WEBVTT", ""]
+            for seg in segments:
+                start = _vtt_time(seg.start)
+                end = _vtt_time(seg.end)
+                lines.append(f"{start} --> {end}")
+                lines.append(seg.text.strip())
+                lines.append("")
+            return "\n".join(lines), 200, {"Content-Type": "text/vtt; charset=utf-8"}
+
+        else:
+            return jsonify({"error": f"Unknown format: {response_format}"}), 400
+
+    finally:
+        os.unlink(tmp_path)
+
+
+def _srt_time(seconds):
+    h = int(seconds // 3600)
+    m = int((seconds % 3600) // 60)
+    s = int(seconds % 60)
+    ms = int((seconds % 1) * 1000)
+    return f"{h:02d}:{m:02d}:{s:02d},{ms:03d}"
+
+
+def _vtt_time(seconds):
+    h = int(seconds // 3600)
+    m = int((seconds % 3600) // 60)
+    s = int(seconds % 60)
+    ms = int((seconds % 1) * 1000)
+    return f"{h:02d}:{m:02d}:{s:02d}.{ms:03d}"
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=PORT, debug=False, threaded=True)

--- a/scripts/whisper-api-faster/whisper_api.py
+++ b/scripts/whisper-api-faster/whisper_api.py
@@ -17,6 +17,7 @@ Configuration via environment variables:
 
 import os
 import tempfile
+import threading
 from pathlib import Path
 
 from flask import Flask, request, jsonify
@@ -32,6 +33,12 @@ COMPUTE_TYPE = os.environ.get("WHISPER_COMPUTE_TYPE", "float16")
 print(f"Loading Whisper {MODEL_SIZE} on {DEVICE} ({COMPUTE_TYPE})...", flush=True)
 model = WhisperModel(MODEL_SIZE, device=DEVICE, compute_type=COMPUTE_TYPE)
 print("Model ready", flush=True)
+
+# A single WhisperModel is not safe to drive from multiple threads at once
+# (Flask is started with threaded=True). Serialize all inference so two
+# concurrent requests can never decode through the same model simultaneously,
+# which would otherwise spike GPU memory / OOM or corrupt output.
+_MODEL_LOCK = threading.Lock()
 
 
 @app.route("/health", methods=["GET"])
@@ -64,20 +71,28 @@ def transcribe():
     prompt = request.form.get("prompt", "")
 
     suffix = Path(audio_file.filename).suffix if audio_file.filename else ".wav"
-    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
-        audio_file.save(tmp)
-        tmp_path = tmp.name
-
+    tmp_path = None
     try:
-        segments, info = model.transcribe(
-            tmp_path,
-            language=language,
-            temperature=temperature,
-            initial_prompt=prompt if prompt else None,
-            beam_size=5,
-            vad_filter=True,
-            word_timestamps=True,
-        )
+        # Assign the path BEFORE save() so a failed save still cleans up the
+        # file created by delete=False (and doesn't raise UnboundLocalError in
+        # the finally block, which would mask the original error).
+        with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+            tmp_path = tmp.name
+            audio_file.save(tmp)
+
+        with _MODEL_LOCK:
+            segments, info = model.transcribe(
+                tmp_path,
+                language=language,
+                temperature=temperature,
+                initial_prompt=prompt if prompt else None,
+                beam_size=5,
+                vad_filter=True,
+                word_timestamps=True,
+            )
+            # Force the lazy generator to completion while holding the lock —
+            # this is where the actual decode happens.
+            segments = list(segments)
 
         if response_format in ("json", "verbose_json"):
             text_parts = []
@@ -131,7 +146,8 @@ def transcribe():
             return jsonify({"error": f"Unknown format: {response_format}"}), 400
 
     finally:
-        os.unlink(tmp_path)
+        if tmp_path and os.path.exists(tmp_path):
+            os.unlink(tmp_path)
 
 
 def _srt_time(seconds):

--- a/scripts/whisper-api-faster/whisper_api.py
+++ b/scripts/whisper-api-faster/whisper_api.py
@@ -11,10 +11,13 @@ word timings), which MinusPod requires for precise ad-boundary detection.
 Configuration via environment variables:
   WHISPER_MODEL         (default: large-v3)
   WHISPER_PORT          (default: 8090)
+  WHISPER_HOST          (default: 0.0.0.0; set 127.0.0.1 to bind localhost only)
   WHISPER_DEVICE        (default: cuda)
   WHISPER_COMPUTE_TYPE  (default: float16; use int8 for CPU)
+  WHISPER_API_KEY       (optional: when set, require `Authorization: Bearer <key>`)
 """
 
+import hmac
 import os
 import tempfile
 import threading
@@ -27,8 +30,14 @@ app = Flask(__name__)
 
 MODEL_SIZE = os.environ.get("WHISPER_MODEL", "large-v3")
 PORT = int(os.environ.get("WHISPER_PORT", 8090))
+HOST = os.environ.get("WHISPER_HOST", "0.0.0.0")
 DEVICE = os.environ.get("WHISPER_DEVICE", "cuda")
 COMPUTE_TYPE = os.environ.get("WHISPER_COMPUTE_TYPE", "float16")
+# Optional bearer-token auth. Empty = open (trusted-network deployments keep
+# working unchanged); set WHISPER_API_KEY to require a matching token. The
+# service binds 0.0.0.0 by default, so set this whenever the port is reachable
+# beyond the host.
+API_KEY = os.environ.get("WHISPER_API_KEY", "")
 
 print(f"Loading Whisper {MODEL_SIZE} on {DEVICE} ({COMPUTE_TYPE})...", flush=True)
 model = WhisperModel(MODEL_SIZE, device=DEVICE, compute_type=COMPUTE_TYPE)
@@ -39,6 +48,22 @@ print("Model ready", flush=True)
 # concurrent requests can never decode through the same model simultaneously,
 # which would otherwise spike GPU memory / OOM or corrupt output.
 _MODEL_LOCK = threading.Lock()
+
+
+def _auth_error():
+    """When WHISPER_API_KEY is configured, require a matching Bearer token.
+    Returns a 401 response tuple on failure, or None when the request is
+    allowed. Uses a constant-time compare to avoid token-timing leaks."""
+    if not API_KEY:
+        return None
+    auth = request.headers.get("Authorization", "")
+    token = auth[len("Bearer "):] if auth.startswith("Bearer ") else ""
+    # Compare as bytes: hmac.compare_digest raises TypeError on a non-ASCII str,
+    # so a non-ASCII Authorization header would otherwise 500 (a DoS vector).
+    # encode('utf-8') makes the compare total over all inputs.
+    if not hmac.compare_digest(token.encode("utf-8"), API_KEY.encode("utf-8")):
+        return jsonify({"error": "Unauthorized"}), 401
+    return None
 
 
 @app.route("/health", methods=["GET"])
@@ -61,13 +86,20 @@ def transcribe():
     `verbose_json` is required by MinusPod and emits per-segment `words[]`
     timing alongside `segments[]` and top-level `text`.
     """
+    auth_err = _auth_error()
+    if auth_err:
+        return auth_err
+
     if "file" not in request.files:
         return jsonify({"error": "No file provided"}), 400
 
     audio_file = request.files["file"]
     language = request.form.get("language", None)
     response_format = request.form.get("response_format", "json")
-    temperature = float(request.form.get("temperature", 0.0))
+    try:
+        temperature = float(request.form.get("temperature", 0.0))
+    except (TypeError, ValueError):
+        return jsonify({"error": "temperature must be a number"}), 400
     prompt = request.form.get("prompt", "")
 
     suffix = Path(audio_file.filename).suffix if audio_file.filename else ".wav"
@@ -167,4 +199,4 @@ def _vtt_time(seconds):
 
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=PORT, debug=False, threaded=True)
+    app.run(host=HOST, port=PORT, debug=False, threaded=True)


### PR DESCRIPTION
Adds an optional standalone OpenAI-compatible transcription server backed by faster-whisper, for pointing MinusPod's `openai-api` whisper backend at a dedicated GPU host.

## What
- `scripts/whisper-api-faster/`: Flask app exposing `/v1/audio/transcriptions` (verbose_json with per-segment word timings), requirements, systemd unit, README.

## Hardening included
- **Concurrency:** a single shared `WhisperModel` is serialized under a lock — and the lock is held through `list(segments)` so the *actual* (lazy) decode is serialized, not just the call.
- **Temp files:** cleanup is safe on every failure path, including a failed upload save.
- **Auth:** optional bearer token via `WHISPER_API_KEY` (constant-time `hmac.compare_digest` over UTF-8 bytes); open by default so trusted-network deploys are unchanged. Configurable bind via `WHISPER_HOST`.
- **Input:** non-numeric `temperature` returns 400 instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)