### PR TITLE
fix(ui): theme-aware pattern dialogs + themed scrollbars

### DIFF
--- a/frontend/src/components/PatternExportDialog.tsx
+++ b/frontend/src/components/PatternExportDialog.tsx
@@ -164,7 +164,7 @@ function PatternExportDialogImpl({ patterns, onClose }: Omit<Props, 'open'>) {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" onClick={handleClose}>
       <div
-        className="w-full max-w-2xl max-h-[80vh] flex flex-col rounded-lg bg-white dark:bg-slate-900 shadow-xl"
+        className="w-full max-w-2xl max-h-[80vh] flex flex-col rounded-lg bg-card text-card-foreground border border-border shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="p-6 pb-3 border-b border-border">

--- a/frontend/src/components/PatternExportDialog.tsx
+++ b/frontend/src/components/PatternExportDialog.tsx
@@ -358,7 +358,7 @@ function PatternExportDialogImpl({ patterns, onClose }: Omit<Props, 'open'>) {
                     type="button"
                     onClick={downloadSelected}
                     disabled={effectiveSelection.size === 0}
-                    className="px-3 py-1.5 text-sm rounded bg-blue-600 text-white disabled:opacity-50"
+                    className="px-3 py-1.5 text-sm rounded bg-primary text-primary-foreground disabled:opacity-50"
                   >
                     Export {effectiveSelection.size} pattern{effectiveSelection.size === 1 ? '' : 's'}
                   </button>
@@ -367,7 +367,7 @@ function PatternExportDialogImpl({ patterns, onClose }: Omit<Props, 'open'>) {
                     type="button"
                     onClick={runPreview}
                     disabled={effectiveSelection.size === 0 || busy}
-                    className="px-3 py-1.5 text-sm rounded bg-blue-600 text-white disabled:opacity-50"
+                    className="px-3 py-1.5 text-sm rounded bg-primary text-primary-foreground disabled:opacity-50"
                   >
                     {busy ? 'Checking...' : 'Continue'}
                   </button>
@@ -437,7 +437,7 @@ function CommunityPreview({
           type="button"
           onClick={onDownload}
           disabled={ready_count === 0 || busy}
-          className="px-3 py-1.5 text-sm rounded bg-blue-600 text-white disabled:opacity-50"
+          className="px-3 py-1.5 text-sm rounded bg-primary text-primary-foreground disabled:opacity-50"
         >
           {busy ? 'Building bundle...' : `Download bundle (${ready_count})`}
         </button>
@@ -472,7 +472,7 @@ function CommunityDone({ filename, onClose }: { filename: string; onClose: () =>
         <button
           type="button"
           onClick={onClose}
-          className="px-3 py-1.5 text-sm rounded bg-blue-600 text-white"
+          className="px-3 py-1.5 text-sm rounded bg-primary text-primary-foreground"
         >
           Done
         </button>

--- a/frontend/src/components/PatternImportDialog.tsx
+++ b/frontend/src/components/PatternImportDialog.tsx
@@ -56,11 +56,11 @@ export function PatternImportDialog({ open, onClose, onComplete }: Props) {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" onClick={onClose}>
       <div
-        className="w-full max-w-md rounded-lg bg-white dark:bg-slate-900 p-6 shadow-xl"
+        className="w-full max-w-md rounded-lg bg-card text-card-foreground border border-border p-6 shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
         <h2 className="text-lg font-semibold mb-3">Import patterns</h2>
-        <p className="text-sm text-slate-500 mb-4">
+        <p className="text-sm text-muted-foreground mb-4">
           Upload a JSON file exported from MinusPod, or a single community-pattern JSON.
         </p>
 

--- a/frontend/src/components/PatternImportDialog.tsx
+++ b/frontend/src/components/PatternImportDialog.tsx
@@ -111,7 +111,7 @@ export function PatternImportDialog({ open, onClose, onComplete }: Props) {
             type="button"
             onClick={handleImport}
             disabled={busy}
-            className="px-3 py-1.5 text-sm rounded bg-blue-600 text-white disabled:opacity-50"
+            className="px-3 py-1.5 text-sm rounded bg-primary text-primary-foreground disabled:opacity-50"
           >
             {busy ? 'Importing…' : 'Import'}
           </button>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -61,30 +61,33 @@
   }
 }
 
-/* Themed scrollbars -- track follows the page background, thumb uses a
-   subtle border-toned grey so it reads on true-black (Pure Black) and every
-   other theme alike. The .no-scrollbar utility still wins where applied. */
-* {
-  scrollbar-width: thin;
-  scrollbar-color: hsl(var(--border)) hsl(var(--background));
-}
-::-webkit-scrollbar {
-  width: 10px;
-  height: 10px;
-}
-::-webkit-scrollbar-track {
-  background: hsl(var(--background));
-}
-::-webkit-scrollbar-thumb {
-  background-color: hsl(var(--border));
-  border-radius: 6px;
-  border: 2px solid hsl(var(--background));
-}
-::-webkit-scrollbar-thumb:hover {
-  background-color: hsl(var(--muted-foreground));
-}
-::-webkit-scrollbar-corner {
-  background: hsl(var(--background));
+/* Themed scrollbars: track follows the page background, thumb uses a subtle
+   border-toned grey so it reads on the true-black Obsidian theme and every
+   other theme alike. Kept in @layer base so the .no-scrollbar utility (in
+   @layer utilities) still overrides scrollbar-width where applied. */
+@layer base {
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: hsl(var(--border)) hsl(var(--background));
+  }
+  ::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+  ::-webkit-scrollbar-track {
+    background: hsl(var(--background));
+  }
+  ::-webkit-scrollbar-thumb {
+    background-color: hsl(var(--border));
+    border-radius: 6px;
+    border: 2px solid hsl(var(--background));
+  }
+  ::-webkit-scrollbar-thumb:hover {
+    background-color: hsl(var(--muted-foreground));
+  }
+  ::-webkit-scrollbar-corner {
+    background: hsl(var(--background));
+  }
 }
 
 /* Visual cue while the App.tsx dwell timer is running. */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -61,6 +61,32 @@
   }
 }
 
+/* Themed scrollbars -- track follows the page background, thumb uses a
+   subtle border-toned grey so it reads on true-black (Pure Black) and every
+   other theme alike. The .no-scrollbar utility still wins where applied. */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: hsl(var(--border)) hsl(var(--background));
+}
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+::-webkit-scrollbar-track {
+  background: hsl(var(--background));
+}
+::-webkit-scrollbar-thumb {
+  background-color: hsl(var(--border));
+  border-radius: 6px;
+  border: 2px solid hsl(var(--background));
+}
+::-webkit-scrollbar-thumb:hover {
+  background-color: hsl(var(--muted-foreground));
+}
+::-webkit-scrollbar-corner {
+  background: hsl(var(--background));
+}
+
 /* Visual cue while the App.tsx dwell timer is running. */
 .ptr--ptr.ptr--dwelling .ptr--icon {
   color: hsl(var(--primary));


### PR DESCRIPTION
Two small theme-correctness fixes, split out from the Obsidian theme PR so each stays focused.

## What
- **Pattern import/export dialogs** hardcoded `bg-white dark:bg-slate-900` and `text-slate-*`, so they rendered with wrong colors on any theme other than the default light/dark pair. Switched to theme tokens (`bg-card`, `text-card-foreground`, `border-border`, `text-muted-foreground`) so they follow the active theme.
- **Scrollbars**: added token-driven scrollbar styling so they match dark themes instead of falling back to the default light system scrollbar.

## Notes
- Token-driven, so they adapt to every theme (incl. the existing light/dark).
- Frontend production build passes (`npm run build` clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)