### PR TITLE
docs(changelog): track merged theme work under Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+Merged to main, not yet shipped in a tagged release. Folds into the next version bump.
+
+### Added
+
+- Obsidian theme (#385, by @SimpleHonors): a true-black OLED dark theme in the "Other" group with a cyan accent. Dark-only, like the other true-black themes, and tuned so the near-black background saves power on OLED panels.
+
+### Fixed
+
+- Pattern import/export dialogs now follow the active theme (#389, by @SimpleHonors). They had hardcoded `bg-white dark:bg-slate-900` containers and `text-slate-*` text, so they rendered with the wrong colors on any theme other than the default light/dark pair. They now use `bg-card`, `text-card-foreground`, `border-border`, and `text-muted-foreground`, and the action buttons moved off a hardcoded `bg-blue-600` to `bg-primary` so they pick up the theme color like the rest of the app.
+- Scrollbars now follow the active theme instead of falling back to the default light system scrollbar (#389). The rules sit in `@layer base` so the `.no-scrollbar` utility still hides scrollbars where applied; an earlier unlayered version overrode it and left a thin scrollbar in Firefox on elements meant to have none.
+
 ## [2.8.13] - 2026-06-15
 
 ### Changed


### PR DESCRIPTION
Adds an `[Unreleased]` section to CHANGELOG.md tracking the two theme PRs already merged to main, so they are recorded until the next version bump folds them into a tagged release.

- Obsidian true-black OLED theme (#385)
- Theme-aware pattern dialogs + themed scrollbars, including the maintainer follow-up fixes (scrollbar `@layer` scope, dialog buttons moved to `bg-primary`) (#389)

No code or version change; CHANGELOG only.