### PR TITLE
fix(detection): flatten nested ad-break envelopes from the LLM

### DIFF
--- a/src/ad_detector/prompts.py
+++ b/src/ad_detector/prompts.py
@@ -157,6 +157,24 @@ def get_static_system_prompt() -> str:
     )
 
 
+def _flatten_ad_envelopes(ads: List) -> List:
+    """Flatten ad-break envelopes the model intermittently emits.
+
+    Instead of a flat list of ad objects, the LLM sometimes wraps each break in
+    an envelope like ``{"ad_break_index": N, "ads": [ {ad}, {ad} ]}``. Such an
+    envelope has no top-level start/end, so the per-ad parser would discard the
+    whole break. Expand any dict whose ``ads`` value is a list into its inner ad
+    objects; pass everything else through unchanged.
+    """
+    flat = []
+    for item in ads:
+        if isinstance(item, dict) and isinstance(item.get('ads'), list):
+            flat.extend(inner for inner in item['ads'] if isinstance(inner, dict))
+        else:
+            flat.append(item)
+    return flat
+
+
 def parse_ads_from_response(response_text: str, slug: str = None,
                               episode_id: str = None,
                               sponsor_service=None) -> List[Dict]:
@@ -238,6 +256,10 @@ def parse_ads_from_response(response_text: str, slug: str = None,
         if ads is None or not isinstance(ads, list):
             logger.warning(f"[{slug}:{episode_id}] No valid JSON array found in response")
             return []
+
+        # Flatten any {"ad_break_index": N, "ads": [...]} envelopes the model
+        # sometimes emits, so the per-ad parser below sees the inner ad objects.
+        ads = _flatten_ad_envelopes(ads)
 
         # Validate and normalize ads - handle various field name patterns
         valid_ads = []

--- a/tests/unit/test_ad_detector_module_level.py
+++ b/tests/unit/test_ad_detector_module_level.py
@@ -45,6 +45,40 @@ def test_parse_ads_from_response_module_level_basic():
     assert ads[0]['end'] == 160.0
 
 
+def test_parse_ads_from_response_flattens_ad_break_envelope():
+    # The model intermittently wraps ads in {"ad_break_index": N, "ads": [...]}
+    # instead of emitting them flat (observed in prod 2026-06-18). The envelope
+    # has no top-level start/end, so without flattening the whole break is
+    # discarded. The inner ads must still be extracted.
+    response = json.dumps([
+        {"ad_break_index": 1, "ads": [
+            {"sponsor": "Arm & Hammer", "start_timestamp": 1714.0,
+             "end_timestamp": 1749.5, "confidence": 0.95},
+            {"sponsor": "Capital One", "start_timestamp": 1749.9,
+             "end_timestamp": 1776.0, "confidence": 0.95},
+        ]},
+        {"ad_break_index": 2, "ads": [
+            {"sponsor": "Babbel", "start_timestamp": 2307.3,
+             "end_timestamp": 2341.6, "confidence": 0.95},
+        ]},
+    ])
+    ads = parse_ads_from_response(response)
+    assert len(ads) == 3
+    assert sorted(round(a['start'], 1) for a in ads) == [1714.0, 1749.9, 2307.3]
+
+
+def test_parse_ads_from_response_mixed_flat_and_enveloped():
+    # A response mixing a flat ad and an envelope should yield both.
+    response = json.dumps([
+        {"sponsor": "BetterHelp", "start": 855.5, "end": 887.0, "confidence": 0.9},
+        {"ad_break_index": 1, "ads": [
+            {"sponsor": "Capital One", "start": 1749.9, "end": 1776.0, "confidence": 0.95},
+        ]},
+    ])
+    ads = parse_ads_from_response(response)
+    assert sorted(round(a['start'], 1) for a in ads) == [855.5, 1749.9]
+
+
 @pytest.mark.parametrize('bad_sponsor', [
     # The exact line we caught in prod 2026-05-20:
     'Inferred from ~26 second gap in transcript with no spoken content provided',


### PR DESCRIPTION
## Problem
The ad-detection parser drops ads when the model returns them wrapped in a per-break envelope:
```json
[{"ad_break_index": 1, "ads": [ {ad}, {ad} ]}]
```
The envelope has no top-level `start`/`end`, so `parse_ads_from_response` discarded the whole break. Seen in prod on a 2026-06-18 reprocess (`Window 5 found 0 ads`, `fields=['ad_break_index', 'ads']`). Overlapping windows recovered the ads that time, but a break only seen in one window would be missed.

## Fix
`_flatten_ad_envelopes` expands any dict whose `ads` value is a list into its inner ad objects before the per-ad parse. Scoped to `parse_ads_from_response` (detection + verification); the shared `extract_json_ads_array` used by the reviewer is untouched.

## Tests
Added two cases (enveloped, and mixed flat+enveloped). Full suite: 1770 passed.