### PR TITLE
ci: tolerate missing validation-report artifact in comment workflow

### DIFF
--- a/.github/workflows/comment-community-patterns.yml
+++ b/.github/workflows/comment-community-patterns.yml
@@ -23,6 +23,11 @@ jobs:
     steps:
       - name: Download validation report
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        # The validate workflow skips the artifact upload when a PR touches no
+        # real pattern files (e.g. an index.json-only change), so the artifact
+        # can legitimately be absent. Tolerate that; the Post comment step below
+        # already no-ops when the report files are missing.
+        continue-on-error: true
         with:
           name: pattern-validation-report
           path: /tmp/pattern-validation


### PR DESCRIPTION
## What

Add `continue-on-error: true` to the Download validation report step in the "Comment Community Pattern Results" workflow.

## Why

The validate workflow (`validate-community-patterns.yml`) intentionally excludes `index.json` and gates the artifact upload on `steps.changed.outputs.files != ''`. When a PR's only `patterns/community/` change is `index.json` (a regenerated thin manifest, as in #402), no real pattern files are validated, so no `pattern-validation-report` artifact is uploaded. The comment workflow then failed hard trying to download a non-existent artifact ([failing run](https://github.com/ttlequals0/MinusPod/actions/runs/27892735506)).

This is the first time that path was hit: index.json normally changes via the regenerate-manifest action's direct push to main, and real pattern PRs always include `<sponsor>-<uuid>.json` files.

## Fix

The download step now soft-fails. The Post comment step right after it already no-ops when the report files are missing (`if (!fs.existsSync(...)) return`), so the run goes green with "nothing to post" instead of a red X. Real pattern submissions are unaffected.

## Scope

CI-only (`.github/` is dockerignored). No app code, no image, no version bump.
