### PR TITLE
docs: recommend a stereo replace.mp3 (custom-sound channel note)

### DIFF
--- a/assets/README.md
+++ b/assets/README.md
@@ -3,3 +3,12 @@
 Place your `replace.mp3` file here. This should be a 1-second beep/tone audio file that will replace advertisement segments in podcasts.
 
 The file should be named exactly: `replace.mp3`
+
+## Channel layout
+
+Use a stereo (2-channel) file. MinusPod keeps each podcast's own channel layout
+in the output, except when a replacement lands at the very start of an episode
+(a pre-roll ad): there the spliced output takes the replacement's channel count
+for that episode. So a mono `replace.mp3` can downmix a stereo show to mono,
+while a stereo file is always safe (a mono show is adapted with no quality loss).
+The bundled default is already stereo; this only matters if you supply your own.


### PR DESCRIPTION
## Summary

Adds a "Channel layout" note to `assets/README.md` for anyone swapping in a custom `replace.mp3`.

Why: the cut/splice ffmpeg `concat` does not force a channel count, so the output normally keeps the podcast's own layout. The one exception is a pre-roll ad, where the replacement is the first concat segment and the output takes the replacement's channel count for that episode. A mono custom sound would then downmix a stereo show to mono. The bundled default `replace.mp3` is already stereo, so this only affects custom sounds.

Verified with ffmpeg locally: output channel count follows the first concat segment (content normally, the replacement on a pre-roll); mismatch does not error, it adapts.

## Version

No code change (docs only) -- no version bump, no image rebuild.

## Test plan

- [x] Confirmed default `assets/replace.mp3` is stereo (ffprobe: 2 channels)
- [x] Confirmed `concat` output follows the first segment's channel count (mono/stereo permutations)