### PR TITLE
benchmark docs: fix stale report.py reference

### DIFF
--- a/benchmarks/llm/CONTRIBUTING.md
+++ b/benchmarks/llm/CONTRIBUTING.md
@@ -69,7 +69,7 @@ uv run pytest tests/ -q
 
 All tests must pass. A schema-version bump on `calls.jsonl` or `episode_results.jsonl` requires a maintainer review thread and a migration path for existing data (see `benchmark migrate-raw` for the v1 -> v2 precedent). The current schema is v2.
 
-For changes to `report.py`, charts, or the metric glossary: the bar is clarity for a deep-technical-but-not-ML-research audience, not just correctness. Reviewers will read the rendered Markdown, not just the diff.
+For changes to the report package (`src/benchmark/report/`), charts, or the metric glossary: the bar is clarity for a deep-technical-but-not-ML-research audience, not just correctness. Reviewers will read the rendered Markdown, not just the diff.
 
 ## What's in the repo vs what your PR should include
 

--- a/benchmarks/llm/README.md
+++ b/benchmarks/llm/README.md
@@ -21,7 +21,7 @@ benchmarks/llm/
     archive/                 # explicit snapshots: results/archive/<date>/
 ```
 
-Raw response bodies live in one JSONL shard per model (`results/raw/responses/<model>.jsonl`, lines of `{call_id, body}`), so the file count stays flat as the corpus grows. Prompts are not stored at all: they reconstruct deterministically from the corpus, and `benchmark show-prompt <call_id>` proves fidelity by recomputing the `prompt_hash` recorded at call time. `benchmark show-response <call_id>` prints a single raw response body.
+Raw response bodies live in one JSONL shard per model (`results/raw/responses/<model>.jsonl`, lines of `{call_id, body}`), so the file count stays flat as the corpus grows. Prompts are not stored at all: they reconstruct deterministically from the corpus, and `benchmark show-prompt <call_id>` verifies the result against the `prompt_hash` recorded at call time. `benchmark show-response <call_id>` prints a single raw response body.
 
 ## Setup
 


### PR DESCRIPTION
Two follow-ups to #498:

- CONTRIBUTING.md still pointed reviewers at `report.py`, which is now the `src/benchmark/report/` package.
- README.md described `show-prompt` as proving fidelity; it verifies the rebuilt prompt against the recorded `prompt_hash`, so say that instead.