### PR TITLE
Accept singular "ad" JSON key from local LLM responses

### DIFF
--- a/src/utils/llm_response.py
+++ b/src/utils/llm_response.py
@@ -90,7 +90,9 @@ def extract_json_ads_array(
         if isinstance(parsed, dict):
             if 'window' in parsed and isinstance(parsed['window'], dict):
                 window = parsed['window']
-                for key in ['ads_detected', 'ads', 'advertisement_segments',
+                # Include singular "ad" — local models (e.g. qwen2.5 via Ollama)
+                # often return {"ad": [...]} instead of {"ads": [...]}.
+                for key in ['ads_detected', 'ads', 'ad', 'advertisement_segments',
                             'ads_and_sponsorships', 'segments']:
                     if key in window and isinstance(window[key], list):
                         ads = window[key]
@@ -98,7 +100,7 @@ def extract_json_ads_array(
                             ads = [s for s in ads
                                    if isinstance(s, dict) and s.get('type') == 'advertisement']
                         return ads, f"json_object_window_{key}"
-            ad_keys = ['ads', 'ads_detected', 'advertisement_segments', 'ads_and_sponsorships']
+            ad_keys = ['ads', 'ad', 'ads_detected', 'advertisement_segments', 'ads_and_sponsorships']
             for key in ad_keys:
                 if key in parsed and isinstance(parsed[key], list):
                     return parsed[key], f"json_object_{key}_key"

--- a/tests/unit/test_llm_response.py
+++ b/tests/unit/test_llm_response.py
@@ -245,3 +245,14 @@ def test_salvage_recovers_array_wrapped_truncation():
     assert ads[0]["start"] == 1320.4
     assert ads[0]["end"] == 1514.02
     assert ads[0]["confidence"] == 0.92
+
+def test_extract_json_ads_array_accepts_singular_ad_key():
+    """Local Ollama models often return {"ad": [...]} instead of {"ads": [...]}."""
+    from utils.llm_response import extract_json_ads_array
+
+    ads, method = extract_json_ads_array(
+        '{"ad":[{"start":964.0,"end":1015.0,"sponsor":"Mr. Doodle"}]}'
+    )
+    assert ads == [{"start": 964.0, "end": 1015.0, "sponsor": "Mr. Doodle"}]
+    assert method == "json_object_ad_key"
+


### PR DESCRIPTION
## Summary
- Local Ollama models (e.g. `qwen2.5:14b`) often return `{"ad":[...]}` instead of `{"ads":[...]}`.
- `extract_json_ads_array` already aliases several wrapper keys but missed the singular form, so real detections were counted as zero ads (`json_object_no_ads`).
- Add `"ad"` to both the top-level and nested `window` key lists, plus a unit test.

## Test plan
- [x] All 30 tests in `tests/unit/test_llm_response.py` pass against the patched module in the MinusPod 2.68.0 container
- [x] Live parser smoke: `extract_json_ads_array('{"ad":[{"start":964.0,"end":1015.0,"sponsor":"Mr. Doodle"}]}')` → `json_object_ad_key`
- [x] Live episode reprocess: the same singular-`"ad"` Window 2 response changed from `found 0 ads` to `found 2 ads`; candidates survived parsing into the validation stage