### PR TITLE
Defer ad_detector DB import, pin brace-expansion and postcss

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4007,9 +4007,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6803,9 +6803,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,7 +32,9 @@
     "minimatch": ">=3.1.3",
     "picomatch": ">=2.3.2",
     "esbuild": ">=0.27.0",
-    "@babel/core": "^7.29.6"
+    "@babel/core": "^7.29.6",
+    "brace-expansion": ">=5.0.9",
+    "postcss": ">=8.5.23"
   },
   "devDependencies": {
     "@babel/core": "^7.29.6",

--- a/src/ad_detector/__init__.py
+++ b/src/ad_detector/__init__.py
@@ -63,7 +63,6 @@ from config import (
 from ad_detector.cue_boundary_snap import _cue_role
 from ad_detector.cue_pair_ads import synthesize_ads_from_cue_pairs
 from ad_detector.keep_content import CONTENT_SYSTEM_PROMPT, invert_content_to_ads
-from database.settings import registry_get_default
 from llm_capabilities import PASS_AD_DETECTION_1, PASS_AD_DETECTION_2, supports_json_schema
 from sponsor_service import SponsorService
 from utils.constants import (
@@ -1676,6 +1675,8 @@ class AdDetector:
                     f"[{slug}:{episode_id}] Cue fusion extraction failed: {e}")
                 cue_marks, pair_spans = [], []
             corroborating_spans.extend(pair_spans)
+            # Deferred so create_windows imports without the DB stack.
+            from database.settings import registry_get_default
             # Thresholds read at detection time so settings changes apply on
             # the next run without a restart; registry defaults when the
             # detector has no DB (test-only construction).


### PR DESCRIPTION
## Problem

`ad_detector/__init__.py` imported `registry_get_default` from `database.settings` at module scope, so importing `create_windows` pulled in `database.settings` -> `secrets_crypto` -> `cryptography`. Any consumer without the DB stack installed could not import the package at all.

The LLM benchmark is one such consumer. Its CLI failed on every command with `ModuleNotFoundError: No module named 'cryptography'`. `benchmarks/llm/README.md` documents that these imports were deferred in 2.0.28 for this reason, so this is a regression against a documented contract.

## Change

Move the import to its only use site, inside `AdDetector.process_transcript`.

## Why this is safe

- `registry_get_default` has exactly two call sites, both in the same block.
- Resolution moves from module load to first call, and `sys.modules` caches it.
- The import sits behind `if dai_differential:` and outside both `for` loops in that function, so it runs at most once per episode.
- No version bump, because nothing user-visible changes and a bump would cut a release with no content.

## Testing

- Full suite: 5029 passed
- `ruff check src/ tests/`: clean
- `from ad_detector import create_windows` succeeds without `cryptography` installed
- Benchmark CLI starts

## npm audit advisories

`npm audit --audit-level=high` gates CI and started failing on main when GHSA-rgw5-rvv9-x895 was published against `brace-expansion` 4.0.0-5.0.8, which arrives through `eslint` -> `minimatch`. A moderate `postcss` advisory arrives through `vite`.

Both go into the existing `overrides` block, which already pins seven transitive packages for the same reason. Neither ships to users, since `eslint` is dev-only and `postcss` is build-time.

Unrelated to the import change above, folded in to get CI green in one pass.

### Frontend testing

- `npm audit --audit-level=high`: 0 vulnerabilities
- `npx tsc --noEmit`: clean
- `npm run lint`: clean
- `npm run build`: succeeds
- `npm run test`: 42 files, 446 passed