### PR TITLE
Widen the benchmark's native-JSON-mode rejection match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Alongside the standard sections, a "Breaking" section marks changes
 that require operator action; these are surfaced at the top of stable
 release notes.
 
+## [Unreleased]
+
+### Fixed
+
+- LLM benchmark: a provider that rejects native JSON mode with wording other
+  than `response_format` no longer fails the call outright. Novita reports
+  `does not support feature: structured-outputs`, which missed the existing
+  fallback and failed every request for
+  `deepseek/deepseek-r1-distill-llama-70b`, its only OpenRouter provider. The
+  match now also covers that phrasing, so those models fall back to the
+  prompt-injection path and report as `prompt-inject` in the JSON mode column.
+  Benchmark tooling only, no runtime change; rolls into the next release.
+
 ## [2.85.2] - 2026-08-03
 
 ### Added

--- a/benchmarks/llm/src/benchmark/llm.py
+++ b/benchmarks/llm/src/benchmark/llm.py
@@ -144,6 +144,15 @@ async def _call_anthropic(
     )
 
 
+_JSON_MODE_REJECTIONS = ("response_format", "structured-outputs", "structured outputs")
+
+
+def _rejects_json_mode(err: str) -> bool:
+    """True when a 400 means the provider will not accept native JSON mode."""
+    low = err.lower()
+    return any(k in low for k in _JSON_MODE_REJECTIONS)
+
+
 async def _call_openai_compatible(
     *,
     provider: ProviderConfig,
@@ -195,7 +204,9 @@ async def _call_openai_compatible(
         raise LLMTransientError(str(e)) from e
     except APIStatusError as e:
         status = getattr(e, "status_code", 0)
-        if status == 400 and "response_format" in str(e).lower() and json_format_used == "native":
+        # Providers word the rejection differently: OpenAI says `response_format`,
+        # Novita says "does not support feature: structured-outputs".
+        if status == 400 and json_format_used == "native" and _rejects_json_mode(str(e)):
             kwargs.pop("response_format", None)
             try:
                 msg = await client.chat.completions.create(**kwargs)


### PR DESCRIPTION
## Problem

`_call_openai_compatible` falls back to prompt-injected JSON when a provider rejects `response_format` with a 400. The match tested for the literal string `response_format`, which is OpenAI's wording.

Novita words it differently:

```
400 INVALID_REQUEST_BODY
model: deepseek/deepseek-r1-distill-llama-70b does not support feature: structured-outputs
```

So the fallback missed and the call failed. That took out `deepseek/deepseek-r1-distill-llama-70b` completely. 855 of 855 calls failed in the 2026-08 sweep. Novita is its only OpenRouter provider and does not list structured outputs among its supported parameters, so no route accepts native JSON mode.

## Change

Extract the match into `_rejects_json_mode()` and cover `structured-outputs` and `structured outputs` alongside `response_format`. Affected models now take the prompt-injection path, which is how a third of the roster already runs, and report as `prompt-inject` in the report's JSON mode column.

## Testing

- 7 matcher cases, covering all three phrasings plus credit, rate-limit, moderation, and auth messages that must not match
- Benchmark suite: 189 passed
- `ruff check` on the changed file: clean
- End-to-end against the live provider: a real call to `deepseek/deepseek-r1-distill-llama-70b` now returns `[1,2,3]` with `json_format_used=prompt_injection` and `stop_reason=stop`, where it previously failed with the 400

No version bump. Benchmark tooling only, no runtime change. Noted under Unreleased in the changelog so it rolls into the next release.