### PR TITLE
Make the cross-model agreement chart legible at 75 models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,14 @@ release notes.
 - `docs/llm-providers.md` model recommendations refreshed from the 2026-08
   sweep, including a note on provider-side content moderation.
 
+### Fixed
+
+- Cross-model agreement chart was unreadable at 75 models: every integer
+  got an x tick so the labels ran together, and the two-line bar labels
+  overlapped each other. Ticks now thin out to about 25 across any
+  model count, and bar labels rotate to a single line once the chart passes
+  30 bars.
+
 ### Security
 
 - cryptography 49.0.0 to 50.0.0 (PYSEC-2026-3552), transitive fast-uri

--- a/benchmarks/llm/results/report.md
+++ b/benchmarks/llm/results/report.md
@@ -3835,7 +3835,7 @@ The `initial_prompt` carries a sponsor vocabulary so Whisper produces consistent
 
 ## Run Metadata
 
-- Report generated: 2026-08-07T21:15:39Z
+- Report generated: 2026-08-08T18:52:53Z
 - Unique work units (current state, last-write-wins after retries): 64125
 - Raw rows in calls.jsonl: 70072 (5947 superseded by later retries; kept for audit)
 - Successful: 63986

--- a/benchmarks/llm/results/report_assets/agreement.svg
+++ b/benchmarks/llm/results/report_assets/agreement.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="784.243437pt" height="388.480156pt" viewBox="0 0 784.243437 388.480156" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="922.483437pt" height="388.480156pt" viewBox="0 0 922.483437 388.480156" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -21,8 +21,8 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 388.480156 
-L 784.243437 388.480156 
-L 784.243437 0 
+L 922.483437 388.480156 
+L 922.483437 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
@@ -30,619 +30,619 @@ z
   <g id="axes_1">
    <g id="patch_2">
     <path d="M 40.925781 352.279375 
-L 777.043437 352.279375 
-L 777.043437 35.862363 
+L 915.283438 352.279375 
+L 915.283438 35.862363 
 L 40.925781 35.862363 
 z
 " style="fill: #ffffff"/>
    </g>
    <g id="patch_3">
-    <path d="M 74.385675 352.279375 
-L 81.448449 352.279375 
-L 81.448449 352.279375 
-L 74.385675 352.279375 
+    <path d="M 47.738958 352.279375 
+L 56.823193 352.279375 
+L 56.823193 352.279375 
+L 47.738958 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 83.214143 352.279375 
-L 90.276917 352.279375 
-L 90.276917 352.279375 
-L 83.214143 352.279375 
+    <path d="M 59.094252 352.279375 
+L 68.178487 352.279375 
+L 68.178487 352.279375 
+L 59.094252 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 92.042611 352.279375 
-L 99.105385 352.279375 
-L 99.105385 352.279375 
-L 92.042611 352.279375 
+    <path d="M 70.449546 352.279375 
+L 79.533782 352.279375 
+L 79.533782 352.279375 
+L 70.449546 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 100.871079 352.279375 
-L 107.933853 352.279375 
-L 107.933853 352.279375 
-L 100.871079 352.279375 
+    <path d="M 81.804841 352.279375 
+L 90.889076 352.279375 
+L 90.889076 352.279375 
+L 81.804841 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 109.699546 352.279375 
-L 116.762321 352.279375 
-L 116.762321 352.279375 
-L 109.699546 352.279375 
+    <path d="M 93.160135 352.279375 
+L 102.24437 352.279375 
+L 102.24437 352.279375 
+L 93.160135 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 118.528014 352.279375 
-L 125.590789 352.279375 
-L 125.590789 329.350606 
-L 118.528014 329.350606 
+    <path d="M 104.515429 352.279375 
+L 113.599664 352.279375 
+L 113.599664 334.094489 
+L 104.515429 334.094489 
 z
-" clip-path="url(#p68304d9980)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 127.356482 352.279375 
-L 134.419257 352.279375 
-L 134.419257 352.279375 
-L 127.356482 352.279375 
+    <path d="M 115.870723 352.279375 
+L 124.954959 352.279375 
+L 124.954959 352.279375 
+L 115.870723 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 136.18495 352.279375 
-L 143.247725 352.279375 
-L 143.247725 168.849223 
-L 136.18495 168.849223 
+    <path d="M 127.226017 352.279375 
+L 136.310253 352.279375 
+L 136.310253 206.800289 
+L 127.226017 206.800289 
 z
-" clip-path="url(#p68304d9980)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 145.013418 352.279375 
-L 152.076193 352.279375 
-L 152.076193 260.564299 
-L 145.013418 260.564299 
+    <path d="M 138.581312 352.279375 
+L 147.665547 352.279375 
+L 147.665547 279.539832 
+L 138.581312 279.539832 
 z
-" clip-path="url(#p68304d9980)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 153.841886 352.279375 
-L 160.90466 352.279375 
-L 160.90466 214.706761 
-L 153.841886 214.706761 
+    <path d="M 149.936606 352.279375 
+L 159.020841 352.279375 
+L 159.020841 243.170061 
+L 149.936606 243.170061 
 z
-" clip-path="url(#p68304d9980)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 162.670354 352.279375 
-L 169.733128 352.279375 
-L 169.733128 77.134147 
-L 162.670354 77.134147 
+    <path d="M 161.2919 352.279375 
+L 170.376136 352.279375 
+L 170.376136 134.060746 
+L 161.2919 134.060746 
 z
-" clip-path="url(#p68304d9980)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 171.498822 352.279375 
-L 178.561596 352.279375 
-L 178.561596 191.777992 
-L 171.498822 191.777992 
+    <path d="M 172.647194 352.279375 
+L 181.73143 352.279375 
+L 181.73143 224.985175 
+L 172.647194 224.985175 
 z
-" clip-path="url(#p68304d9980)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 180.32729 352.279375 
-L 187.390064 352.279375 
-L 187.390064 260.564299 
-L 180.32729 260.564299 
+    <path d="M 184.002489 352.279375 
+L 193.086724 352.279375 
+L 193.086724 279.539832 
+L 184.002489 279.539832 
 z
-" clip-path="url(#p68304d9980)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 189.155758 352.279375 
-L 196.218532 352.279375 
-L 196.218532 145.920454 
-L 189.155758 145.920454 
+    <path d="M 195.357783 352.279375 
+L 204.442018 352.279375 
+L 204.442018 188.615403 
+L 195.357783 188.615403 
 z
-" clip-path="url(#p68304d9980)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 197.984226 352.279375 
-L 205.047 352.279375 
-L 205.047 260.564299 
-L 197.984226 260.564299 
+    <path d="M 206.713077 352.279375 
+L 215.797313 352.279375 
+L 215.797313 279.539832 
+L 206.713077 279.539832 
 z
-" clip-path="url(#p68304d9980)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 206.812694 352.279375 
-L 213.875468 352.279375 
-L 213.875468 214.706761 
-L 206.812694 214.706761 
+    <path d="M 218.068371 352.279375 
+L 227.152607 352.279375 
+L 227.152607 243.170061 
+L 218.068371 243.170061 
 z
-" clip-path="url(#p68304d9980)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 215.641162 352.279375 
-L 222.703936 352.279375 
-L 222.703936 122.991685 
-L 215.641162 122.991685 
+    <path d="M 229.423666 352.279375 
+L 238.507901 352.279375 
+L 238.507901 170.430518 
+L 229.423666 170.430518 
 z
-" clip-path="url(#p68304d9980)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 224.46963 352.279375 
-L 231.532404 352.279375 
-L 231.532404 260.564299 
-L 224.46963 260.564299 
+    <path d="M 240.77896 352.279375 
+L 249.863195 352.279375 
+L 249.863195 279.539832 
+L 240.77896 279.539832 
 z
-" clip-path="url(#p68304d9980)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 233.298098 352.279375 
-L 240.360872 352.279375 
-L 240.360872 214.706761 
-L 233.298098 214.706761 
+    <path d="M 252.134254 352.279375 
+L 261.218489 352.279375 
+L 261.218489 243.170061 
+L 252.134254 243.170061 
 z
-" clip-path="url(#p68304d9980)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #d62728; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 242.126565 352.279375 
-L 249.18934 352.279375 
-L 249.18934 352.279375 
-L 242.126565 352.279375 
+    <path d="M 263.489548 352.279375 
+L 272.573784 352.279375 
+L 272.573784 352.279375 
+L 263.489548 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 250.955033 352.279375 
-L 258.017808 352.279375 
-L 258.017808 306.421837 
-L 250.955033 306.421837 
+    <path d="M 274.844843 352.279375 
+L 283.929078 352.279375 
+L 283.929078 315.909604 
+L 274.844843 315.909604 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 259.783501 352.279375 
-L 266.846276 352.279375 
-L 266.846276 352.279375 
-L 259.783501 352.279375 
+    <path d="M 286.200137 352.279375 
+L 295.284372 352.279375 
+L 295.284372 352.279375 
+L 286.200137 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 268.611969 352.279375 
-L 275.674744 352.279375 
-L 275.674744 260.564299 
-L 268.611969 260.564299 
+    <path d="M 297.555431 352.279375 
+L 306.639666 352.279375 
+L 306.639666 279.539832 
+L 297.555431 279.539832 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 277.440437 352.279375 
-L 284.503212 352.279375 
-L 284.503212 329.350606 
-L 277.440437 329.350606 
+    <path d="M 308.910725 352.279375 
+L 317.994961 352.279375 
+L 317.994961 334.094489 
+L 308.910725 334.094489 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 286.268905 352.279375 
-L 293.331679 352.279375 
-L 293.331679 329.350606 
-L 286.268905 329.350606 
+    <path d="M 320.266019 352.279375 
+L 329.350255 352.279375 
+L 329.350255 334.094489 
+L 320.266019 334.094489 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 295.097373 352.279375 
-L 302.160147 352.279375 
-L 302.160147 329.350606 
-L 295.097373 329.350606 
+    <path d="M 331.621314 352.279375 
+L 340.705549 352.279375 
+L 340.705549 334.094489 
+L 331.621314 334.094489 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_29">
-    <path d="M 303.925841 352.279375 
-L 310.988615 352.279375 
-L 310.988615 329.350606 
-L 303.925841 329.350606 
+    <path d="M 342.976608 352.279375 
+L 352.060843 352.279375 
+L 352.060843 334.094489 
+L 342.976608 334.094489 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_30">
-    <path d="M 312.754309 352.279375 
-L 319.817083 352.279375 
-L 319.817083 329.350606 
-L 312.754309 329.350606 
+    <path d="M 354.331902 352.279375 
+L 363.416138 352.279375 
+L 363.416138 334.094489 
+L 354.331902 334.094489 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_31">
-    <path d="M 321.582777 352.279375 
-L 328.645551 352.279375 
-L 328.645551 352.279375 
-L 321.582777 352.279375 
+    <path d="M 365.687196 352.279375 
+L 374.771432 352.279375 
+L 374.771432 352.279375 
+L 365.687196 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_32">
-    <path d="M 330.411245 352.279375 
-L 337.474019 352.279375 
-L 337.474019 329.350606 
-L 330.411245 329.350606 
+    <path d="M 377.042491 352.279375 
+L 386.126726 352.279375 
+L 386.126726 334.094489 
+L 377.042491 334.094489 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_33">
-    <path d="M 339.239713 352.279375 
-L 346.302487 352.279375 
-L 346.302487 352.279375 
-L 339.239713 352.279375 
+    <path d="M 388.397785 352.279375 
+L 397.48202 352.279375 
+L 397.48202 352.279375 
+L 388.397785 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_34">
-    <path d="M 348.068181 352.279375 
-L 355.130955 352.279375 
-L 355.130955 352.279375 
-L 348.068181 352.279375 
+    <path d="M 399.753079 352.279375 
+L 408.837315 352.279375 
+L 408.837315 352.279375 
+L 399.753079 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_35">
-    <path d="M 356.896649 352.279375 
-L 363.959423 352.279375 
-L 363.959423 329.350606 
-L 356.896649 329.350606 
+    <path d="M 411.108373 352.279375 
+L 420.192609 352.279375 
+L 420.192609 334.094489 
+L 411.108373 334.094489 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_36">
-    <path d="M 365.725117 352.279375 
-L 372.787891 352.279375 
-L 372.787891 352.279375 
-L 365.725117 352.279375 
+    <path d="M 422.463668 352.279375 
+L 431.547903 352.279375 
+L 431.547903 352.279375 
+L 422.463668 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_37">
-    <path d="M 374.553584 352.279375 
-L 381.616359 352.279375 
-L 381.616359 352.279375 
-L 374.553584 352.279375 
+    <path d="M 433.818962 352.279375 
+L 442.903197 352.279375 
+L 442.903197 352.279375 
+L 433.818962 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_38">
-    <path d="M 383.382052 352.279375 
-L 390.444827 352.279375 
-L 390.444827 329.350606 
-L 383.382052 329.350606 
+    <path d="M 445.174256 352.279375 
+L 454.258491 352.279375 
+L 454.258491 334.094489 
+L 445.174256 334.094489 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_39">
-    <path d="M 392.21052 352.279375 
-L 399.273295 352.279375 
-L 399.273295 352.279375 
-L 392.21052 352.279375 
+    <path d="M 456.52955 352.279375 
+L 465.613786 352.279375 
+L 465.613786 352.279375 
+L 456.52955 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_40">
-    <path d="M 401.038988 352.279375 
-L 408.101763 352.279375 
-L 408.101763 352.279375 
-L 401.038988 352.279375 
+    <path d="M 467.884845 352.279375 
+L 476.96908 352.279375 
+L 476.96908 352.279375 
+L 467.884845 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_41">
-    <path d="M 409.867456 352.279375 
-L 416.930231 352.279375 
-L 416.930231 352.279375 
-L 409.867456 352.279375 
+    <path d="M 479.240139 352.279375 
+L 488.324374 352.279375 
+L 488.324374 352.279375 
+L 479.240139 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_42">
-    <path d="M 418.695924 352.279375 
-L 425.758698 352.279375 
-L 425.758698 329.350606 
-L 418.695924 329.350606 
+    <path d="M 490.595433 352.279375 
+L 499.679668 352.279375 
+L 499.679668 334.094489 
+L 490.595433 334.094489 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_43">
-    <path d="M 427.524392 352.279375 
-L 434.587166 352.279375 
-L 434.587166 329.350606 
-L 427.524392 329.350606 
+    <path d="M 501.950727 352.279375 
+L 511.034963 352.279375 
+L 511.034963 334.094489 
+L 501.950727 334.094489 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_44">
-    <path d="M 436.35286 352.279375 
-L 443.415634 352.279375 
-L 443.415634 352.279375 
-L 436.35286 352.279375 
+    <path d="M 513.306022 352.279375 
+L 522.390257 352.279375 
+L 522.390257 352.279375 
+L 513.306022 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_45">
-    <path d="M 445.181328 352.279375 
-L 452.244102 352.279375 
-L 452.244102 352.279375 
-L 445.181328 352.279375 
+    <path d="M 524.661316 352.279375 
+L 533.745551 352.279375 
+L 533.745551 352.279375 
+L 524.661316 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_46">
-    <path d="M 454.009796 352.279375 
-L 461.07257 352.279375 
-L 461.07257 352.279375 
-L 454.009796 352.279375 
+    <path d="M 536.01661 352.279375 
+L 545.100845 352.279375 
+L 545.100845 352.279375 
+L 536.01661 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_47">
-    <path d="M 462.838264 352.279375 
-L 469.901038 352.279375 
-L 469.901038 329.350606 
-L 462.838264 329.350606 
+    <path d="M 547.371904 352.279375 
+L 556.45614 352.279375 
+L 556.45614 334.094489 
+L 547.371904 334.094489 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_48">
-    <path d="M 471.666732 352.279375 
-L 478.729506 352.279375 
-L 478.729506 352.279375 
-L 471.666732 352.279375 
+    <path d="M 558.727198 352.279375 
+L 567.811434 352.279375 
+L 567.811434 352.279375 
+L 558.727198 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_49">
-    <path d="M 480.4952 352.279375 
-L 487.557974 352.279375 
-L 487.557974 306.421837 
-L 480.4952 306.421837 
+    <path d="M 570.082493 352.279375 
+L 579.166728 352.279375 
+L 579.166728 315.909604 
+L 570.082493 315.909604 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_50">
-    <path d="M 489.323668 352.279375 
-L 496.386442 352.279375 
-L 496.386442 352.279375 
-L 489.323668 352.279375 
+    <path d="M 581.437787 352.279375 
+L 590.522022 352.279375 
+L 590.522022 352.279375 
+L 581.437787 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_51">
-    <path d="M 498.152135 352.279375 
-L 505.21491 352.279375 
-L 505.21491 352.279375 
-L 498.152135 352.279375 
+    <path d="M 592.793081 352.279375 
+L 601.877317 352.279375 
+L 601.877317 352.279375 
+L 592.793081 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_52">
-    <path d="M 506.980603 352.279375 
-L 514.043378 352.279375 
-L 514.043378 352.279375 
-L 506.980603 352.279375 
+    <path d="M 604.148375 352.279375 
+L 613.232611 352.279375 
+L 613.232611 352.279375 
+L 604.148375 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_53">
-    <path d="M 515.809071 352.279375 
-L 522.871846 352.279375 
-L 522.871846 352.279375 
-L 515.809071 352.279375 
+    <path d="M 615.50367 352.279375 
+L 624.587905 352.279375 
+L 624.587905 352.279375 
+L 615.50367 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_54">
-    <path d="M 524.637539 352.279375 
-L 531.700314 352.279375 
-L 531.700314 329.350606 
-L 524.637539 329.350606 
+    <path d="M 626.858964 352.279375 
+L 635.943199 352.279375 
+L 635.943199 334.094489 
+L 626.858964 334.094489 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_55">
-    <path d="M 533.466007 352.279375 
-L 540.528782 352.279375 
-L 540.528782 329.350606 
-L 533.466007 329.350606 
+    <path d="M 638.214258 352.279375 
+L 647.298494 352.279375 
+L 647.298494 334.094489 
+L 638.214258 334.094489 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_56">
-    <path d="M 542.294475 352.279375 
-L 549.35725 352.279375 
-L 549.35725 329.350606 
-L 542.294475 329.350606 
+    <path d="M 649.569552 352.279375 
+L 658.653788 352.279375 
+L 658.653788 334.094489 
+L 649.569552 334.094489 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_57">
-    <path d="M 551.122943 352.279375 
-L 558.185717 352.279375 
-L 558.185717 352.279375 
-L 551.122943 352.279375 
+    <path d="M 660.924847 352.279375 
+L 670.009082 352.279375 
+L 670.009082 352.279375 
+L 660.924847 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_58">
-    <path d="M 559.951411 352.279375 
-L 567.014185 352.279375 
-L 567.014185 352.279375 
-L 559.951411 352.279375 
+    <path d="M 672.280141 352.279375 
+L 681.364376 352.279375 
+L 681.364376 352.279375 
+L 672.280141 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_59">
-    <path d="M 568.779879 352.279375 
-L 575.842653 352.279375 
-L 575.842653 352.279375 
-L 568.779879 352.279375 
+    <path d="M 683.635435 352.279375 
+L 692.71967 352.279375 
+L 692.71967 352.279375 
+L 683.635435 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #f0a020; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_60">
-    <path d="M 577.608347 352.279375 
-L 584.671121 352.279375 
-L 584.671121 352.279375 
-L 577.608347 352.279375 
+    <path d="M 694.990729 352.279375 
+L 704.074965 352.279375 
+L 704.074965 352.279375 
+L 694.990729 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_61">
-    <path d="M 586.436815 352.279375 
-L 593.499589 352.279375 
-L 593.499589 352.279375 
-L 586.436815 352.279375 
+    <path d="M 706.346024 352.279375 
+L 715.430259 352.279375 
+L 715.430259 352.279375 
+L 706.346024 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_62">
-    <path d="M 595.265283 352.279375 
-L 602.328057 352.279375 
-L 602.328057 329.350606 
-L 595.265283 329.350606 
+    <path d="M 717.701318 352.279375 
+L 726.785553 352.279375 
+L 726.785553 334.094489 
+L 717.701318 334.094489 
 z
-" clip-path="url(#p68304d9980)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_63">
-    <path d="M 604.093751 352.279375 
-L 611.156525 352.279375 
-L 611.156525 352.279375 
-L 604.093751 352.279375 
+    <path d="M 729.056612 352.279375 
+L 738.140847 352.279375 
+L 738.140847 352.279375 
+L 729.056612 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_64">
-    <path d="M 612.922219 352.279375 
-L 619.984993 352.279375 
-L 619.984993 306.421837 
-L 612.922219 306.421837 
+    <path d="M 740.411906 352.279375 
+L 749.496142 352.279375 
+L 749.496142 315.909604 
+L 740.411906 315.909604 
 z
-" clip-path="url(#p68304d9980)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_65">
-    <path d="M 621.750687 352.279375 
-L 628.813461 352.279375 
-L 628.813461 306.421837 
-L 621.750687 306.421837 
+    <path d="M 751.7672 352.279375 
+L 760.851436 352.279375 
+L 760.851436 315.909604 
+L 751.7672 315.909604 
 z
-" clip-path="url(#p68304d9980)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_66">
-    <path d="M 630.579154 352.279375 
-L 637.641929 352.279375 
-L 637.641929 260.564299 
-L 630.579154 260.564299 
+    <path d="M 763.122495 352.279375 
+L 772.20673 352.279375 
+L 772.20673 279.539832 
+L 763.122495 279.539832 
 z
-" clip-path="url(#p68304d9980)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_67">
-    <path d="M 639.407622 352.279375 
-L 646.470397 352.279375 
-L 646.470397 237.63553 
-L 639.407622 237.63553 
+    <path d="M 774.477789 352.279375 
+L 783.562024 352.279375 
+L 783.562024 261.354946 
+L 774.477789 261.354946 
 z
-" clip-path="url(#p68304d9980)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_68">
-    <path d="M 648.23609 352.279375 
-L 655.298865 352.279375 
-L 655.298865 237.63553 
-L 648.23609 237.63553 
+    <path d="M 785.833083 352.279375 
+L 794.917319 352.279375 
+L 794.917319 261.354946 
+L 785.833083 261.354946 
 z
-" clip-path="url(#p68304d9980)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_69">
-    <path d="M 657.064558 352.279375 
-L 664.127333 352.279375 
-L 664.127333 100.062916 
-L 657.064558 100.062916 
+    <path d="M 797.188377 352.279375 
+L 806.272613 352.279375 
+L 806.272613 152.245632 
+L 797.188377 152.245632 
 z
-" clip-path="url(#p68304d9980)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_70">
-    <path d="M 665.893026 352.279375 
-L 672.955801 352.279375 
-L 672.955801 145.920454 
-L 665.893026 145.920454 
+    <path d="M 808.543672 352.279375 
+L 817.627907 352.279375 
+L 817.627907 188.615403 
+L 808.543672 188.615403 
 z
-" clip-path="url(#p68304d9980)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_71">
-    <path d="M 674.721494 352.279375 
-L 681.784269 352.279375 
-L 681.784269 122.991685 
-L 674.721494 122.991685 
+    <path d="M 819.898966 352.279375 
+L 828.983201 352.279375 
+L 828.983201 170.430518 
+L 819.898966 170.430518 
 z
-" clip-path="url(#p68304d9980)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_72">
-    <path d="M 683.549962 352.279375 
-L 690.612736 352.279375 
-L 690.612736 191.777992 
-L 683.549962 191.777992 
+    <path d="M 831.25426 352.279375 
+L 840.338496 352.279375 
+L 840.338496 224.985175 
+L 831.25426 224.985175 
 z
-" clip-path="url(#p68304d9980)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_73">
-    <path d="M 692.37843 352.279375 
-L 699.441204 352.279375 
-L 699.441204 191.777992 
-L 692.37843 191.777992 
+    <path d="M 842.609554 352.279375 
+L 851.69379 352.279375 
+L 851.69379 224.985175 
+L 842.609554 224.985175 
 z
-" clip-path="url(#p68304d9980)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_74">
-    <path d="M 701.206898 352.279375 
-L 708.269672 352.279375 
-L 708.269672 260.564299 
-L 701.206898 260.564299 
+    <path d="M 853.964849 352.279375 
+L 863.049084 352.279375 
+L 863.049084 279.539832 
+L 853.964849 279.539832 
 z
-" clip-path="url(#p68304d9980)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_75">
-    <path d="M 710.035366 352.279375 
-L 717.09814 352.279375 
-L 717.09814 329.350606 
-L 710.035366 329.350606 
+    <path d="M 865.320143 352.279375 
+L 874.404378 352.279375 
+L 874.404378 334.094489 
+L 865.320143 334.094489 
 z
-" clip-path="url(#p68304d9980)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_76">
-    <path d="M 718.863834 352.279375 
-L 725.926608 352.279375 
-L 725.926608 352.279375 
-L 718.863834 352.279375 
+    <path d="M 876.675437 352.279375 
+L 885.759672 352.279375 
+L 885.759672 352.279375 
+L 876.675437 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_77">
-    <path d="M 727.692302 352.279375 
-L 734.755076 352.279375 
-L 734.755076 352.279375 
-L 727.692302 352.279375 
+    <path d="M 888.030731 352.279375 
+L 897.114967 352.279375 
+L 897.114967 352.279375 
+L 888.030731 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="patch_78">
-    <path d="M 736.52077 352.279375 
-L 743.583544 352.279375 
-L 743.583544 352.279375 
-L 736.52077 352.279375 
+    <path d="M 899.386026 352.279375 
+L 908.470261 352.279375 
+L 908.470261 352.279375 
+L 899.386026 352.279375 
 z
-" clip-path="url(#p68304d9980)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
+" clip-path="url(#pddabd15c8a)" style="fill: #2ca02c; stroke: #000000; stroke-width: 0.4; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
@@ -653,12 +653,12 @@ L 0 3.5
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m55e06c651d" x="77.917062" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m55e06c651d" x="52.281075" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- 0 -->
-      <g transform="translate(75.372062 365.3575) scale(0.08 -0.08)">
+      <g transform="translate(49.736075 365.3575) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-13" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -689,127 +689,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m55e06c651d" x="86.74553" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m55e06c651d" x="97.702252" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
-      <!-- 1 -->
-      <g transform="translate(84.20053 365.3575) scale(0.08 -0.08)">
-       <defs>
-        <path id="DejaVuSans-14" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-14"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_3">
-     <g id="line2d_3">
-      <g>
-       <use xlink:href="#m55e06c651d" x="95.573998" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_3">
-      <!-- 2 -->
-      <g transform="translate(93.028998 365.3575) scale(0.08 -0.08)">
-       <defs>
-        <path id="DejaVuSans-15" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-15"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_4">
-     <g id="line2d_4">
-      <g>
-       <use xlink:href="#m55e06c651d" x="104.402466" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_4">
-      <!-- 3 -->
-      <g transform="translate(101.857466 365.3575) scale(0.08 -0.08)">
-       <defs>
-        <path id="DejaVuSans-16" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-16"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_5">
-     <g id="line2d_5">
-      <g>
-       <use xlink:href="#m55e06c651d" x="113.230934" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_5">
       <!-- 4 -->
-      <g transform="translate(110.685934 365.3575) scale(0.08 -0.08)">
+      <g transform="translate(95.157252 365.3575) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-17" d="M 2419 4116 
 L 825 1625 
@@ -835,125 +720,15 @@ z
       </g>
      </g>
     </g>
-    <g id="xtick_6">
-     <g id="line2d_6">
+    <g id="xtick_3">
+     <g id="line2d_3">
       <g>
-       <use xlink:href="#m55e06c651d" x="122.059402" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m55e06c651d" x="143.123429" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_6">
-      <!-- 5 -->
-      <g transform="translate(119.514402 365.3575) scale(0.08 -0.08)">
-       <defs>
-        <path id="DejaVuSans-18" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-18"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_7">
-     <g id="line2d_7">
-      <g>
-       <use xlink:href="#m55e06c651d" x="130.887869" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_7">
-      <!-- 6 -->
-      <g transform="translate(128.342869 365.3575) scale(0.08 -0.08)">
-       <defs>
-        <path id="DejaVuSans-19" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-19"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_8">
-     <g id="line2d_8">
-      <g>
-       <use xlink:href="#m55e06c651d" x="139.716337" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_8">
-      <!-- 7 -->
-      <g transform="translate(137.171337 365.3575) scale(0.08 -0.08)">
-       <defs>
-        <path id="DejaVuSans-1a" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-1a"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_9">
-     <g id="line2d_9">
-      <g>
-       <use xlink:href="#m55e06c651d" x="148.544805" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_9">
+     <g id="text_3">
       <!-- 8 -->
-      <g transform="translate(145.999805 365.3575) scale(0.08 -0.08)">
+      <g transform="translate(140.578429 365.3575) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-1b" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -999,61 +774,220 @@ z
       </g>
      </g>
     </g>
-    <g id="xtick_10">
-     <g id="line2d_10">
+    <g id="xtick_4">
+     <g id="line2d_4">
       <g>
-       <use xlink:href="#m55e06c651d" x="157.373273" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m55e06c651d" x="188.544606" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_10">
-      <!-- 9 -->
-      <g transform="translate(154.828273 365.3575) scale(0.08 -0.08)">
+     <g id="text_4">
+      <!-- 12 -->
+      <g transform="translate(183.454606 365.3575) scale(0.08 -0.08)">
        <defs>
-        <path id="DejaVuSans-1c" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
+        <path id="DejaVuSans-14" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
 z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-15" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
 z
 " transform="scale(0.015625)"/>
        </defs>
-       <use xlink:href="#DejaVuSans-1c"/>
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m55e06c651d" x="233.965783" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 16 -->
+      <g transform="translate(228.875783 365.3575) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-19" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-19" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m55e06c651d" x="279.38696" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 20 -->
+      <g transform="translate(274.29696 365.3575) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-15"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m55e06c651d" x="324.808137" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 24 -->
+      <g transform="translate(319.718137 365.3575) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-15"/>
+       <use xlink:href="#DejaVuSans-17" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m55e06c651d" x="370.229314" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 28 -->
+      <g transform="translate(365.139314 365.3575) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-15"/>
+       <use xlink:href="#DejaVuSans-1b" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m55e06c651d" x="415.650491" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 32 -->
+      <g transform="translate(410.560491 365.3575) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-16" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-16"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m55e06c651d" x="461.071668" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 36 -->
+      <g transform="translate(455.981668 365.3575) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-16"/>
+       <use xlink:href="#DejaVuSans-19" transform="translate(63.625 0)"/>
       </g>
      </g>
     </g>
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m55e06c651d" x="166.201741" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m55e06c651d" x="506.492845" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
-      <!-- 10 -->
-      <g transform="translate(161.111741 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-14"/>
+      <!-- 40 -->
+      <g transform="translate(501.402845 365.3575) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-17"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
       </g>
      </g>
@@ -1061,916 +995,171 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m55e06c651d" x="175.030209" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m55e06c651d" x="551.914022" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
-      <!-- 11 -->
-      <g transform="translate(169.940209 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-14"/>
-       <use xlink:href="#DejaVuSans-14" transform="translate(63.625 0)"/>
+      <!-- 44 -->
+      <g transform="translate(546.824022 365.3575) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-17"/>
+       <use xlink:href="#DejaVuSans-17" transform="translate(63.625 0)"/>
       </g>
      </g>
     </g>
     <g id="xtick_13">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m55e06c651d" x="183.858677" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m55e06c651d" x="597.335199" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
-      <!-- 12 -->
-      <g transform="translate(178.768677 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-14"/>
-       <use xlink:href="#DejaVuSans-15" transform="translate(63.625 0)"/>
+      <!-- 48 -->
+      <g transform="translate(592.245199 365.3575) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-17"/>
+       <use xlink:href="#DejaVuSans-1b" transform="translate(63.625 0)"/>
       </g>
      </g>
     </g>
     <g id="xtick_14">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m55e06c651d" x="192.687145" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m55e06c651d" x="642.756376" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
-      <!-- 13 -->
-      <g transform="translate(187.597145 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-14"/>
-       <use xlink:href="#DejaVuSans-16" transform="translate(63.625 0)"/>
+      <!-- 52 -->
+      <g transform="translate(637.666376 365.3575) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-18" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-18"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(63.625 0)"/>
       </g>
      </g>
     </g>
     <g id="xtick_15">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m55e06c651d" x="201.515613" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m55e06c651d" x="688.177553" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
-      <!-- 14 -->
-      <g transform="translate(196.425613 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-14"/>
-       <use xlink:href="#DejaVuSans-17" transform="translate(63.625 0)"/>
+      <!-- 56 -->
+      <g transform="translate(683.087553 365.3575) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-18"/>
+       <use xlink:href="#DejaVuSans-19" transform="translate(63.625 0)"/>
       </g>
      </g>
     </g>
     <g id="xtick_16">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m55e06c651d" x="210.344081" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m55e06c651d" x="733.59873" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
-      <!-- 15 -->
-      <g transform="translate(205.254081 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-14"/>
-       <use xlink:href="#DejaVuSans-18" transform="translate(63.625 0)"/>
+      <!-- 60 -->
+      <g transform="translate(728.50873 365.3575) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-19"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
       </g>
      </g>
     </g>
     <g id="xtick_17">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m55e06c651d" x="219.172549" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m55e06c651d" x="779.019907" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
-      <!-- 16 -->
-      <g transform="translate(214.082549 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-14"/>
-       <use xlink:href="#DejaVuSans-19" transform="translate(63.625 0)"/>
+      <!-- 64 -->
+      <g transform="translate(773.929907 365.3575) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-19"/>
+       <use xlink:href="#DejaVuSans-17" transform="translate(63.625 0)"/>
       </g>
      </g>
     </g>
     <g id="xtick_18">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m55e06c651d" x="228.001017" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m55e06c651d" x="824.441084" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
-      <!-- 17 -->
-      <g transform="translate(222.911017 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-14"/>
-       <use xlink:href="#DejaVuSans-1a" transform="translate(63.625 0)"/>
+      <!-- 68 -->
+      <g transform="translate(819.351084 365.3575) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-19"/>
+       <use xlink:href="#DejaVuSans-1b" transform="translate(63.625 0)"/>
       </g>
      </g>
     </g>
     <g id="xtick_19">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m55e06c651d" x="236.829485" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m55e06c651d" x="869.862261" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
-      <!-- 18 -->
-      <g transform="translate(231.739485 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-14"/>
-       <use xlink:href="#DejaVuSans-1b" transform="translate(63.625 0)"/>
+      <!-- 72 -->
+      <g transform="translate(864.772261 365.3575) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-1a" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-1a"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(63.625 0)"/>
       </g>
      </g>
     </g>
     <g id="xtick_20">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m55e06c651d" x="245.657953" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m55e06c651d" x="903.928143" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
-      <!-- 19 -->
-      <g transform="translate(240.567953 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-14"/>
-       <use xlink:href="#DejaVuSans-1c" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_21">
-     <g id="line2d_21">
-      <g>
-       <use xlink:href="#m55e06c651d" x="254.486421" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_21">
-      <!-- 20 -->
-      <g transform="translate(249.396421 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-15"/>
-       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_22">
-     <g id="line2d_22">
-      <g>
-       <use xlink:href="#m55e06c651d" x="263.314888" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_22">
-      <!-- 21 -->
-      <g transform="translate(258.224888 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-15"/>
-       <use xlink:href="#DejaVuSans-14" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_23">
-     <g id="line2d_23">
-      <g>
-       <use xlink:href="#m55e06c651d" x="272.143356" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_23">
-      <!-- 22 -->
-      <g transform="translate(267.053356 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-15"/>
-       <use xlink:href="#DejaVuSans-15" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_24">
-     <g id="line2d_24">
-      <g>
-       <use xlink:href="#m55e06c651d" x="280.971824" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_24">
-      <!-- 23 -->
-      <g transform="translate(275.881824 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-15"/>
-       <use xlink:href="#DejaVuSans-16" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_25">
-     <g id="line2d_25">
-      <g>
-       <use xlink:href="#m55e06c651d" x="289.800292" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_25">
-      <!-- 24 -->
-      <g transform="translate(284.710292 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-15"/>
-       <use xlink:href="#DejaVuSans-17" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_26">
-     <g id="line2d_26">
-      <g>
-       <use xlink:href="#m55e06c651d" x="298.62876" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_26">
-      <!-- 25 -->
-      <g transform="translate(293.53876 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-15"/>
-       <use xlink:href="#DejaVuSans-18" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_27">
-     <g id="line2d_27">
-      <g>
-       <use xlink:href="#m55e06c651d" x="307.457228" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_27">
-      <!-- 26 -->
-      <g transform="translate(302.367228 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-15"/>
-       <use xlink:href="#DejaVuSans-19" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_28">
-     <g id="line2d_28">
-      <g>
-       <use xlink:href="#m55e06c651d" x="316.285696" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_28">
-      <!-- 27 -->
-      <g transform="translate(311.195696 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-15"/>
-       <use xlink:href="#DejaVuSans-1a" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_29">
-     <g id="line2d_29">
-      <g>
-       <use xlink:href="#m55e06c651d" x="325.114164" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_29">
-      <!-- 28 -->
-      <g transform="translate(320.024164 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-15"/>
-       <use xlink:href="#DejaVuSans-1b" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_30">
-     <g id="line2d_30">
-      <g>
-       <use xlink:href="#m55e06c651d" x="333.942632" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_30">
-      <!-- 29 -->
-      <g transform="translate(328.852632 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-15"/>
-       <use xlink:href="#DejaVuSans-1c" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_31">
-     <g id="line2d_31">
-      <g>
-       <use xlink:href="#m55e06c651d" x="342.7711" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_31">
-      <!-- 30 -->
-      <g transform="translate(337.6811 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-16"/>
-       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_32">
-     <g id="line2d_32">
-      <g>
-       <use xlink:href="#m55e06c651d" x="351.599568" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_32">
-      <!-- 31 -->
-      <g transform="translate(346.509568 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-16"/>
-       <use xlink:href="#DejaVuSans-14" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_33">
-     <g id="line2d_33">
-      <g>
-       <use xlink:href="#m55e06c651d" x="360.428036" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_33">
-      <!-- 32 -->
-      <g transform="translate(355.338036 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-16"/>
-       <use xlink:href="#DejaVuSans-15" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_34">
-     <g id="line2d_34">
-      <g>
-       <use xlink:href="#m55e06c651d" x="369.256504" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_34">
-      <!-- 33 -->
-      <g transform="translate(364.166504 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-16"/>
-       <use xlink:href="#DejaVuSans-16" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_35">
-     <g id="line2d_35">
-      <g>
-       <use xlink:href="#m55e06c651d" x="378.084972" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_35">
-      <!-- 34 -->
-      <g transform="translate(372.994972 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-16"/>
-       <use xlink:href="#DejaVuSans-17" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_36">
-     <g id="line2d_36">
-      <g>
-       <use xlink:href="#m55e06c651d" x="386.91344" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_36">
-      <!-- 35 -->
-      <g transform="translate(381.82344 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-16"/>
-       <use xlink:href="#DejaVuSans-18" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_37">
-     <g id="line2d_37">
-      <g>
-       <use xlink:href="#m55e06c651d" x="395.741907" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_37">
-      <!-- 36 -->
-      <g transform="translate(390.651907 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-16"/>
-       <use xlink:href="#DejaVuSans-19" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_38">
-     <g id="line2d_38">
-      <g>
-       <use xlink:href="#m55e06c651d" x="404.570375" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_38">
-      <!-- 37 -->
-      <g transform="translate(399.480375 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-16"/>
-       <use xlink:href="#DejaVuSans-1a" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_39">
-     <g id="line2d_39">
-      <g>
-       <use xlink:href="#m55e06c651d" x="413.398843" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_39">
-      <!-- 38 -->
-      <g transform="translate(408.308843 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-16"/>
-       <use xlink:href="#DejaVuSans-1b" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_40">
-     <g id="line2d_40">
-      <g>
-       <use xlink:href="#m55e06c651d" x="422.227311" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_40">
-      <!-- 39 -->
-      <g transform="translate(417.137311 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-16"/>
-       <use xlink:href="#DejaVuSans-1c" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_41">
-     <g id="line2d_41">
-      <g>
-       <use xlink:href="#m55e06c651d" x="431.055779" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_41">
-      <!-- 40 -->
-      <g transform="translate(425.965779 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-17"/>
-       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_42">
-     <g id="line2d_42">
-      <g>
-       <use xlink:href="#m55e06c651d" x="439.884247" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_42">
-      <!-- 41 -->
-      <g transform="translate(434.794247 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-17"/>
-       <use xlink:href="#DejaVuSans-14" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_43">
-     <g id="line2d_43">
-      <g>
-       <use xlink:href="#m55e06c651d" x="448.712715" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_43">
-      <!-- 42 -->
-      <g transform="translate(443.622715 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-17"/>
-       <use xlink:href="#DejaVuSans-15" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_44">
-     <g id="line2d_44">
-      <g>
-       <use xlink:href="#m55e06c651d" x="457.541183" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_44">
-      <!-- 43 -->
-      <g transform="translate(452.451183 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-17"/>
-       <use xlink:href="#DejaVuSans-16" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_45">
-     <g id="line2d_45">
-      <g>
-       <use xlink:href="#m55e06c651d" x="466.369651" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_45">
-      <!-- 44 -->
-      <g transform="translate(461.279651 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-17"/>
-       <use xlink:href="#DejaVuSans-17" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_46">
-     <g id="line2d_46">
-      <g>
-       <use xlink:href="#m55e06c651d" x="475.198119" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_46">
-      <!-- 45 -->
-      <g transform="translate(470.108119 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-17"/>
-       <use xlink:href="#DejaVuSans-18" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_47">
-     <g id="line2d_47">
-      <g>
-       <use xlink:href="#m55e06c651d" x="484.026587" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_47">
-      <!-- 46 -->
-      <g transform="translate(478.936587 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-17"/>
-       <use xlink:href="#DejaVuSans-19" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_48">
-     <g id="line2d_48">
-      <g>
-       <use xlink:href="#m55e06c651d" x="492.855055" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_48">
-      <!-- 47 -->
-      <g transform="translate(487.765055 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-17"/>
-       <use xlink:href="#DejaVuSans-1a" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_49">
-     <g id="line2d_49">
-      <g>
-       <use xlink:href="#m55e06c651d" x="501.683523" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_49">
-      <!-- 48 -->
-      <g transform="translate(496.593523 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-17"/>
-       <use xlink:href="#DejaVuSans-1b" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_50">
-     <g id="line2d_50">
-      <g>
-       <use xlink:href="#m55e06c651d" x="510.511991" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_50">
-      <!-- 49 -->
-      <g transform="translate(505.421991 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-17"/>
-       <use xlink:href="#DejaVuSans-1c" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_51">
-     <g id="line2d_51">
-      <g>
-       <use xlink:href="#m55e06c651d" x="519.340459" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_51">
-      <!-- 50 -->
-      <g transform="translate(514.250459 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-18"/>
-       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_52">
-     <g id="line2d_52">
-      <g>
-       <use xlink:href="#m55e06c651d" x="528.168926" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_52">
-      <!-- 51 -->
-      <g transform="translate(523.078926 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-18"/>
-       <use xlink:href="#DejaVuSans-14" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_53">
-     <g id="line2d_53">
-      <g>
-       <use xlink:href="#m55e06c651d" x="536.997394" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_53">
-      <!-- 52 -->
-      <g transform="translate(531.907394 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-18"/>
-       <use xlink:href="#DejaVuSans-15" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_54">
-     <g id="line2d_54">
-      <g>
-       <use xlink:href="#m55e06c651d" x="545.825862" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_54">
-      <!-- 53 -->
-      <g transform="translate(540.735862 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-18"/>
-       <use xlink:href="#DejaVuSans-16" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_55">
-     <g id="line2d_55">
-      <g>
-       <use xlink:href="#m55e06c651d" x="554.65433" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_55">
-      <!-- 54 -->
-      <g transform="translate(549.56433 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-18"/>
-       <use xlink:href="#DejaVuSans-17" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_56">
-     <g id="line2d_56">
-      <g>
-       <use xlink:href="#m55e06c651d" x="563.482798" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_56">
-      <!-- 55 -->
-      <g transform="translate(558.392798 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-18"/>
-       <use xlink:href="#DejaVuSans-18" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_57">
-     <g id="line2d_57">
-      <g>
-       <use xlink:href="#m55e06c651d" x="572.311266" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_57">
-      <!-- 56 -->
-      <g transform="translate(567.221266 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-18"/>
-       <use xlink:href="#DejaVuSans-19" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_58">
-     <g id="line2d_58">
-      <g>
-       <use xlink:href="#m55e06c651d" x="581.139734" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_58">
-      <!-- 57 -->
-      <g transform="translate(576.049734 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-18"/>
-       <use xlink:href="#DejaVuSans-1a" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_59">
-     <g id="line2d_59">
-      <g>
-       <use xlink:href="#m55e06c651d" x="589.968202" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_59">
-      <!-- 58 -->
-      <g transform="translate(584.878202 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-18"/>
-       <use xlink:href="#DejaVuSans-1b" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_60">
-     <g id="line2d_60">
-      <g>
-       <use xlink:href="#m55e06c651d" x="598.79667" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_60">
-      <!-- 59 -->
-      <g transform="translate(593.70667 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-18"/>
-       <use xlink:href="#DejaVuSans-1c" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_61">
-     <g id="line2d_61">
-      <g>
-       <use xlink:href="#m55e06c651d" x="607.625138" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_61">
-      <!-- 60 -->
-      <g transform="translate(602.535138 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-19"/>
-       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_62">
-     <g id="line2d_62">
-      <g>
-       <use xlink:href="#m55e06c651d" x="616.453606" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_62">
-      <!-- 61 -->
-      <g transform="translate(611.363606 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-19"/>
-       <use xlink:href="#DejaVuSans-14" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_63">
-     <g id="line2d_63">
-      <g>
-       <use xlink:href="#m55e06c651d" x="625.282074" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_63">
-      <!-- 62 -->
-      <g transform="translate(620.192074 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-19"/>
-       <use xlink:href="#DejaVuSans-15" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_64">
-     <g id="line2d_64">
-      <g>
-       <use xlink:href="#m55e06c651d" x="634.110542" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_64">
-      <!-- 63 -->
-      <g transform="translate(629.020542 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-19"/>
-       <use xlink:href="#DejaVuSans-16" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_65">
-     <g id="line2d_65">
-      <g>
-       <use xlink:href="#m55e06c651d" x="642.93901" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_65">
-      <!-- 64 -->
-      <g transform="translate(637.84901 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-19"/>
-       <use xlink:href="#DejaVuSans-17" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_66">
-     <g id="line2d_66">
-      <g>
-       <use xlink:href="#m55e06c651d" x="651.767478" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_66">
-      <!-- 65 -->
-      <g transform="translate(646.677478 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-19"/>
-       <use xlink:href="#DejaVuSans-18" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_67">
-     <g id="line2d_67">
-      <g>
-       <use xlink:href="#m55e06c651d" x="660.595945" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_67">
-      <!-- 66 -->
-      <g transform="translate(655.505945 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-19"/>
-       <use xlink:href="#DejaVuSans-19" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_68">
-     <g id="line2d_68">
-      <g>
-       <use xlink:href="#m55e06c651d" x="669.424413" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_68">
-      <!-- 67 -->
-      <g transform="translate(664.334413 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-19"/>
-       <use xlink:href="#DejaVuSans-1a" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_69">
-     <g id="line2d_69">
-      <g>
-       <use xlink:href="#m55e06c651d" x="678.252881" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_69">
-      <!-- 68 -->
-      <g transform="translate(673.162881 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-19"/>
-       <use xlink:href="#DejaVuSans-1b" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_70">
-     <g id="line2d_70">
-      <g>
-       <use xlink:href="#m55e06c651d" x="687.081349" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_70">
-      <!-- 69 -->
-      <g transform="translate(681.991349 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-19"/>
-       <use xlink:href="#DejaVuSans-1c" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_71">
-     <g id="line2d_71">
-      <g>
-       <use xlink:href="#m55e06c651d" x="695.909817" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_71">
-      <!-- 70 -->
-      <g transform="translate(690.819817 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-1a"/>
-       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_72">
-     <g id="line2d_72">
-      <g>
-       <use xlink:href="#m55e06c651d" x="704.738285" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_72">
-      <!-- 71 -->
-      <g transform="translate(699.648285 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-1a"/>
-       <use xlink:href="#DejaVuSans-14" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_73">
-     <g id="line2d_73">
-      <g>
-       <use xlink:href="#m55e06c651d" x="713.566753" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_73">
-      <!-- 72 -->
-      <g transform="translate(708.476753 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-1a"/>
-       <use xlink:href="#DejaVuSans-15" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_74">
-     <g id="line2d_74">
-      <g>
-       <use xlink:href="#m55e06c651d" x="722.395221" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_74">
-      <!-- 73 -->
-      <g transform="translate(717.305221 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-1a"/>
-       <use xlink:href="#DejaVuSans-16" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_75">
-     <g id="line2d_75">
-      <g>
-       <use xlink:href="#m55e06c651d" x="731.223689" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_75">
-      <!-- 74 -->
-      <g transform="translate(726.133689 365.3575) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-1a"/>
-       <use xlink:href="#DejaVuSans-17" transform="translate(63.625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_76">
-     <g id="line2d_76">
-      <g>
-       <use xlink:href="#m55e06c651d" x="740.052157" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_76">
       <!-- 75 -->
-      <g transform="translate(734.962157 365.3575) scale(0.08 -0.08)">
+      <g transform="translate(898.838143 365.3575) scale(0.08 -0.08)">
        <use xlink:href="#DejaVuSans-1a"/>
        <use xlink:href="#DejaVuSans-18" transform="translate(63.625 0)"/>
       </g>
      </g>
     </g>
-    <g id="text_77">
+    <g id="text_21">
      <!-- Models predicting at least one ad (out of 75) -->
-     <g transform="translate(297.519766 378.877812) scale(0.1 -0.1)">
+     <g transform="translate(366.639766 378.877812) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-30" d="M 628 4666 
 L 1569 4666 
@@ -2403,12 +1592,12 @@ z
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
-     <g id="line2d_77">
+     <g id="line2d_21">
       <path d="M 40.925781 352.279375 
-L 777.043437 352.279375 
-" clip-path="url(#p68304d9980)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+L 915.283438 352.279375 
+" clip-path="url(#pddabd15c8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_78">
+     <g id="line2d_22">
       <defs>
        <path id="m6c65b3b03c" d="M 0 0 
 L -3.5 0 
@@ -2418,7 +1607,7 @@ L -3.5 0
        <use xlink:href="#m6c65b3b03c" x="40.925781" y="352.279375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_78">
+     <g id="text_22">
       <!-- 0 -->
       <g transform="translate(27.563281 356.078203) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-13"/>
@@ -2426,116 +1615,154 @@ L -3.5 0
      </g>
     </g>
     <g id="ytick_2">
-     <g id="line2d_79">
-      <path d="M 40.925781 306.421837 
-L 777.043437 306.421837 
-" clip-path="url(#p68304d9980)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     <g id="line2d_23">
+      <path d="M 40.925781 315.909604 
+L 915.283438 315.909604 
+" clip-path="url(#pddabd15c8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_80">
+     <g id="line2d_24">
       <g>
-       <use xlink:href="#m6c65b3b03c" x="40.925781" y="306.421837" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6c65b3b03c" x="40.925781" y="315.909604" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_79">
+     <g id="text_23">
       <!-- 2 -->
-      <g transform="translate(27.563281 310.220665) scale(0.1 -0.1)">
+      <g transform="translate(27.563281 319.708432) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-15"/>
       </g>
      </g>
     </g>
     <g id="ytick_3">
-     <g id="line2d_81">
-      <path d="M 40.925781 260.564299 
-L 777.043437 260.564299 
-" clip-path="url(#p68304d9980)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     <g id="line2d_25">
+      <path d="M 40.925781 279.539832 
+L 915.283438 279.539832 
+" clip-path="url(#pddabd15c8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_82">
+     <g id="line2d_26">
       <g>
-       <use xlink:href="#m6c65b3b03c" x="40.925781" y="260.564299" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6c65b3b03c" x="40.925781" y="279.539832" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_80">
+     <g id="text_24">
       <!-- 4 -->
-      <g transform="translate(27.563281 264.363127) scale(0.1 -0.1)">
+      <g transform="translate(27.563281 283.33866) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-17"/>
       </g>
      </g>
     </g>
     <g id="ytick_4">
-     <g id="line2d_83">
-      <path d="M 40.925781 214.706761 
-L 777.043437 214.706761 
-" clip-path="url(#p68304d9980)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     <g id="line2d_27">
+      <path d="M 40.925781 243.170061 
+L 915.283438 243.170061 
+" clip-path="url(#pddabd15c8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_84">
+     <g id="line2d_28">
       <g>
-       <use xlink:href="#m6c65b3b03c" x="40.925781" y="214.706761" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6c65b3b03c" x="40.925781" y="243.170061" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_81">
+     <g id="text_25">
       <!-- 6 -->
-      <g transform="translate(27.563281 218.505589) scale(0.1 -0.1)">
+      <g transform="translate(27.563281 246.968889) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-19"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
-     <g id="line2d_85">
-      <path d="M 40.925781 168.849223 
-L 777.043437 168.849223 
-" clip-path="url(#p68304d9980)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     <g id="line2d_29">
+      <path d="M 40.925781 206.800289 
+L 915.283438 206.800289 
+" clip-path="url(#pddabd15c8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_86">
+     <g id="line2d_30">
       <g>
-       <use xlink:href="#m6c65b3b03c" x="40.925781" y="168.849223" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6c65b3b03c" x="40.925781" y="206.800289" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_82">
+     <g id="text_26">
       <!-- 8 -->
-      <g transform="translate(27.563281 172.648051) scale(0.1 -0.1)">
+      <g transform="translate(27.563281 210.599117) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-1b"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
-     <g id="line2d_87">
-      <path d="M 40.925781 122.991685 
-L 777.043437 122.991685 
-" clip-path="url(#p68304d9980)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     <g id="line2d_31">
+      <path d="M 40.925781 170.430518 
+L 915.283438 170.430518 
+" clip-path="url(#pddabd15c8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_88">
+     <g id="line2d_32">
       <g>
-       <use xlink:href="#m6c65b3b03c" x="40.925781" y="122.991685" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6c65b3b03c" x="40.925781" y="170.430518" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_83">
+     <g id="text_27">
       <!-- 10 -->
-      <g transform="translate(21.200781 126.790513) scale(0.1 -0.1)">
+      <g transform="translate(21.200781 174.229346) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
-     <g id="line2d_89">
-      <path d="M 40.925781 77.134147 
-L 777.043437 77.134147 
-" clip-path="url(#p68304d9980)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     <g id="line2d_33">
+      <path d="M 40.925781 134.060746 
+L 915.283438 134.060746 
+" clip-path="url(#pddabd15c8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
-     <g id="line2d_90">
+     <g id="line2d_34">
       <g>
-       <use xlink:href="#m6c65b3b03c" x="40.925781" y="77.134147" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6c65b3b03c" x="40.925781" y="134.060746" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_84">
+     <g id="text_28">
       <!-- 12 -->
-      <g transform="translate(21.200781 80.932976) scale(0.1 -0.1)">
+      <g transform="translate(21.200781 137.859574) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-15" transform="translate(63.625 0)"/>
       </g>
      </g>
     </g>
-    <g id="text_85">
+    <g id="ytick_8">
+     <g id="line2d_35">
+      <path d="M 40.925781 97.690975 
+L 915.283438 97.690975 
+" clip-path="url(#pddabd15c8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#m6c65b3b03c" x="40.925781" y="97.690975" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_29">
+      <!-- 14 -->
+      <g transform="translate(21.200781 101.489803) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-17" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_37">
+      <path d="M 40.925781 61.321203 
+L 915.283438 61.321203 
+" clip-path="url(#pddabd15c8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#m6c65b3b03c" x="40.925781" y="61.321203" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_30">
+      <!-- 16 -->
+      <g transform="translate(21.200781 65.120031) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-19" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_31">
      <!-- Window count -->
      <g transform="translate(14.798437 229.480244) rotate(-90) scale(0.1 -0.1)">
       <defs>
@@ -2593,27 +1820,23 @@ L 40.925781 35.862363
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_80">
-    <path d="M 777.043437 352.279375 
-L 777.043437 35.862363 
+    <path d="M 915.283438 352.279375 
+L 915.283438 35.862363 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_81">
     <path d="M 40.925781 352.279375 
-L 777.043437 352.279375 
+L 915.283438 352.279375 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_82">
     <path d="M 40.925781 35.862363 
-L 777.043437 35.862363 
+L 915.283438 35.862363 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="text_86">
-    <!-- 1 -->
-    <g transform="translate(119.514402 314.274935) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-14"/>
-    </g>
-    <!-- (1%) -->
-    <g transform="translate(112.592527 323.876498) scale(0.08 -0.08)">
+   <g id="text_32">
+    <!-- 1 (1%) -->
+    <g transform="translate(110.875906 329.730117) rotate(-90) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-8" d="M 4653 2053 
 Q 4381 2053 4226 1822 
@@ -2663,565 +1886,515 @@ Q 934 4750 1428 4750
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-14" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-14"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_87">
-    <!-- 8 -->
-    <g transform="translate(137.171337 153.773552) scale(0.08 -0.08)">
+   <g id="text_33">
+    <!-- 8 (5%) -->
+    <g transform="translate(133.586495 202.435917) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-1b"/>
-    </g>
-    <!-- (5%) -->
-    <g transform="translate(130.249462 163.375115) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-18" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-18" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_88">
-    <!-- 4 -->
-    <g transform="translate(145.999805 245.488628) scale(0.08 -0.08)">
+   <g id="text_34">
+    <!-- 4 (2%) -->
+    <g transform="translate(144.941789 275.17546) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-17"/>
-    </g>
-    <!-- (2%) -->
-    <g transform="translate(139.07793 255.090191) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-15" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_89">
-    <!-- 6 -->
-    <g transform="translate(154.828273 199.63109) scale(0.08 -0.08)">
+   <g id="text_35">
+    <!-- 6 (4%) -->
+    <g transform="translate(156.297083 238.805688) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-19"/>
-    </g>
-    <!-- (4%) -->
-    <g transform="translate(147.906398 209.232653) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-17" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_90">
-    <!-- 12 -->
-    <g transform="translate(161.111741 62.058476) scale(0.08 -0.08)">
+   <g id="text_36">
+    <!-- 12 (7%) -->
+    <g transform="translate(167.652377 129.696374) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-14"/>
      <use xlink:href="#DejaVuSans-15" transform="translate(63.625 0)"/>
-    </g>
-    <!-- (7%) -->
-    <g transform="translate(156.734866 71.660039) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-1a" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(127.25 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(159.03125 0)"/>
+     <use xlink:href="#DejaVuSans-1a" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(261.671875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(356.6875 0)"/>
     </g>
    </g>
-   <g id="text_91">
-    <!-- 7 -->
-    <g transform="translate(172.485209 176.702321) scale(0.08 -0.08)">
+   <g id="text_37">
+    <!-- 7 (4%) -->
+    <g transform="translate(179.007671 220.620802) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-1a"/>
-    </g>
-    <!-- (4%) -->
-    <g transform="translate(165.563334 186.303884) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-17" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_92">
-    <!-- 4 -->
-    <g transform="translate(181.313677 245.488628) scale(0.08 -0.08)">
+   <g id="text_38">
+    <!-- 4 (2%) -->
+    <g transform="translate(190.362966 275.17546) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-17"/>
-    </g>
-    <!-- (2%) -->
-    <g transform="translate(174.391802 255.090191) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-15" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_93">
-    <!-- 9 -->
-    <g transform="translate(190.142145 130.844783) scale(0.08 -0.08)">
+   <g id="text_39">
+    <!-- 9 (5%) -->
+    <g transform="translate(201.71826 184.251031) rotate(-90) scale(0.07 -0.07)">
+     <defs>
+      <path id="DejaVuSans-1c" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-1c"/>
-    </g>
-    <!-- (5%) -->
-    <g transform="translate(183.22027 140.446346) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-18" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-18" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_94">
-    <!-- 4 -->
-    <g transform="translate(198.970613 245.488628) scale(0.08 -0.08)">
+   <g id="text_40">
+    <!-- 4 (2%) -->
+    <g transform="translate(213.073554 275.17546) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-17"/>
-    </g>
-    <!-- (2%) -->
-    <g transform="translate(192.048738 255.090191) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-15" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_95">
-    <!-- 6 -->
-    <g transform="translate(207.799081 199.63109) scale(0.08 -0.08)">
+   <g id="text_41">
+    <!-- 6 (4%) -->
+    <g transform="translate(224.428848 238.805688) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-19"/>
-    </g>
-    <!-- (4%) -->
-    <g transform="translate(200.877206 209.232653) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-17" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_96">
-    <!-- 10 -->
-    <g transform="translate(214.082549 107.916014) scale(0.08 -0.08)">
+   <g id="text_42">
+    <!-- 10 (6%) -->
+    <g transform="translate(235.784143 166.066145) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-14"/>
      <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
-    </g>
-    <!-- (6%) -->
-    <g transform="translate(209.705674 117.517577) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-19" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(127.25 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(159.03125 0)"/>
+     <use xlink:href="#DejaVuSans-19" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(261.671875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(356.6875 0)"/>
     </g>
    </g>
-   <g id="text_97">
-    <!-- 4 -->
-    <g transform="translate(225.456017 245.488628) scale(0.08 -0.08)">
+   <g id="text_43">
+    <!-- 4 (2%) -->
+    <g transform="translate(247.139437 275.17546) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-17"/>
-    </g>
-    <!-- (2%) -->
-    <g transform="translate(218.534142 255.090191) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-15" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_98">
-    <!-- 6 -->
-    <g transform="translate(234.284485 199.63109) scale(0.08 -0.08)">
+   <g id="text_44">
+    <!-- 6 (4%) -->
+    <g transform="translate(258.494731 238.805688) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-19"/>
-    </g>
-    <!-- (4%) -->
-    <g transform="translate(227.36261 209.232653) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-17" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_99">
-    <!-- 2 -->
-    <g transform="translate(251.941421 291.346166) scale(0.08 -0.08)">
+   <g id="text_45">
+    <!-- 2 (1%) -->
+    <g transform="translate(281.20532 311.545231) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-15"/>
-    </g>
-    <!-- (1%) -->
-    <g transform="translate(245.019546 300.947729) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-14" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_100">
-    <!-- 4 -->
-    <g transform="translate(269.598356 245.488628) scale(0.08 -0.08)">
+   <g id="text_46">
+    <!-- 4 (2%) -->
+    <g transform="translate(303.915908 275.17546) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-17"/>
-    </g>
-    <!-- (2%) -->
-    <g transform="translate(262.676481 255.090191) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-15" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_101">
-    <!-- 1 -->
-    <g transform="translate(278.426824 314.274935) scale(0.08 -0.08)">
+   <g id="text_47">
+    <!-- 1 (1%) -->
+    <g transform="translate(315.271202 329.730117) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-14"/>
-    </g>
-    <!-- (1%) -->
-    <g transform="translate(271.504949 323.876498) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-14" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_102">
-    <!-- 1 -->
-    <g transform="translate(287.255292 314.274935) scale(0.08 -0.08)">
+   <g id="text_48">
+    <!-- 1 (1%) -->
+    <g transform="translate(326.626497 329.730117) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-14"/>
-    </g>
-    <!-- (1%) -->
-    <g transform="translate(280.333417 323.876498) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-14" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_103">
-    <!-- 1 -->
-    <g transform="translate(296.08376 314.274935) scale(0.08 -0.08)">
+   <g id="text_49">
+    <!-- 1 (1%) -->
+    <g transform="translate(337.981791 329.730117) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-14"/>
-    </g>
-    <!-- (1%) -->
-    <g transform="translate(289.161885 323.876498) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-14" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_104">
-    <!-- 1 -->
-    <g transform="translate(304.912228 314.274935) scale(0.08 -0.08)">
+   <g id="text_50">
+    <!-- 1 (1%) -->
+    <g transform="translate(349.337085 329.730117) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-14"/>
-    </g>
-    <!-- (1%) -->
-    <g transform="translate(297.990353 323.876498) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-14" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_105">
-    <!-- 1 -->
-    <g transform="translate(313.740696 314.274935) scale(0.08 -0.08)">
+   <g id="text_51">
+    <!-- 1 (1%) -->
+    <g transform="translate(360.692379 329.730117) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-14"/>
-    </g>
-    <!-- (1%) -->
-    <g transform="translate(306.818821 323.876498) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-14" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_106">
-    <!-- 1 -->
-    <g transform="translate(331.397632 314.274935) scale(0.08 -0.08)">
+   <g id="text_52">
+    <!-- 1 (1%) -->
+    <g transform="translate(383.402968 329.730117) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-14"/>
-    </g>
-    <!-- (1%) -->
-    <g transform="translate(324.475757 323.876498) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-14" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_107">
-    <!-- 1 -->
-    <g transform="translate(357.883036 314.274935) scale(0.08 -0.08)">
+   <g id="text_53">
+    <!-- 1 (1%) -->
+    <g transform="translate(417.46885 329.730117) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-14"/>
-    </g>
-    <!-- (1%) -->
-    <g transform="translate(350.961161 323.876498) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-14" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_108">
-    <!-- 1 -->
-    <g transform="translate(384.36844 314.274935) scale(0.08 -0.08)">
+   <g id="text_54">
+    <!-- 1 (1%) -->
+    <g transform="translate(451.534733 329.730117) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-14"/>
-    </g>
-    <!-- (1%) -->
-    <g transform="translate(377.446565 323.876498) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-14" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_109">
-    <!-- 1 -->
-    <g transform="translate(419.682311 314.274935) scale(0.08 -0.08)">
+   <g id="text_55">
+    <!-- 1 (1%) -->
+    <g transform="translate(496.95591 329.730117) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-14"/>
-    </g>
-    <!-- (1%) -->
-    <g transform="translate(412.760436 323.876498) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-14" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_110">
-    <!-- 1 -->
-    <g transform="translate(428.510779 314.274935) scale(0.08 -0.08)">
+   <g id="text_56">
+    <!-- 1 (1%) -->
+    <g transform="translate(508.311204 329.730117) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-14"/>
-    </g>
-    <!-- (1%) -->
-    <g transform="translate(421.588904 323.876498) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-14" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_111">
-    <!-- 1 -->
-    <g transform="translate(463.824651 314.274935) scale(0.08 -0.08)">
+   <g id="text_57">
+    <!-- 1 (1%) -->
+    <g transform="translate(553.732381 329.730117) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-14"/>
-    </g>
-    <!-- (1%) -->
-    <g transform="translate(456.902776 323.876498) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-14" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_112">
-    <!-- 2 -->
-    <g transform="translate(481.481587 291.346166) scale(0.08 -0.08)">
+   <g id="text_58">
+    <!-- 2 (1%) -->
+    <g transform="translate(576.44297 311.545231) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-15"/>
-    </g>
-    <!-- (1%) -->
-    <g transform="translate(474.559712 300.947729) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-14" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_113">
-    <!-- 1 -->
-    <g transform="translate(525.623926 314.274935) scale(0.08 -0.08)">
+   <g id="text_59">
+    <!-- 1 (1%) -->
+    <g transform="translate(633.219441 329.730117) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-14"/>
-    </g>
-    <!-- (1%) -->
-    <g transform="translate(518.702051 323.876498) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-14" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_114">
-    <!-- 1 -->
-    <g transform="translate(534.452394 314.274935) scale(0.08 -0.08)">
+   <g id="text_60">
+    <!-- 1 (1%) -->
+    <g transform="translate(644.574735 329.730117) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-14"/>
-    </g>
-    <!-- (1%) -->
-    <g transform="translate(527.530519 323.876498) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-14" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_115">
-    <!-- 1 -->
-    <g transform="translate(543.280862 314.274935) scale(0.08 -0.08)">
+   <g id="text_61">
+    <!-- 1 (1%) -->
+    <g transform="translate(655.930029 329.730117) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-14"/>
-    </g>
-    <!-- (1%) -->
-    <g transform="translate(536.358987 323.876498) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-14" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_116">
-    <!-- 1 -->
-    <g transform="translate(596.25167 314.274935) scale(0.08 -0.08)">
+   <g id="text_62">
+    <!-- 1 (1%) -->
+    <g transform="translate(724.061795 329.730117) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-14"/>
-    </g>
-    <!-- (1%) -->
-    <g transform="translate(589.329795 323.876498) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-14" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_117">
-    <!-- 2 -->
-    <g transform="translate(613.908606 291.346166) scale(0.08 -0.08)">
+   <g id="text_63">
+    <!-- 2 (1%) -->
+    <g transform="translate(746.772383 311.545231) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-15"/>
-    </g>
-    <!-- (1%) -->
-    <g transform="translate(606.986731 300.947729) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-14" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_118">
-    <!-- 2 -->
-    <g transform="translate(622.737074 291.346166) scale(0.08 -0.08)">
+   <g id="text_64">
+    <!-- 2 (1%) -->
+    <g transform="translate(758.127678 311.545231) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-15"/>
-    </g>
-    <!-- (1%) -->
-    <g transform="translate(615.815199 300.947729) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-14" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_119">
-    <!-- 4 -->
-    <g transform="translate(631.565542 245.488628) scale(0.08 -0.08)">
+   <g id="text_65">
+    <!-- 4 (2%) -->
+    <g transform="translate(769.482972 275.17546) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-17"/>
-    </g>
-    <!-- (2%) -->
-    <g transform="translate(624.643667 255.090191) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-15" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_120">
-    <!-- 5 -->
-    <g transform="translate(640.39401 222.559859) scale(0.08 -0.08)">
+   <g id="text_66">
+    <!-- 5 (3%) -->
+    <g transform="translate(780.838266 256.990574) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-18"/>
-    </g>
-    <!-- (3%) -->
-    <g transform="translate(633.472135 232.161422) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-16" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-16" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_121">
-    <!-- 5 -->
-    <g transform="translate(649.222478 222.559859) scale(0.08 -0.08)">
+   <g id="text_67">
+    <!-- 5 (3%) -->
+    <g transform="translate(792.19356 256.990574) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-18"/>
-    </g>
-    <!-- (3%) -->
-    <g transform="translate(642.300603 232.161422) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-16" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-16" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_122">
-    <!-- 11 -->
-    <g transform="translate(655.505945 84.987245) scale(0.08 -0.08)">
+   <g id="text_68">
+    <!-- 11 (6%) -->
+    <g transform="translate(803.548855 147.881259) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-14"/>
      <use xlink:href="#DejaVuSans-14" transform="translate(63.625 0)"/>
-    </g>
-    <!-- (6%) -->
-    <g transform="translate(651.12907 94.588808) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-19" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(127.25 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(159.03125 0)"/>
+     <use xlink:href="#DejaVuSans-19" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(261.671875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(356.6875 0)"/>
     </g>
    </g>
-   <g id="text_123">
-    <!-- 9 -->
-    <g transform="translate(666.879413 130.844783) scale(0.08 -0.08)">
+   <g id="text_69">
+    <!-- 9 (5%) -->
+    <g transform="translate(814.904149 184.251031) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-1c"/>
-    </g>
-    <!-- (5%) -->
-    <g transform="translate(659.957538 140.446346) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-18" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-18" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_124">
-    <!-- 10 -->
-    <g transform="translate(673.162881 107.916014) scale(0.08 -0.08)">
+   <g id="text_70">
+    <!-- 10 (6%) -->
+    <g transform="translate(826.259443 166.066145) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-14"/>
      <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
-    </g>
-    <!-- (6%) -->
-    <g transform="translate(668.786006 117.517577) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-19" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(127.25 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(159.03125 0)"/>
+     <use xlink:href="#DejaVuSans-19" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(261.671875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(356.6875 0)"/>
     </g>
    </g>
-   <g id="text_125">
-    <!-- 7 -->
-    <g transform="translate(684.536349 176.702321) scale(0.08 -0.08)">
+   <g id="text_71">
+    <!-- 7 (4%) -->
+    <g transform="translate(837.614737 220.620802) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-1a"/>
-    </g>
-    <!-- (4%) -->
-    <g transform="translate(677.614474 186.303884) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-17" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_126">
-    <!-- 7 -->
-    <g transform="translate(693.364817 176.702321) scale(0.08 -0.08)">
+   <g id="text_72">
+    <!-- 7 (4%) -->
+    <g transform="translate(848.970031 220.620802) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-1a"/>
-    </g>
-    <!-- (4%) -->
-    <g transform="translate(686.442942 186.303884) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-17" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_127">
-    <!-- 4 -->
-    <g transform="translate(702.193285 245.488628) scale(0.08 -0.08)">
+   <g id="text_73">
+    <!-- 4 (2%) -->
+    <g transform="translate(860.325326 275.17546) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-17"/>
-    </g>
-    <!-- (2%) -->
-    <g transform="translate(695.27141 255.090191) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-15" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_128">
-    <!-- 1 -->
-    <g transform="translate(711.021753 314.274935) scale(0.08 -0.08)">
+   <g id="text_74">
+    <!-- 1 (1%) -->
+    <g transform="translate(871.68062 329.730117) rotate(-90) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-14"/>
-    </g>
-    <!-- (1%) -->
-    <g transform="translate(704.099878 323.876498) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-b"/>
-     <use xlink:href="#DejaVuSans-14" transform="translate(39.015625 0)"/>
-     <use xlink:href="#DejaVuSans-8" transform="translate(102.640625 0)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(197.65625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(134.421875 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(198.046875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(293.0625 0)"/>
     </g>
    </g>
-   <g id="text_129">
+   <g id="text_75">
     <!-- Cross-model agreement per window -->
-    <g transform="translate(296.935 16.659355) scale(0.11 -0.11)">
+    <g transform="translate(366.055 16.659355) scale(0.11 -0.11)">
      <defs>
       <path id="DejaVuSans-Bold-26" d="M 4288 256 
 Q 3956 84 3597 -3 
@@ -3611,7 +2784,7 @@ z
      <use xlink:href="#DejaVuSans-Bold-5a" transform="translate(1944.875 0)"/>
     </g>
     <!-- Left = nobody flags (clear non-ad), right = everyone agrees (clear ad), middle = contested -->
-    <g transform="translate(127.211875 29.862363) scale(0.11 -0.11)">
+    <g transform="translate(196.331875 29.862363) scale(0.11 -0.11)">
      <defs>
       <path id="DejaVuSans-Bold-2f" d="M 588 4666 
 L 1791 4666 
@@ -3905,8 +3078,8 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p68304d9980">
-   <rect x="40.925781" y="35.862363" width="736.117656" height="316.417012"/>
+  <clipPath id="pddabd15c8a">
+   <rect x="40.925781" y="35.862363" width="874.357656" height="316.417012"/>
   </clipPath>
  </defs>
 </svg>

--- a/benchmarks/llm/src/benchmark/report/charts.py
+++ b/benchmarks/llm/src/benchmark/report/charts.py
@@ -393,14 +393,20 @@ def _render_agreement_chart(
     # Color gradient: low agreement = red, mid = yellow, high = green
     colors = ["#d62728" if i < n_models * 0.25 else "#f0a020" if i < n_models * 0.75 else "#2ca02c" for i in xs]
 
-    fig, ax = plt.subplots(figsize=(11, 5.5))
+    # Past ~30 bars the two-line labels and every-integer ticks collide into an
+    # unreadable smear, so rotate the labels and thin the ticks.
+    dense = len(xs) > 30
+    peak = counts.max()
+    fig, ax = plt.subplots(figsize=(max(11, 0.17 * len(xs)), 5.5))
     bars = ax.bar(xs, counts, color=colors, edgecolor="black", linewidth=0.4)
     for bar, c in zip(bars, counts):
         if c == 0:
             continue
-        ax.text(bar.get_x() + bar.get_width() / 2, c + max(counts) * 0.01,
-                f"{c}\n({c * 100 / total:.0f}%)",
-                ha="center", va="bottom", fontsize=8)
+        pct = f"{c * 100 / total:.0f}%"
+        ax.text(bar.get_x() + bar.get_width() / 2, c + peak * 0.02,
+                f"{c} ({pct})" if dense else f"{c}\n({pct})",
+                ha="center", va="bottom", fontsize=7 if dense else 8,
+                rotation=90 if dense else 0)
     ax.set_xlabel(f"Models predicting at least one ad (out of {n_models})", fontsize=10)
     ax.set_ylabel("Window count", fontsize=10)
     ax.set_title(
@@ -408,9 +414,14 @@ def _render_agreement_chart(
         "Left = nobody flags (clear non-ad), right = everyone agrees (clear ad), middle = contested",
         fontsize=11, fontweight="bold",
     )
-    ax.set_xticks(xs)
-    ax.set_xticklabels([str(i) for i in xs], fontsize=8)
-    ax.set_ylim(0, max(counts) * 1.15)
+    step = (len(xs) + 24) // 25
+    ticks = list(range(0, n_models + 1, step))
+    if ticks[-1] != n_models:
+        ticks.append(n_models)
+    ax.set_xticks(ticks)
+    ax.set_xticklabels([str(i) for i in ticks], fontsize=8)
+    ax.set_xlim(-1, n_models + 1)
+    ax.set_ylim(0, peak * (1.45 if dense else 1.15))
     ax.grid(True, axis="y", alpha=0.3)
     fig.tight_layout()
     _save_svg(fig, path)


### PR DESCRIPTION
The cross-model agreement chart became unreadable once the corpus grew to 75 models. Two things collided at that width:

- `set_xticks(xs)` put a tick on every integer from 0 to 75, so the labels ran together into a strip of digits.
- Bar value labels were two lines (`12` over `(7%)`) at 8pt, wider than the roughly 15px bar pitch, so neighbouring labels overwrote each other.

Fix, in `_render_agreement_chart`:

- Ticks thin to a step that keeps about 25 labels at any model count, always including 0 and the last one.
- Above 30 bars, value labels drop to one line (`12 (7%)`) at 7pt and rotate 90 degrees, so each label stays inside its own bar width. Extra y headroom (1.45x instead of 1.15x) keeps the rotated text off the top of the axes.
- Figure width scales with bar count (`max(11, 0.17 * len(xs))`), matching the other charts in this file.
- Charts with 30 bars or fewer keep the old two-line labels and full tick set.

`results/report.md` and `report_assets/agreement.svg` are regenerated. The report diff is the generation timestamp only; no numbers moved.

Note for anyone regenerating: the committed SVGs were produced with matplotlib 3.11.0. Running `benchmark report` on 3.10.x rewrites every asset with sub-pixel differences, so match the version before committing charts.

Tests: `pytest tests/` in `benchmarks/llm` passes (201 tests). `ruff check` is clean on the changed file.
