### PR TITLE
Port VAD gap extension guardrails from kristofferR fork

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -366,6 +366,7 @@ export interface AdSegment {
     | 'no_splice_evidence'
     | 'verification_miss'
     | 'differential_uncorroborated'
+    | 'large_vad_gap_extension'
     | 'cue_template_unproven'
     | 'cue_low_confidence';
   // Set when a confirm correction matched this held marker (issue #509);

--- a/frontend/src/pages/EpisodeDetail.test.tsx
+++ b/frontend/src/pages/EpisodeDetail.test.tsx
@@ -210,6 +210,15 @@ describe('Held for Review section: rendering', () => {
     const chip = screen.getByTitle('Audio differs across fetches with no corroborating signal');
     expect(chip.textContent).toBe('Differential hold');
   });
+
+  it('labels a large VAD gap hold with its safety reason', async () => {
+    renderDetail(makeEpisode({ pendingReviewMarkers: [{ ...heldMarker, hold_reason: 'large_vad_gap_extension' }] }));
+    await waitFor(() => {
+      expect(screen.getByTestId('held-for-review-section')).toBeDefined();
+    });
+    const chip = screen.getByTitle('Large untranscribed gap lacked enough evidence for automatic ad-boundary extension');
+    expect(chip.textContent).toBe('Large VAD gap');
+  });
 });
 
 describe('Held for Review: Approve & Recut (hasOriginalAudio=true)', () => {

--- a/frontend/src/pages/EpisodeDetail.test.tsx
+++ b/frontend/src/pages/EpisodeDetail.test.tsx
@@ -216,8 +216,8 @@ describe('Held for Review section: rendering', () => {
     await waitFor(() => {
       expect(screen.getByTestId('held-for-review-section')).toBeDefined();
     });
-    const chip = screen.getByTitle('Large untranscribed gap lacked enough evidence for automatic ad-boundary extension');
-    expect(chip.textContent).toBe('Large VAD gap');
+    const chip = screen.getByTitle('Untranscribed audio exceeded the safe adjacency-only extension limit');
+    expect(chip.textContent).toBe('VAD extension limit');
   });
 });
 

--- a/frontend/src/pages/EpisodeDetail.tsx
+++ b/frontend/src/pages/EpisodeDetail.tsx
@@ -1042,7 +1042,7 @@ function EpisodeDetail() {
                 : segment.hold_reason === 'differential_uncorroborated'
                 ? 'Audio differs across fetches with no corroborating signal'
                 : segment.hold_reason === 'large_vad_gap_extension'
-                ? 'Large untranscribed gap lacked enough evidence for automatic ad-boundary extension'
+                ? 'Untranscribed audio exceeded the safe adjacency-only extension limit'
                 : segment.hold_reason === 'cue_template_unproven'
                 ? "This cue template hasn't cut a confirmed ad yet"
                 : segment.hold_reason === 'cue_low_confidence'
@@ -1053,7 +1053,7 @@ function EpisodeDetail() {
                 : segment.hold_reason === 'differential_uncorroborated'
                 ? 'Differential hold'
                 : segment.hold_reason === 'large_vad_gap_extension'
-                ? 'Large VAD gap'
+                ? 'VAD extension limit'
                 : segment.hold_reason === 'cue_template_unproven'
                 ? 'Unproven cue'
                 : segment.hold_reason === 'cue_low_confidence'

--- a/frontend/src/pages/EpisodeDetail.tsx
+++ b/frontend/src/pages/EpisodeDetail.tsx
@@ -1041,6 +1041,8 @@ function EpisodeDetail() {
                 ? 'A standalone catch from the verification pass, held for a second opinion'
                 : segment.hold_reason === 'differential_uncorroborated'
                 ? 'Audio differs across fetches with no corroborating signal'
+                : segment.hold_reason === 'large_vad_gap_extension'
+                ? 'Large untranscribed gap lacked enough evidence for automatic ad-boundary extension'
                 : segment.hold_reason === 'cue_template_unproven'
                 ? "This cue template hasn't cut a confirmed ad yet"
                 : segment.hold_reason === 'cue_low_confidence'
@@ -1050,6 +1052,8 @@ function EpisodeDetail() {
                 ? 'Verification catch'
                 : segment.hold_reason === 'differential_uncorroborated'
                 ? 'Differential hold'
+                : segment.hold_reason === 'large_vad_gap_extension'
+                ? 'Large VAD gap'
                 : segment.hold_reason === 'cue_template_unproven'
                 ? 'Unproven cue'
                 : segment.hold_reason === 'cue_low_confidence'

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -828,6 +828,15 @@ class AdValidator:
         A held ad gets decision=REVIEW with held_for_review=True so the gate
         keeps it in the audio. Returns the (possibly updated) decision.
         """
+        # Adjacency is boundary evidence, not authority to classify an
+        # arbitrarily large untranscribed span. This safety marker is stamped
+        # before validation so it cannot merge into the neighboring ad, then
+        # re-derived here before generic duration holds choose another reason.
+        if (ad.get('detection_stage') == 'vad_gap'
+                and ad.get('vad_gap_requires_review')):
+            self._mark_held(ad, flags, HOLD_REASON_LARGE_VAD_GAP)
+            return Decision.REVIEW
+
         # Rule 1a: per-feed cap holds an ad that would otherwise be cut.
         if (self.max_ad_duration_override is not None
                 and duration > self.max_ad_duration_override
@@ -852,16 +861,6 @@ class AdValidator:
                 and ad.get('detection_stage') == 'dai_differential'
                 and ad.get('differential_uncorroborated')):
             self._mark_held(ad, flags, HOLD_REASON_DIFFERENTIAL_UNCORROBORATED)
-            return Decision.REVIEW
-
-        # Adjacency is boundary evidence, not authority to classify an
-        # arbitrarily long untranscribed span. The detector leaves large,
-        # unsupported gaps separate and stamps this flag so validation can
-        # preserve them for a human decision.
-        if (decision != Decision.REJECT
-                and ad.get('detection_stage') == 'vad_gap'
-                and ad.get('vad_gap_requires_review')):
-            self._mark_held(ad, flags, HOLD_REASON_LARGE_VAD_GAP)
             return Decision.REVIEW
 
         # Rule 2: cue-gated approval. Only applies to ACCEPT after rule 1.

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -1039,15 +1039,13 @@ class AdValidator:
             last = merged[-1]
             gap = current['start'] - last['end']
 
-            # #541, generalized: never merge across a held/not-held boundary
-            # (any hold reason) -- the fold would hold the real ad or cut
-            # the held span, and on an auto-approve recut it would grow the
-            # marker past its trimmed confirm so the confirmed_span clamp
-            # never fires and trimmed-out audio gets cut.
-            if (bool(last.get('differential_uncorroborated'))
-                    != bool(current.get('differential_uncorroborated'))
-                    or bool(last.get('held_for_review'))
-                    != bool(current.get('held_for_review'))):
+            # Pending-review markers represent individual human decisions.
+            # Never merge one with a cut marker or another hold: either fold
+            # can absorb content that was not part of the reviewed span.
+            if (last.get('held_for_review')
+                    or current.get('held_for_review')
+                    or bool(last.get('differential_uncorroborated'))
+                    != bool(current.get('differential_uncorroborated'))):
                 merged.append(current.copy())
                 continue
 

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -985,6 +985,11 @@ class AdValidator:
         sorted_ads = sorted(ads, key=lambda x: x['start'])
         last_ad = sorted_ads[-1]
 
+        # A held marker has not been approved for cutting. Extending it could
+        # absorb post-gap speech that was not part of the reviewed span.
+        if last_ad.get('held_for_review') or last_ad.get('vad_gap_requires_review'):
+            return ads
+
         gap_to_end = self.episode_duration - last_ad['end']
 
         # Only extend if gap is positive and within threshold

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -21,6 +21,7 @@ from config import (
     CUE_ONLY_SAFETY_HOLD_NEW, CUE_ONLY_SAFETY_AUTO_CUT,
     CUE_ONLY_AUTOCUT_CONFIDENCE,
     HOLD_REASON_CUE_TEMPLATE_UNPROVEN, HOLD_REASON_CUE_LOW_CONFIDENCE,
+    HOLD_REASON_LARGE_VAD_GAP,
     normalize_segment_category, DEFAULT_SEGMENT_ACTION,
 )
 from utils.markers import mark_distinct_merge
@@ -851,6 +852,16 @@ class AdValidator:
                 and ad.get('detection_stage') == 'dai_differential'
                 and ad.get('differential_uncorroborated')):
             self._mark_held(ad, flags, HOLD_REASON_DIFFERENTIAL_UNCORROBORATED)
+            return Decision.REVIEW
+
+        # Adjacency is boundary evidence, not authority to classify an
+        # arbitrarily long untranscribed span. The detector leaves large,
+        # unsupported gaps separate and stamps this flag so validation can
+        # preserve them for a human decision.
+        if (decision != Decision.REJECT
+                and ad.get('detection_stage') == 'vad_gap'
+                and ad.get('vad_gap_requires_review')):
+            self._mark_held(ad, flags, HOLD_REASON_LARGE_VAD_GAP)
             return Decision.REVIEW
 
         # Rule 2: cue-gated approval. Only applies to ACCEPT after rule 1.

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -22,6 +22,7 @@ from config import (
     CUE_ONLY_AUTOCUT_CONFIDENCE,
     HOLD_REASON_CUE_TEMPLATE_UNPROVEN, HOLD_REASON_CUE_LOW_CONFIDENCE,
     HOLD_REASON_LARGE_VAD_GAP,
+    MAX_ADJACENT_AUTO_EXTENSION_SECONDS,
     normalize_segment_category, DEFAULT_SEGMENT_ACTION,
 )
 from utils.markers import mark_distinct_merge
@@ -29,6 +30,12 @@ from utils.text import extract_text_from_segments
 from utils.time import overlap_ratio
 
 logger = logging.getLogger(__name__)
+
+
+def _vad_gap_adjacency_extension_seconds(ad: dict) -> float:
+    """Return an ad's accumulated adjacency-only VAD extension."""
+    value = ad.get('vad_gap_adjacency_extension_seconds', 0.0)
+    return float(value) if isinstance(value, (int, float)) else 0.0
 
 
 class Decision(Enum):
@@ -1049,6 +1056,8 @@ class AdValidator:
             # can absorb content that was not part of the reviewed span.
             if (last.get('held_for_review')
                     or current.get('held_for_review')
+                    or last.get('vad_gap_requires_review')
+                    or current.get('vad_gap_requires_review')
                     or bool(last.get('differential_uncorroborated'))
                     != bool(current.get('differential_uncorroborated'))):
                 merged.append(current.copy())
@@ -1073,10 +1082,22 @@ class AdValidator:
                 merged.append(current.copy())
                 continue
 
+            adjacency_extension = (
+                _vad_gap_adjacency_extension_seconds(last)
+                + _vad_gap_adjacency_extension_seconds(current)
+            )
+            # Each marker can satisfy the adjacency-only safety limit on its
+            # own. Keep them distinct when their union would evade that cap.
+            if adjacency_extension > MAX_ADJACENT_AUTO_EXTENSION_SECONDS:
+                merged.append(current.copy())
+                continue
+
             if 0 <= gap < MERGE_GAP_THRESHOLD:
                 # Always merge small gaps (< 5s)
                 mark_distinct_merge(last, current)
                 last['end'] = max(last['end'], current['end'])
+                if adjacency_extension:
+                    last['vad_gap_adjacency_extension_seconds'] = adjacency_extension
                 if current.get('reason') and current['reason'] != last.get('reason'):
                     last['reason'] = f"{last.get('reason', '')} + {current['reason']}"
                 if current.get('confidence', 0) > last.get('confidence', 0):
@@ -1088,6 +1109,8 @@ class AdValidator:
                 # Merge larger gaps if no speech in between
                 mark_distinct_merge(last, current)
                 last['end'] = max(last['end'], current['end'])
+                if adjacency_extension:
+                    last['vad_gap_adjacency_extension_seconds'] = adjacency_extension
                 if current.get('reason') and current['reason'] != last.get('reason'):
                     last['reason'] = f"{last.get('reason', '')} + {current['reason']}"
                 if current.get('confidence', 0) > last.get('confidence', 0):

--- a/src/config.py
+++ b/src/config.py
@@ -1270,6 +1270,9 @@ def resolve_whisper_device():
 # disclaimers, distorted ad tails) that the transcript-based ad detectors
 # never see. A "gap" is a span with no Whisper segment.
 VAD_GAP_CONFIDENCE = 0.75                # emitted marker confidence
+# Adjacency alone is insufficient evidence to classify an arbitrarily long
+# untranscribed span as ad audio.
+MAX_ADJACENT_AUTO_EXTENSION_SECONDS = 60.0
 
 # Default base URL for OpenAI-compatible providers (single source of truth;
 # the OPENAI_BASE_URL env var overrides). Used by get_effective_base_url, the

--- a/src/config.py
+++ b/src/config.py
@@ -55,6 +55,7 @@ HOLD_REASON_VERIFICATION_MISS = 'verification_miss'
 HOLD_REASON_VERIFICATION_KEPT_CONFLICT = 'verification_kept_conflict'
 HOLD_REASON_CUE_TEMPLATE_UNPROVEN = 'cue_template_unproven'
 HOLD_REASON_CUE_LOW_CONFIDENCE = 'cue_low_confidence'
+HOLD_REASON_LARGE_VAD_GAP = 'large_vad_gap_extension'
 
 # Segment categories (issue #565): what kind of content a marker spans. A
 # marker may carry none: unset means no stage classified it, and only action

--- a/src/vad_gap_detector.py
+++ b/src/vad_gap_detector.py
@@ -22,7 +22,7 @@ from roll_detector import (
     _region_covered,
 )
 from utils.text import get_transcript_text_for_range
-from config import VAD_GAP_CONFIDENCE
+from config import HOLD_REASON_LARGE_VAD_GAP, VAD_GAP_CONFIDENCE
 
 logger = logging.getLogger(__name__)
 
@@ -211,26 +211,45 @@ def detect_vad_gaps(
                 _ends_with_signoff(before_text)
                 and _starts_with_resume(after_text)
             )
-            if (gap_duration > adjacent_auto_extend_max_seconds
+            old_start = adjacent.get('start', 0.0)
+            old_end = adjacent.get('end', 0.0)
+            proposed_start = min(old_start, gap_start)
+            proposed_end = max(old_end, gap_end)
+            added_extension = (
+                max(0.0, old_start - proposed_start)
+                + max(0.0, proposed_end - old_end)
+            )
+            prior_auto_extension = adjacent.get(
+                'vad_gap_adjacency_extension_seconds', 0.0)
+            if not isinstance(prior_auto_extension, (int, float)):
+                prior_auto_extension = 0.0
+            cumulative_auto_extension = prior_auto_extension + added_extension
+            if (cumulative_auto_extension > adjacent_auto_extend_max_seconds
                     and not has_break_context):
                 marker = _new_marker(
                     gap_start,
                     gap_end,
-                    f'Large VAD gap adjacent to detected ad '
-                    f'({gap_duration:.1f}s untranscribed)',
+                    f'VAD gap exceeds adjacency-only extension limit '
+                    f'({gap_duration:.1f}s gap, '
+                    f'{cumulative_auto_extension:.1f}s cumulative)',
                 )
                 marker['vad_gap_requires_review'] = True
+                marker['held_for_review'] = True
+                marker['was_cut'] = False
+                marker['hold_reason'] = HOLD_REASON_LARGE_VAD_GAP
                 new_markers.append(marker)
                 logger.warning(
                     f"VAD mid gap {gap_start:.1f}-{gap_end:.1f}s is too "
-                    f"large for adjacency-only extension; holding separately"
+                    f"large for cumulative adjacency-only extension; "
+                    f"holding separately"
                 )
                 continue
-            old_start = adjacent.get('start', 0.0)
-            old_end = adjacent.get('end', 0.0)
-            adjacent['start'] = min(old_start, gap_start)
-            adjacent['end'] = max(old_end, gap_end)
+            adjacent['start'] = proposed_start
+            adjacent['end'] = proposed_end
             adjacent['vad_gap_extended'] = True
+            if not has_break_context:
+                adjacent['vad_gap_adjacency_extension_seconds'] = (
+                    cumulative_auto_extension)
             logger.info(
                 f"VAD mid gap merged into adjacent ad: "
                 f"{old_start:.1f}-{old_end:.1f}s -> "

--- a/src/vad_gap_detector.py
+++ b/src/vad_gap_detector.py
@@ -27,6 +27,10 @@ from config import VAD_GAP_CONFIDENCE
 logger = logging.getLogger(__name__)
 
 _GAP_ADJACENCY_BUFFER = 1.0  # seconds; how close a gap must be to an ad to count as adjacent
+# Adjacency is useful boundary evidence, but it is not enough to classify an
+# arbitrarily long untranscribed span. A minute already covers a conventional
+# spot; longer gaps need transcript context or a human decision.
+MAX_ADJACENT_AUTO_EXTENSION_SECONDS = 60.0
 
 # DAI seam check: dynamic insertion can duplicate a few seconds of show
 # audio around the splice, so extending an ad across the gap swallows real
@@ -145,6 +149,7 @@ def detect_vad_gaps(
     start_min_seconds: float = 3.0,
     mid_min_seconds: float = 8.0,
     tail_min_seconds: float = 3.0,
+    adjacent_auto_extend_max_seconds: float = MAX_ADJACENT_AUTO_EXTENSION_SECONDS,
 ) -> list[dict]:
     """Return ad markers for suspicious untranscribed audio spans.
 
@@ -160,6 +165,9 @@ def detect_vad_gaps(
         start_min_seconds: Minimum head-gap duration to emit.
         mid_min_seconds: Minimum mid-gap duration to emit (still needs both signoff-before AND resume-after context).
         tail_min_seconds: Minimum tail-gap duration to emit.
+        adjacent_auto_extend_max_seconds: Largest adjacent gap that can extend
+            an existing ad on adjacency evidence alone. Larger gaps require
+            signoff/resume context or are emitted as held review candidates.
 
     Returns:
         List of new ad markers. May be empty.
@@ -195,6 +203,27 @@ def detect_vad_gaps(
                     f"VAD mid gap {gap_start:.1f}-{gap_end:.1f}s: DAI seam "
                     f"duplicate beyond boundary; not extending ad "
                     f"{adjacent.get('start', 0.0):.1f}-{adjacent.get('end', 0.0):.1f}s"
+                )
+                continue
+            before_text = segments[i].get('text', '')
+            after_text = segments[i + 1].get('text', '')
+            has_break_context = (
+                _ends_with_signoff(before_text)
+                and _starts_with_resume(after_text)
+            )
+            if (gap_duration > adjacent_auto_extend_max_seconds
+                    and not has_break_context):
+                marker = _new_marker(
+                    gap_start,
+                    gap_end,
+                    f'Large VAD gap adjacent to detected ad '
+                    f'({gap_duration:.1f}s untranscribed)',
+                )
+                marker['vad_gap_requires_review'] = True
+                new_markers.append(marker)
+                logger.warning(
+                    f"VAD mid gap {gap_start:.1f}-{gap_end:.1f}s is too "
+                    f"large for adjacency-only extension; holding separately"
                 )
                 continue
             old_start = adjacent.get('start', 0.0)

--- a/src/vad_gap_detector.py
+++ b/src/vad_gap_detector.py
@@ -22,15 +22,14 @@ from roll_detector import (
     _region_covered,
 )
 from utils.text import get_transcript_text_for_range
-from config import HOLD_REASON_LARGE_VAD_GAP, VAD_GAP_CONFIDENCE
+from config import (
+    HOLD_REASON_LARGE_VAD_GAP, MAX_ADJACENT_AUTO_EXTENSION_SECONDS,
+    VAD_GAP_CONFIDENCE,
+)
 
 logger = logging.getLogger(__name__)
 
 _GAP_ADJACENCY_BUFFER = 1.0  # seconds; how close a gap must be to an ad to count as adjacent
-# Adjacency is useful boundary evidence, but it is not enough to classify an
-# arbitrarily long untranscribed span. A minute already covers a conventional
-# spot; longer gaps need transcript context or a human decision.
-MAX_ADJACENT_AUTO_EXTENSION_SECONDS = 60.0
 
 # DAI seam check: dynamic insertion can duplicate a few seconds of show
 # audio around the splice, so extending an ad across the gap swallows real

--- a/tests/unit/test_ad_validator.py
+++ b/tests/unit/test_ad_validator.py
@@ -714,6 +714,25 @@ class TestAdValidatorVadGapVerification:
         # stays at or above 0.85 (modulo position adjustments).
         assert result.ads[0]['validation']['adjusted_confidence'] > 0.79
 
+    def test_large_adjacency_only_gap_is_held(self):
+        from config import HOLD_REASON_LARGE_VAD_GAP
+
+        validator = AdValidator(episode_duration=8000.0, segments=[])
+        marker = {
+            'start': 2000.0,
+            'end': 2120.0,
+            'confidence': 0.95,
+            'reason': 'Large VAD gap adjacent to detected ad',
+            'detection_stage': 'vad_gap',
+            'vad_gap_requires_review': True,
+        }
+
+        ad = validator.validate([marker]).ads[0]
+
+        assert ad['validation']['decision'] == Decision.REVIEW.value
+        assert ad['held_for_review'] is True
+        assert ad['hold_reason'] == HOLD_REASON_LARGE_VAD_GAP
+
 
 class TestPositionalPriorBoost:
     """Tests for learned positional prior boosts (issue #360)."""

--- a/tests/unit/test_ad_validator.py
+++ b/tests/unit/test_ad_validator.py
@@ -720,7 +720,7 @@ class TestAdValidatorVadGapVerification:
         validator = AdValidator(episode_duration=8000.0, segments=[])
         marker = {
             'start': 2000.0,
-            'end': 2120.0,
+            'end': 2400.0,
             'confidence': 0.95,
             'reason': 'Large VAD gap adjacent to detected ad',
             'detection_stage': 'vad_gap',
@@ -732,6 +732,38 @@ class TestAdValidatorVadGapVerification:
         assert ad['validation']['decision'] == Decision.REVIEW.value
         assert ad['held_for_review'] is True
         assert ad['hold_reason'] == HOLD_REASON_LARGE_VAD_GAP
+
+    def test_large_gap_hold_does_not_merge_into_adjacent_ad(self):
+        from config import HOLD_REASON_LARGE_VAD_GAP
+
+        validator = AdValidator(episode_duration=500.0, segments=[])
+        adjacent_ad = {
+            'start': 40.0,
+            'end': 50.0,
+            'confidence': 0.95,
+            'reason': 'Sponsor read',
+            'detection_stage': 'claude',
+        }
+        gap = {
+            'start': 50.0,
+            'end': 170.0,
+            'confidence': 0.75,
+            'reason': 'VAD gap exceeds adjacency-only extension limit',
+            'detection_stage': 'vad_gap',
+            'vad_gap_requires_review': True,
+            'held_for_review': True,
+            'was_cut': False,
+            'hold_reason': HOLD_REASON_LARGE_VAD_GAP,
+        }
+
+        result = validator.validate([adjacent_ad, gap])
+
+        assert len(result.ads) == 2
+        held = result.ads[1]
+        assert held['start'] == 50.0
+        assert held['end'] == 170.0
+        assert held['held_for_review'] is True
+        assert held['hold_reason'] == HOLD_REASON_LARGE_VAD_GAP
 
 
 class TestPositionalPriorBoost:

--- a/tests/unit/test_ad_validator.py
+++ b/tests/unit/test_ad_validator.py
@@ -1483,6 +1483,43 @@ def test_distinct_held_markers_never_merge_with_each_other():
     assert merged[1]['start'] == 152.0
 
 
+def test_recut_keeps_approved_vad_hold_distinct():
+    """A recut clears the hold but retains the VAD safety provenance."""
+    validator = AdValidator(episode_duration=300.0, segments=[])
+    result = ValidationResult(ads=[])
+    ads = [
+        {'start': 100.0, 'end': 150.0, 'confidence': 0.95,
+         'vad_gap_requires_review': True, '_saved_was_cut': True},
+        {'start': 152.0, 'end': 200.0, 'confidence': 0.95,
+         '_saved_was_cut': True},
+    ]
+
+    merged = validator._merge_close_ads(ads, result)
+
+    assert len(merged) == 2
+    assert merged[0]['end'] == 150.0
+
+
+def test_merge_preserves_vad_adjacency_extension_limit():
+    validator = AdValidator(episode_duration=400.0, segments=[])
+    result = ValidationResult(ads=[])
+    ads = [
+        {'start': 100.0, 'end': 150.0, 'confidence': 0.95,
+         'vad_gap_adjacency_extension_seconds': 20.0},
+        {'start': 152.0, 'end': 200.0, 'confidence': 0.95,
+         'vad_gap_adjacency_extension_seconds': 20.0},
+        {'start': 202.0, 'end': 250.0, 'confidence': 0.95,
+         'vad_gap_adjacency_extension_seconds': 25.0},
+    ]
+
+    merged = validator._merge_close_ads(ads, result)
+
+    assert len(merged) == 2
+    assert merged[0]['end'] == 200.0
+    assert merged[0]['vad_gap_adjacency_extension_seconds'] == 40.0
+    assert merged[1]['start'] == 202.0
+
+
 class TestRegistryConfirmsLongAds:
     """A real multi-sponsor break was rejected on length alone.
 

--- a/tests/unit/test_ad_validator.py
+++ b/tests/unit/test_ad_validator.py
@@ -765,6 +765,32 @@ class TestAdValidatorVadGapVerification:
         assert held['held_for_review'] is True
         assert held['hold_reason'] == HOLD_REASON_LARGE_VAD_GAP
 
+    def test_held_tail_gap_does_not_extend_into_transcript(self):
+        from config import HOLD_REASON_LARGE_VAD_GAP
+
+        validator = AdValidator(
+            episode_duration=1000.0,
+            segments=[{'start': 990.0, 'end': 1000.0,
+                       'text': 'Thanks for listening to the show.'}],
+        )
+        marker = {
+            'start': 870.0,
+            'end': 990.0,
+            'confidence': 0.75,
+            'reason': 'Large VAD gap at episode tail',
+            'detection_stage': 'vad_gap',
+            'vad_gap_requires_review': True,
+            'held_for_review': True,
+            'was_cut': False,
+            'hold_reason': HOLD_REASON_LARGE_VAD_GAP,
+        }
+
+        ad = validator.validate([marker]).ads[0]
+
+        assert ad['end'] == 990.0
+        assert ad['held_for_review'] is True
+        assert ad['hold_reason'] == HOLD_REASON_LARGE_VAD_GAP
+
 
 class TestPositionalPriorBoost:
     """Tests for learned positional prior boosts (issue #360)."""

--- a/tests/unit/test_ad_validator.py
+++ b/tests/unit/test_ad_validator.py
@@ -1438,6 +1438,25 @@ def test_merge_never_crosses_held_boundary():
     assert merged[0]['end'] == 160.0
 
 
+def test_distinct_held_markers_never_merge_with_each_other():
+    validator = AdValidator(episode_duration=300.0)
+    result = ValidationResult(ads=[])
+    ads = [
+        {'start': 100.0, 'end': 150.0, 'confidence': 0.75,
+         'held_for_review': True, 'hold_reason': 'large_vad_gap_extension',
+         'vad_gap_requires_review': True},
+        {'start': 152.0, 'end': 200.0, 'confidence': 0.75,
+         'held_for_review': True, 'hold_reason': 'large_vad_gap_extension',
+         'vad_gap_requires_review': True},
+    ]
+
+    merged = validator._merge_close_ads(ads, result)
+
+    assert len(merged) == 2
+    assert merged[0]['end'] == 150.0
+    assert merged[1]['start'] == 152.0
+
+
 class TestRegistryConfirmsLongAds:
     """A real multi-sponsor break was rejected on length alone.
 

--- a/tests/unit/test_vad_gap_detector.py
+++ b/tests/unit/test_vad_gap_detector.py
@@ -1,6 +1,7 @@
 """Tests for src/vad_gap_detector.py."""
 import pytest
 
+from config import HOLD_REASON_LARGE_VAD_GAP
 from vad_gap_detector import detect_vad_gaps
 
 
@@ -118,6 +119,29 @@ class TestMidGap:
         assert gaps[0]['start'] == pytest.approx(50.0)
         assert gaps[0]['end'] == pytest.approx(170.0)
         assert gaps[0]['vad_gap_requires_review'] is True
+        assert gaps[0]['held_for_review'] is True
+        assert gaps[0]['hold_reason'] == HOLD_REASON_LARGE_VAD_GAP
+
+    def test_fragmented_gaps_cannot_bypass_cumulative_extension_limit(self):
+        segments = [
+            _seg(0.0, 50.0, 'The hosts continue their discussion.'),
+            _seg(105.0, 106.0, 'A brief show interjection.'),
+            _seg(161.0, 200.0, 'They move on to the next topic.'),
+        ]
+        existing = [{'start': 40.0, 'end': 50.0, 'reason': 'Sponsor'}]
+
+        gaps = detect_vad_gaps(
+            segments, existing_ads=existing, episode_duration=200.0,
+            mid_min_seconds=10.0,
+        )
+
+        assert existing[0]['end'] == pytest.approx(105.0)
+        assert existing[0]['vad_gap_adjacency_extension_seconds'] == pytest.approx(55.0)
+        assert len(gaps) == 1
+        assert gaps[0]['start'] == pytest.approx(106.0)
+        assert gaps[0]['end'] == pytest.approx(161.0)
+        assert gaps[0]['held_for_review'] is True
+        assert gaps[0]['hold_reason'] == HOLD_REASON_LARGE_VAD_GAP
 
     def test_large_adjacent_gap_with_break_context_can_extend(self):
         segments = [

--- a/tests/unit/test_vad_gap_detector.py
+++ b/tests/unit/test_vad_gap_detector.py
@@ -100,6 +100,41 @@ class TestMidGap:
                                mid_min_seconds=10.0)
         assert not any(g['start'] == 60.0 and g['end'] == 75.0 for g in gaps)
 
+    def test_large_adjacent_gap_is_held_separately(self):
+        segments = [
+            _seg(0.0, 50.0, 'The hosts continue their discussion.'),
+            _seg(170.0, 200.0, 'They move on to the next topic.'),
+        ]
+        existing = [{'start': 40.0, 'end': 50.0, 'reason': 'Sponsor'}]
+
+        gaps = detect_vad_gaps(
+            segments, existing_ads=existing, episode_duration=200.0,
+            mid_min_seconds=10.0,
+        )
+
+        assert existing[0]['end'] == pytest.approx(50.0)
+        assert 'vad_gap_extended' not in existing[0]
+        assert len(gaps) == 1
+        assert gaps[0]['start'] == pytest.approx(50.0)
+        assert gaps[0]['end'] == pytest.approx(170.0)
+        assert gaps[0]['vad_gap_requires_review'] is True
+
+    def test_large_adjacent_gap_with_break_context_can_extend(self):
+        segments = [
+            _seg(0.0, 50.0, 'Visit example.com slash show for a free trial.'),
+            _seg(170.0, 200.0, 'Welcome back everyone, let us continue.'),
+        ]
+        existing = [{'start': 40.0, 'end': 50.0, 'reason': 'Sponsor'}]
+
+        gaps = detect_vad_gaps(
+            segments, existing_ads=existing, episode_duration=200.0,
+            mid_min_seconds=10.0,
+        )
+
+        assert gaps == []
+        assert existing[0]['end'] == pytest.approx(170.0)
+        assert existing[0]['vad_gap_extended'] is True
+
 
 class TestTailGap:
     def test_tail_gap_above_threshold_emits_marker(self):


### PR DESCRIPTION
Ports kristofferR/MinusPod agent/vad-gap-guardrails (5 commits, original authorship preserved) onto current main.

## What it does
- Caps cumulative adjacency-only VAD gap extension at 60s (MAX_ADJACENT_AUTO_EXTENSION_SECONDS in src/config.py). Adjacency evidence alone can no longer classify arbitrarily long untranscribed spans as ad audio.
- Larger gaps without signoff/resume context become held markers with new hold reason large_vad_gap_extension, surfaced in the episode detail UI (frontend/src/api/types.ts, EpisodeDetail.tsx).
- Held markers are excluded from end-of-episode extension.
- Merge rule in src/ad_validator.py tightens from 'never merge across a held/not-held boundary' to 'never merge if either side is held', so two holds stay distinct review decisions.

## Port notes
- One conflict in src/vad_gap_detector.py (fork used legacy List[Dict] typing vs main's modernized list[dict]); resolved to main's style, plus one leftover Dict annotation in ad_validator.py fixed.
- Everything else applied cleanly; the touched regions had not drifted since 2.88.3.

## Test plan
- tests/unit: 5132 passed locally (includes the port's new test cases in test_vad_gap_detector.py and test_ad_validator.py)
- frontend: 550 passed (includes new EpisodeDetail hold-reason test)
- ruff clean