### PR TITLE
Port Ollama reasoning-effort fix from kristofferR fork

### DIFF
--- a/src/llm_capabilities.py
+++ b/src/llm_capabilities.py
@@ -102,12 +102,10 @@ def translate_reasoning_effort(
     if normalized not in ("none", "low", "medium", "high"):
         return {}
 
-    if provider == PROVIDER_OPENAI_COMPATIBLE:
+    if provider in (PROVIDER_OPENAI_COMPATIBLE, PROVIDER_OLLAMA):
         return {"reasoning_effort": normalized}
     if provider == PROVIDER_OPENROUTER:
         return {"extra_body": {"reasoning": {"effort": normalized}}}
-    if provider == PROVIDER_OLLAMA:
-        return {"extra_body": {"options": {"think": normalized != "none"}}}
     return {}
 
 

--- a/tests/unit/test_llm_capabilities.py
+++ b/tests/unit/test_llm_capabilities.py
@@ -109,13 +109,13 @@ class TestTranslateReasoningEffort:
 
     def test_ollama_none_string_disables_thinking(self):
         assert translate_reasoning_effort("ollama", "none") == {
-            "extra_body": {"options": {"think": False}}
+            "reasoning_effort": "none"
         }
 
     @pytest.mark.parametrize("level", ["low", "medium", "high"])
-    def test_ollama_levels_enable_thinking(self, level):
+    def test_ollama_preserves_reasoning_level(self, level):
         assert translate_reasoning_effort("ollama", level) == {
-            "extra_body": {"options": {"think": True}}
+            "reasoning_effort": level
         }
 
     def test_unknown_level_drops(self):

--- a/tests/unit/test_llm_client_tunables.py
+++ b/tests/unit/test_llm_client_tunables.py
@@ -311,7 +311,8 @@ class TestOpenAIFallback:
             )
 
         kwargs = mock_sdk.chat.completions.create.call_args.kwargs
-        assert kwargs["extra_body"] == {"options": {"think": False}}
+        assert kwargs["reasoning_effort"] == "none"
+        assert "extra_body" not in kwargs
 
 
 class TestAnthropicTemperatureOmission:


### PR DESCRIPTION
Ports kristofferR/MinusPod agent/ollama-reasoning-effort (6c454fd2, original authorship preserved).

## What it does
translate_reasoning_effort for Ollama previously returned extra_body {"options": {"think": bool}} — dead code twice over: Ollama's OpenAI-compatible endpoint has no options field, and even the native API takes think top-level. The reasoning value never reached the model. The fix sends reasoning_effort through the OpenAI-compatible API, the same form the openai_compatible provider uses.

## Verification of the fork's caveats (against ollama/ollama main, openai/openai.go)
- thinkFromReasoningEffort maps "none" to think=false, so the disable path is preserved, not dropped.
- low/medium/high map directly; out-of-range values clamp rather than 400.
- Older Ollama versions ignore unknown OpenAI-compat fields, so pre-reasoning_effort servers behave exactly as they did with the old dead options form — no regression.

## Test plan
- test_llm_capabilities.py, test_llm_client_tunables.py, test_stage_tunables_api.py: 123 passed
- ruff clean