### PR TITLE
Port pass-2 category actions from kristofferR fork

### DIFF
--- a/src/ad_detector/__init__.py
+++ b/src/ad_detector/__init__.py
@@ -2348,17 +2348,19 @@ class AdDetector:
 
             # Check for overlap (within 3 seconds)
             if current['start'] <= last['end'] + 3.0:
+                last_action = (resolve_category_action(
+                    last.get('category'), action_map) if action_map else None)
+                current_action = (resolve_category_action(
+                    current.get('category'), action_map) if action_map else None)
                 same_action = (
-                    action_map is None
-                    or resolve_category_action(last.get('category'), action_map)
-                       == resolve_category_action(current.get('category'), action_map)
-                )
+                    action_map is None or last_action == current_action)
                 if not same_action:
                     # Contested audio: never merge a keep-resolving marker
                     # into a remove-resolving one, and never let a shorter
                     # span nested inside the other collapse to nothing (e.g.
                     # an intro/outro inside a remove-resolving match).
-                    new_last, new_entries = split_conflicting_action_span(last, current)
+                    new_last, new_entries = split_conflicting_action_span(
+                        last, current, last_action, current_action)
                     if new_last is None:
                         merged.pop()
                     else:

--- a/src/ad_detector/__init__.py
+++ b/src/ad_detector/__init__.py
@@ -2755,7 +2755,8 @@ class AdDetector:
                 "status": "success",
                 "raw_response": "\n\n".join(all_raw_responses),
                 "prompt": f"Verification: Processed {len(windows)} windows",
-                "model": model
+                "model": model,
+                "segment_actions": action_map,
             }
 
         except Exception as e:

--- a/src/ad_detector/__init__.py
+++ b/src/ad_detector/__init__.py
@@ -1080,8 +1080,8 @@ class AdDetector:
 
         ``category_repair_enabled``: when True, any window with an ad missing
         "category" gets one follow-up LLM call for just those categories (see
-        ``_repair_window_categories``). False (default; always for
-        verification) skips repair, no extra calls.
+        ``_repair_window_categories``). False skips repair and makes no extra
+        calls.
 
         Returns ``(final_ads, all_raw_responses, failed_windows,
         failure_response, category_missing, category_total,
@@ -2684,14 +2684,22 @@ class AdDetector:
             if sponsor_history:
                 description_section += sponsor_history
 
+            # Category actions must enter at the earliest merge seam. The
+            # default verification prompt requires a category, and configured
+            # non-default actions enable the same narrow repair pass used by
+            # pass 1 for custom/legacy prompts or omitted model fields.
+            action_map = self._resolve_segment_action_map(slug)
+            segment_categories_configured = (
+                action_map is not None
+                and any(action != DEFAULT_SEGMENT_ACTION
+                        for action in action_map.values())
+            )
+
             # Verification stamps every surviving ad so the merge downstream
-            # can distinguish first-pass from verification. The verification
-            # prompt never asks for "category", so category counts are
-            # discarded here, and category_repair_enabled stays False: repair
-            # would be a no-op on every ad and cost a call for nothing.
+            # can distinguish first-pass from verification.
             (final_ads, all_raw_responses, _failed_windows, failure,
-             _category_missing, _category_total,
-             _category_repaired) = self._run_detection_pass(
+             category_missing, category_total,
+             category_repaired) = self._run_detection_pass(
                 windows,
                 pass_label='Verification',
                 model=model,
@@ -2708,9 +2716,25 @@ class AdDetector:
                 pass_name=PASS_AD_DETECTION_2,
                 window_label_prefix='Verification Window',
                 validate_timestamps=False,
+                action_map=action_map,
+                category_repair_enabled=segment_categories_configured,
             )
             if failure is not None:
                 return failure
+
+            if category_repaired > 0:
+                logger.info(
+                    f"[{slug}:{episode_id}] Verification category repair "
+                    f"resolved {category_repaired} missing segment "
+                    f"categor{'y' if category_repaired == 1 else 'ies'}"
+                )
+            if segment_categories_configured and category_missing > 0:
+                logger.warning(
+                    f"[{slug}:{episode_id}] Verification left "
+                    f"{category_missing} of {category_total} detections "
+                    f"uncategorized after repair; they default to sponsor, "
+                    f"so per-category actions may not apply as configured."
+                )
 
             # Single stamping point: dedup returns copies, so stamping the
             # final list covers every surviving ad.
@@ -2736,4 +2760,3 @@ class AdDetector:
             logger.error(f"[{slug}:{episode_id}] Verification detection failed: {e}")
             return {"ads": [], "status": "failed", "error": str(e), "retryable": is_retryable_error(e),
                     "model_not_configured": isinstance(e, ModelNotConfiguredError)}
-

--- a/src/ad_detector/boundaries.py
+++ b/src/ad_detector/boundaries.py
@@ -1137,9 +1137,15 @@ def split_conflicting_action_span(last: dict, current: dict,
     priority = {'remove': 0, 'beep': 1, 'keep': 2}
     last_pattern = bool(last.get('pattern_defined'))
     current_pattern = bool(current.get('pattern_defined'))
+    effective_last_action = (
+        'remove' if last_pattern and last_action == 'keep' else last_action)
+    effective_current_action = (
+        'remove' if current_pattern and current_action == 'keep'
+        else current_action)
     pattern_overrides_keep = (
         last_pattern != current_pattern
-        and 'keep' in (last_action, current_action)
+        and ((last_action == 'keep' and not last_pattern)
+             or (current_action == 'keep' and not current_pattern))
     )
     if (not pattern_overrides_keep
             and (last_action is None or current_action is None)
@@ -1161,9 +1167,10 @@ def split_conflicting_action_span(last: dict, current: dict,
         current_wins = current_pattern
     else:
         current_wins = (
-            last_action is None
-            or current_action is None
-            or priority.get(current_action, 0) >= priority.get(last_action, 0)
+            effective_last_action is None
+            or effective_current_action is None
+            or (priority.get(effective_current_action, 0)
+                >= priority.get(effective_last_action, 0))
         )
     if not current_wins:
         if current['end'] <= last['end']:

--- a/src/ad_detector/boundaries.py
+++ b/src/ad_detector/boundaries.py
@@ -1137,8 +1137,11 @@ def split_conflicting_action_span(last: dict, current: dict,
     priority = {'remove': 0, 'beep': 1, 'keep': 2}
     last_pattern = bool(last.get('pattern_defined'))
     current_pattern = bool(current.get('pattern_defined'))
-    pattern_decides = last_pattern != current_pattern
-    if (not pattern_decides
+    pattern_overrides_keep = (
+        last_pattern != current_pattern
+        and 'keep' in (last_action, current_action)
+    )
+    if (not pattern_overrides_keep
             and (last_action is None or current_action is None)
             and current['end'] > last['end']):
         # Legacy no-action behavior: the earlier marker owns a partial
@@ -1150,10 +1153,11 @@ def split_conflicting_action_span(last: dict, current: dict,
         clamped['start'] = last['end']
         mark_trusted_fragment(clamped, current)
         return last, [clamped]
-    if pattern_decides:
+    if pattern_overrides_keep:
         # A defined pattern is standing operator evidence and deliberately
-        # overrides category actions downstream. Preserve that same policy
-        # while assigning contested audio at the earlier merge seam.
+        # overrides a keep action downstream. Preserve that same policy while
+        # assigning contested audio at the earlier merge seam; beep retains
+        # its normal precedence over remove.
         current_wins = current_pattern
     else:
         current_wins = (

--- a/src/ad_detector/boundaries.py
+++ b/src/ad_detector/boundaries.py
@@ -1107,7 +1107,9 @@ def resolve_category_action(category, action_map: dict[str, str]) -> str:
     return action_map.get(normalize_segment_category(category), DEFAULT_SEGMENT_ACTION)
 
 
-def split_conflicting_action_span(last: dict, current: dict) -> tuple:
+def split_conflicting_action_span(last: dict, current: dict,
+                                  last_action: str | None = None,
+                                  current_action: str | None = None) -> tuple:
     """Resolve two adjacent-or-overlapping ads whose resolved actions differ:
     never merge a keep-resolving detection into a remove-resolving one, and
     never let a span fully nested inside the other collapse to nothing.
@@ -1117,13 +1119,38 @@ def split_conflicting_action_span(last: dict, current: dict) -> tuple:
     consumed) replaces ``last``.
 
     - No true overlap: both survive untouched.
-    - ``current`` fully nested in ``last``: split ``last`` around it so both
-      pieces and the nested span survive.
-    - ``current`` extends past ``last``'s end: clamp its start forward past
-      ``last``'s end so the two spans never double-cut the same audio.
+    When actions are supplied, precedence is keep > beep > remove. The
+    higher-priority action owns contested audio; without actions, preserve
+    the historical behavior where ``current`` owns it.
     """
     if current['start'] >= last['end']:
         return last, [current.copy()]
+
+    priority = {'remove': 0, 'beep': 1, 'keep': 2}
+    if ((last_action is None or current_action is None)
+            and current['end'] > last['end']):
+        # Legacy no-action behavior: the earlier marker owns a partial
+        # overlap. Action-aware callers use explicit precedence below.
+        clamped = current.copy()
+        for key in ('merged_distinct_ads', 'merged_protected_start',
+                    'merged_protected_end'):
+            clamped.pop(key, None)
+        clamped['start'] = last['end']
+        return last, [clamped]
+    current_wins = (
+        last_action is None
+        or current_action is None
+        or priority.get(current_action, 0) >= priority.get(last_action, 0)
+    )
+    if not current_wins:
+        if current['end'] <= last['end']:
+            return last, []
+        after = current.copy()
+        for key in ('merged_distinct_ads', 'merged_protected_start',
+                    'merged_protected_end'):
+            after.pop(key, None)
+        after['start'] = last['end']
+        return last, [after]
 
     if current['end'] <= last['end']:
         # Splitting last invalidates any merged_distinct_ads/
@@ -1145,9 +1172,14 @@ def split_conflicting_action_span(last: dict, current: dict) -> tuple:
             entries.append(after)
         return new_last, entries
 
-    clamped = current.copy()
-    clamped['start'] = last['end']
-    return last, [clamped]
+    shortened_last = last.copy()
+    for key in ('merged_distinct_ads', 'merged_protected_start',
+                'merged_protected_end'):
+        shortened_last.pop(key, None)
+    shortened_last['end'] = current['start']
+    if shortened_last['end'] <= shortened_last['start']:
+        shortened_last = None
+    return shortened_last, [current.copy()]
 
 
 def deduplicate_window_ads(all_ads: list[dict], merge_threshold: float = 5.0,
@@ -1184,13 +1216,15 @@ def deduplicate_window_ads(all_ads: list[dict], merge_threshold: float = 5.0,
 
         # Check for overlap (ads within threshold seconds are considered overlapping)
         if current['start'] <= last['end'] + merge_threshold:
+            last_action = (resolve_category_action(
+                last.get('category'), action_map) if action_map else None)
+            current_action = (resolve_category_action(
+                current.get('category'), action_map) if action_map else None)
             same_action = (
-                action_map is None
-                or resolve_category_action(last.get('category'), action_map)
-                   == resolve_category_action(current.get('category'), action_map)
-            )
+                action_map is None or last_action == current_action)
             if not same_action:
-                new_last, new_entries = split_conflicting_action_span(last, current)
+                new_last, new_entries = split_conflicting_action_span(
+                    last, current, last_action, current_action)
                 if new_last is None:
                     merged.pop()
                 else:

--- a/src/ad_detector/boundaries.py
+++ b/src/ad_detector/boundaries.py
@@ -25,6 +25,7 @@ from config import (
     MIN_KEYWORD_LENGTH, MIN_UNCOVERED_TAIL_DURATION,
     TERMINAL_SNAP_EOF_TOLERANCE_SECONDS,
     DEFAULT_SEGMENT_ACTION, normalize_segment_category,
+    MIN_AD_DURATION_FOR_REMOVAL,
     PATTERN_TIGHTEN_MIN_EXCESS_SECONDS, PATTERN_TIGHTEN_MIN_CONFIDENCE,
 )
 
@@ -1126,6 +1127,13 @@ def split_conflicting_action_span(last: dict, current: dict,
     if current['start'] >= last['end']:
         return last, [current.copy()]
 
+    def mark_trusted_fragment(fragment, parent):
+        if (parent.get('_trusted_split_fragment')
+                or parent['end'] - parent['start']
+                >= MIN_AD_DURATION_FOR_REMOVAL):
+            fragment['_trusted_split_fragment'] = True
+        return fragment
+
     priority = {'remove': 0, 'beep': 1, 'keep': 2}
     if ((last_action is None or current_action is None)
             and current['end'] > last['end']):
@@ -1136,6 +1144,7 @@ def split_conflicting_action_span(last: dict, current: dict,
                     'merged_protected_end'):
             clamped.pop(key, None)
         clamped['start'] = last['end']
+        mark_trusted_fragment(clamped, current)
         return last, [clamped]
     current_wins = (
         last_action is None
@@ -1150,6 +1159,7 @@ def split_conflicting_action_span(last: dict, current: dict,
                     'merged_protected_end'):
             after.pop(key, None)
         after['start'] = last['end']
+        mark_trusted_fragment(after, current)
         return last, [after]
 
     if current['end'] <= last['end']:
@@ -1166,6 +1176,8 @@ def split_conflicting_action_span(last: dict, current: dict,
         after = dict(before)
         after['start'] = current['end']
         after['end'] = last['end']
+        mark_trusted_fragment(before, last)
+        mark_trusted_fragment(after, last)
         new_last = before if before['start'] < before['end'] else None
         entries = [current.copy()]
         if after['start'] < after['end']:
@@ -1177,6 +1189,7 @@ def split_conflicting_action_span(last: dict, current: dict,
                 'merged_protected_end'):
         shortened_last.pop(key, None)
     shortened_last['end'] = current['start']
+    mark_trusted_fragment(shortened_last, last)
     if shortened_last['end'] <= shortened_last['start']:
         shortened_last = None
     return shortened_last, [current.copy()]

--- a/src/ad_detector/boundaries.py
+++ b/src/ad_detector/boundaries.py
@@ -1142,13 +1142,7 @@ def split_conflicting_action_span(last: dict, current: dict,
     effective_current_action = (
         'remove' if current_pattern and current_action == 'keep'
         else current_action)
-    pattern_overrides_keep = (
-        last_pattern != current_pattern
-        and ((last_action == 'keep' and not last_pattern)
-             or (current_action == 'keep' and not current_pattern))
-    )
-    if (not pattern_overrides_keep
-            and (last_action is None or current_action is None)
+    if ((last_action is None or current_action is None)
             and current['end'] > last['end']):
         # Legacy no-action behavior: the earlier marker owns a partial
         # overlap. Action-aware callers use explicit precedence below.
@@ -1159,19 +1153,12 @@ def split_conflicting_action_span(last: dict, current: dict,
         clamped['start'] = last['end']
         mark_trusted_fragment(clamped, current)
         return last, [clamped]
-    if pattern_overrides_keep:
-        # A defined pattern is standing operator evidence and deliberately
-        # overrides a keep action downstream. Preserve that same policy while
-        # assigning contested audio at the earlier merge seam; beep retains
-        # its normal precedence over remove.
-        current_wins = current_pattern
-    else:
-        current_wins = (
-            effective_last_action is None
-            or effective_current_action is None
-            or (priority.get(effective_current_action, 0)
-                >= priority.get(effective_last_action, 0))
-        )
+    current_wins = (
+        effective_last_action is None
+        or effective_current_action is None
+        or (priority.get(effective_current_action, 0)
+            >= priority.get(effective_last_action, 0))
+    )
     if not current_wins:
         if current['end'] <= last['end']:
             return last, []

--- a/src/ad_detector/boundaries.py
+++ b/src/ad_detector/boundaries.py
@@ -1135,7 +1135,11 @@ def split_conflicting_action_span(last: dict, current: dict,
         return fragment
 
     priority = {'remove': 0, 'beep': 1, 'keep': 2}
-    if ((last_action is None or current_action is None)
+    last_pattern = bool(last.get('pattern_defined'))
+    current_pattern = bool(current.get('pattern_defined'))
+    pattern_decides = last_pattern != current_pattern
+    if (not pattern_decides
+            and (last_action is None or current_action is None)
             and current['end'] > last['end']):
         # Legacy no-action behavior: the earlier marker owns a partial
         # overlap. Action-aware callers use explicit precedence below.
@@ -1146,11 +1150,17 @@ def split_conflicting_action_span(last: dict, current: dict,
         clamped['start'] = last['end']
         mark_trusted_fragment(clamped, current)
         return last, [clamped]
-    current_wins = (
-        last_action is None
-        or current_action is None
-        or priority.get(current_action, 0) >= priority.get(last_action, 0)
-    )
+    if pattern_decides:
+        # A defined pattern is standing operator evidence and deliberately
+        # overrides category actions downstream. Preserve that same policy
+        # while assigning contested audio at the earlier merge seam.
+        current_wins = current_pattern
+    else:
+        current_wins = (
+            last_action is None
+            or current_action is None
+            or priority.get(current_action, 0) >= priority.get(last_action, 0)
+        )
     if not current_wins:
         if current['end'] <= last['end']:
             return last, []

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -1047,7 +1047,7 @@ class AdValidator:
         sorted_ads = sorted(ads, key=lambda x: x['start'])
         merged = [sorted_ads[0].copy()]
 
-        def merge_original_twins(last: Dict, current: Dict) -> None:
+        def merge_original_twins(last: dict, current: dict) -> None:
             """Keep a pass-two marker's persisted twin aligned with its merge."""
             original = last.get('_orig_twin')
             current_original = current.get('_orig_twin')

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -1104,6 +1104,8 @@ class AdValidator:
                     last['confidence'] = current['confidence']
                 if current.get('pattern_defined'):
                     last['pattern_defined'] = True
+                if current.get('_trusted_split_fragment'):
+                    last['_trusted_split_fragment'] = True
                 result.corrections.append(f"Merged ads with {gap:.1f}s gap")
             elif 0 <= gap < MAX_SILENT_GAP and not self._has_speech_in_range(last['end'], current['start']):
                 # Merge larger gaps if no speech in between
@@ -1117,6 +1119,8 @@ class AdValidator:
                     last['confidence'] = current['confidence']
                 if current.get('pattern_defined'):
                     last['pattern_defined'] = True
+                if current.get('_trusted_split_fragment'):
+                    last['_trusted_split_fragment'] = True
                 result.corrections.append(f"Merged ads across {gap:.1f}s silent gap")
             else:
                 merged.append(current.copy())

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -1047,6 +1047,17 @@ class AdValidator:
         sorted_ads = sorted(ads, key=lambda x: x['start'])
         merged = [sorted_ads[0].copy()]
 
+        def merge_original_twins(last: Dict, current: Dict) -> None:
+            """Keep a pass-two marker's persisted twin aligned with its merge."""
+            original = last.get('_orig_twin')
+            current_original = current.get('_orig_twin')
+            if original is None or current_original is None:
+                return
+            original['start'] = min(original['start'], current_original['start'])
+            original['end'] = max(original['end'], current_original['end'])
+            if current.get('_trusted_split_fragment'):
+                original['_trusted_split_fragment'] = True
+
         for current in sorted_ads[1:]:
             last = merged[-1]
             gap = current['start'] - last['end']
@@ -1095,6 +1106,7 @@ class AdValidator:
             if 0 <= gap < MERGE_GAP_THRESHOLD:
                 # Always merge small gaps (< 5s)
                 mark_distinct_merge(last, current)
+                merge_original_twins(last, current)
                 last['end'] = max(last['end'], current['end'])
                 if adjacency_extension:
                     last['vad_gap_adjacency_extension_seconds'] = adjacency_extension
@@ -1110,6 +1122,7 @@ class AdValidator:
             elif 0 <= gap < MAX_SILENT_GAP and not self._has_speech_in_range(last['end'], current['start']):
                 # Merge larger gaps if no speech in between
                 mark_distinct_merge(last, current)
+                merge_original_twins(last, current)
                 last['end'] = max(last['end'], current['end'])
                 if adjacency_extension:
                     last['vad_gap_adjacency_extension_seconds'] = adjacency_extension

--- a/src/audio_processor.py
+++ b/src/audio_processor.py
@@ -240,13 +240,17 @@ class AudioProcessor:
                     pass
 
     def compute_applied_cuts(self, ad_segments: list[dict],
-                             total_duration: float) -> list[dict]:
+                             total_duration: float,
+                             end_extension_barriers: list[dict] | None = None
+                             ) -> list[dict]:
         """Compute the cuts remove_ads actually applies to the audio.
 
         Requested segments diverge from applied cuts: near-adjacent segments
         merge, short ones drop, and an end-of-episode cut extends to the end
-        of the file. Asset generation and verification timestamp mapping need
-        the applied list, not the requested one -- remove_ads returns it.
+        of the file. ``end_extension_barriers`` identifies content after the
+        final cut that must prevent that extension. Asset generation and
+        verification timestamp mapping need the applied list, not the
+        requested one -- remove_ads returns it.
         """
         if not ad_segments or not total_duration:
             return []
@@ -326,7 +330,17 @@ class AudioProcessor:
         # cut, the episode ends at the beep, so the cut runs to the end.
         if ads:
             remaining = total_duration - ads[-1]['end']
-            if remaining < POST_ROLL_TRIM_THRESHOLD and ads[-1]['end'] != total_duration:
+            extension_blocked = any(
+                barrier['start'] < total_duration
+                and barrier['end'] > ads[-1]['end']
+                for barrier in end_extension_barriers or []
+            )
+            if extension_blocked:
+                logger.info(
+                    f"End-of-episode cut: preserving content after "
+                    f"{ads[-1]['end']:.1f}s because a keep barrier follows")
+            elif (remaining < POST_ROLL_TRIM_THRESHOLD
+                  and ads[-1]['end'] != total_duration):
                 logger.info(f"End-of-episode cut: extending {ads[-1]['end']:.1f}s -> "
                             f"{total_duration:.1f}s ({remaining:.1f}s would remain)")
                 ads[-1]['end'] = total_duration
@@ -351,7 +365,9 @@ class AudioProcessor:
         return ads
 
     def remove_ads(self, input_path: str, ad_segments: list[dict],
-                   output_path: str) -> list[dict] | None:
+                   output_path: str,
+                   end_extension_barriers: list[dict] | None = None
+                   ) -> list[dict] | None:
         """Remove ad segments from audio file.
 
         Returns the applied cut list (see compute_applied_cuts) on success --
@@ -378,7 +394,9 @@ class AudioProcessor:
 
             logger.info(f"Processing audio: {total_duration:.1f}s total, {len(ad_segments)} ad segments")
 
-            ads = self.compute_applied_cuts(ad_segments, total_duration)
+            ads = self.compute_applied_cuts(
+                ad_segments, total_duration,
+                end_extension_barriers=end_extension_barriers)
             logger.info(f"After merging and filtering: {len(ads)} ad segments")
             if not ads:
                 # Every requested cut merged/filtered away: nothing to cut,
@@ -566,8 +584,9 @@ class AudioProcessor:
             if chapters_meta_path and os.path.exists(chapters_meta_path):
                 os.unlink(chapters_meta_path)
 
-    def process_episode(self, input_path: str,
-                        ad_segments: list[dict]) -> tuple[str, list[dict]] | None:
+    def process_episode(self, input_path: str, ad_segments: list[dict],
+                        end_extension_barriers: list[dict] | None = None
+                        ) -> tuple[str, list[dict]] | None:
         """Process episode audio to remove ads.
 
         Returns (output_path, applied_cuts) on success, None on failure.
@@ -578,7 +597,9 @@ class AudioProcessor:
             temp_output = tmp.name
 
         try:
-            applied_cuts = self.remove_ads(input_path, ad_segments, temp_output)
+            applied_cuts = self.remove_ads(
+                input_path, ad_segments, temp_output,
+                end_extension_barriers=end_extension_barriers)
             if applied_cuts is not None:
                 return temp_output, applied_cuts
             # Clean up on failure

--- a/src/audio_processor.py
+++ b/src/audio_processor.py
@@ -299,11 +299,14 @@ class AudioProcessor:
                     current_segment['confidence'] = ad['confidence']
                 if ad.get('detection_stage') == 'fingerprint':
                     current_segment['detection_stage'] = 'fingerprint'
+                if ad.get('_trusted_split_fragment'):
+                    current_segment['_trusted_split_fragment'] = True
             else:
                 if current_segment:
                     merged_ads.append(current_segment)
                 current_segment = {'start': ad['start'], 'end': ad['end']}
-                for key in ('reason', 'confidence', 'detection_stage', 'beep'):
+                for key in ('reason', 'confidence', 'detection_stage', 'beep',
+                            '_trusted_split_fragment'):
                     if key in ad:
                         current_segment[key] = ad[key]
         if current_segment:
@@ -317,8 +320,10 @@ class AudioProcessor:
         skipped_count = 0
         for ad in merged_ads:
             duration = ad['end'] - ad['start']
+            trusted_split = bool(ad.get('_trusted_split_fragment'))
             trusted = (ad.get('detection_stage') == 'fingerprint'
-                       or ad.get('confidence', 0) >= SHORT_CUT_KEEP_CONFIDENCE)
+                       or ad.get('confidence', 0) >= SHORT_CUT_KEEP_CONFIDENCE
+                       or trusted_split)
             if duration >= MIN_AD_DURATION_FOR_REMOVAL:
                 ads.append(ad)
             elif trusted:
@@ -326,12 +331,15 @@ class AudioProcessor:
                 logger.info(
                     f"Keeping short ad ({duration:.1f}s < {MIN_AD_DURATION_FOR_REMOVAL}s): "
                     f"stage={ad.get('detection_stage', '?')} "
-                    f"confidence={ad.get('confidence', 'n/a')}")
+                    f"confidence={ad.get('confidence', 'n/a')} "
+                    f"trusted_split={trusted_split}")
             else:
                 skipped_count += 1
                 logger.info(f"Skipping short ad ({duration:.1f}s < {MIN_AD_DURATION_FOR_REMOVAL}s): {ad.get('reason', 'unknown')[:50]}")
         if skipped_count > 0:
             logger.info(f"Skipped {skipped_count} short ad detections (< {MIN_AD_DURATION_FOR_REMOVAL}s)")
+        for ad in ads:
+            ad.pop('_trusted_split_fragment', None)
 
         # End-of-episode cut: when less than 30s would remain after the last
         # cut, the episode ends at the beep, so the cut runs to the end.

--- a/src/audio_processor.py
+++ b/src/audio_processor.py
@@ -241,16 +241,16 @@ class AudioProcessor:
 
     def compute_applied_cuts(self, ad_segments: list[dict],
                              total_duration: float,
-                             end_extension_barriers: list[dict] | None = None
+                             cut_barriers: list[dict] | None = None
                              ) -> list[dict]:
         """Compute the cuts remove_ads actually applies to the audio.
 
         Requested segments diverge from applied cuts: near-adjacent segments
         merge, short ones drop, and an end-of-episode cut extends to the end
-        of the file. ``end_extension_barriers`` identifies content after the
-        final cut that must prevent that extension. Asset generation and
-        verification timestamp mapping need the applied list, not the
-        requested one -- remove_ads returns it.
+        of the file. ``cut_barriers`` identifies content that must neither be
+        swallowed by a gap merge nor by that trailing extension. Asset
+        generation and verification timestamp mapping need the applied list,
+        not the requested one -- remove_ads returns it.
         """
         if not ad_segments or not total_duration:
             return []
@@ -274,6 +274,12 @@ class AudioProcessor:
 
         sorted_segments = sorted(clamped, key=lambda x: x['start'])
 
+        def crosses_barrier(start, end):
+            return any(
+                barrier['start'] < end and barrier['end'] > start
+                for barrier in cut_barriers or []
+            )
+
         # Merge segments with < 1 second gaps. Remove and beep spans render
         # differently below, so the gap check also requires matching 'beep' status.
         merged_ads = []
@@ -281,6 +287,7 @@ class AudioProcessor:
         for ad in sorted_segments:
             if (current_segment
                     and ad['start'] - current_segment['end'] < MERGE_GAP_SECONDS
+                    and not crosses_barrier(current_segment['end'], ad['start'])
                     and ad.get('beep', False) == current_segment.get('beep', False)):
                 # Extend current segment (use max to handle overlapping/contained ads)
                 current_segment['end'] = max(current_segment['end'], ad['end'])
@@ -330,11 +337,8 @@ class AudioProcessor:
         # cut, the episode ends at the beep, so the cut runs to the end.
         if ads:
             remaining = total_duration - ads[-1]['end']
-            extension_blocked = any(
-                barrier['start'] < total_duration
-                and barrier['end'] > ads[-1]['end']
-                for barrier in end_extension_barriers or []
-            )
+            extension_blocked = crosses_barrier(
+                ads[-1]['end'], total_duration)
             if extension_blocked:
                 logger.info(
                     f"End-of-episode cut: preserving content after "
@@ -366,7 +370,7 @@ class AudioProcessor:
 
     def remove_ads(self, input_path: str, ad_segments: list[dict],
                    output_path: str,
-                   end_extension_barriers: list[dict] | None = None
+                   cut_barriers: list[dict] | None = None
                    ) -> list[dict] | None:
         """Remove ad segments from audio file.
 
@@ -396,7 +400,7 @@ class AudioProcessor:
 
             ads = self.compute_applied_cuts(
                 ad_segments, total_duration,
-                end_extension_barriers=end_extension_barriers)
+                cut_barriers=cut_barriers)
             logger.info(f"After merging and filtering: {len(ads)} ad segments")
             if not ads:
                 # Every requested cut merged/filtered away: nothing to cut,
@@ -585,7 +589,7 @@ class AudioProcessor:
                 os.unlink(chapters_meta_path)
 
     def process_episode(self, input_path: str, ad_segments: list[dict],
-                        end_extension_barriers: list[dict] | None = None
+                        cut_barriers: list[dict] | None = None
                         ) -> tuple[str, list[dict]] | None:
         """Process episode audio to remove ads.
 
@@ -599,7 +603,7 @@ class AudioProcessor:
         try:
             applied_cuts = self.remove_ads(
                 input_path, ad_segments, temp_output,
-                end_extension_barriers=end_extension_barriers)
+                cut_barriers=cut_barriers)
             if applied_cuts is not None:
                 return temp_output, applied_cuts
             # Clean up on failure

--- a/src/audio_processor.py
+++ b/src/audio_processor.py
@@ -275,6 +275,8 @@ class AudioProcessor:
         sorted_segments = sorted(clamped, key=lambda x: x['start'])
 
         def crosses_barrier(start, end):
+            if end <= start:
+                return False
             return any(
                 barrier['start'] < end and barrier['end'] > start
                 for barrier in cut_barriers or []

--- a/src/main_app/processing.py
+++ b/src/main_app/processing.py
@@ -1361,6 +1361,68 @@ def _partition_pass2_category_actions(processed_ads, original_ads, actions_map):
             kept_processed, kept_original)
 
 
+def _exclude_category_kept_spans(processed_ads, original_ads,
+                                  kept_processed, pass1_cuts):
+    """Subtract category-kept pass-2 spans from the remaining candidates.
+
+    Heuristic roll detection can overlap an LLM marker whose category action
+    is keep. Split the candidate on the processed timeline, then remap each
+    surviving fragment to original coordinates so validation, recutting, and
+    the UI retain paired markers without cutting through the kept audio.
+    """
+    if not kept_processed:
+        return processed_ads, original_ads
+    if len(processed_ads) != len(original_ads):
+        raise ValueError(
+            'Pass-2 processed/original marker lists must stay paired')
+
+    barriers = sorted(
+        ((marker['start'], marker['end']) for marker in kept_processed),
+        key=lambda span: span[0],
+    )
+    timestamp_map = _build_timestamp_map(pass1_cuts)
+    replacement_duration = get_replacement_duration()
+    surviving_processed = []
+    surviving_original = []
+
+    for processed, original in zip(processed_ads, original_ads):
+        fragments = [(processed['start'], processed['end'])]
+        for barrier_start, barrier_end in barriers:
+            next_fragments = []
+            for start, end in fragments:
+                if barrier_end <= start or barrier_start >= end:
+                    next_fragments.append((start, end))
+                    continue
+                if start < barrier_start:
+                    next_fragments.append((start, barrier_start))
+                if barrier_end < end:
+                    next_fragments.append((barrier_end, end))
+            fragments = next_fragments
+
+        if fragments == [(processed['start'], processed['end'])]:
+            surviving_processed.append(processed)
+            surviving_original.append(original)
+            continue
+
+        audio_logger.info(
+            f"Pass-2 candidate {processed['start']:.1f}s-"
+            f"{processed['end']:.1f}s split around category-kept audio into "
+            f"{len(fragments)} removable fragment(s)")
+        for start, end in fragments:
+            fragment_processed = dict(processed, start=start, end=end)
+            fragment_original = dict(
+                original,
+                start=_map_to_original(
+                    start, timestamp_map, replacement_duration),
+                end=_map_to_original(
+                    end, timestamp_map, replacement_duration),
+            )
+            surviving_processed.append(fragment_processed)
+            surviving_original.append(fragment_original)
+
+    return surviving_processed, surviving_original
+
+
 def _stamp_pass2_cut_actions(processed_cuts, original_cuts, actions_map):
     """Stamp remove/beep only after pass-2 candidates become actual cuts.
 
@@ -2156,7 +2218,7 @@ def _pass2_cuts_in_original(recut_applied, pass1_cuts):
 
 def _recut_processed_audio(slug, episode_id, processed_path, v_ads_to_cut,
                             local_audio_processor,
-                            end_extension_barriers=None):
+                            cut_barriers=None):
     """Re-cut the pass-1 processed audio with verification ads.
 
     Returns (processed_path, recut_applied, recut_ok) where recut_applied is
@@ -2170,7 +2232,7 @@ def _recut_processed_audio(slug, episode_id, processed_path, v_ads_to_cut,
                       for ad in v_ads_to_cut]
     recut_result = local_audio_processor.process_episode(
         processed_path, audio_segments,
-        end_extension_barriers=end_extension_barriers)
+        cut_barriers=cut_barriers)
     if recut_result:
         recut_path, recut_applied = recut_result
         if os.path.exists(processed_path):
@@ -2318,6 +2380,14 @@ def _run_verification_pass(ctx, processed_path, pass1_cuts,
                 f"{len(category_kept)} segment(s) by category action"
             )
 
+        (verification_ads_processed,
+         verification_ads_original) = _exclude_category_kept_spans(
+            verification_ads_processed,
+            verification_ads_original,
+            category_kept_processed,
+            pass1_cuts,
+        )
+
         had_verification_candidates = bool(verification_ads_processed)
         if verification_ads_processed:
             audio_logger.info(f"[{slug}:{episode_id}] Verification found {len(verification_ads_processed)} missed ads")
@@ -2382,7 +2452,7 @@ def _run_verification_pass(ctx, processed_path, pass1_cuts,
                     processed_path, recut_applied, recut_ok = _recut_processed_audio(
                         slug, episode_id, processed_path, v_ads_to_cut,
                         local_audio_processor,
-                        end_extension_barriers=category_kept_processed,
+                        cut_barriers=category_kept_processed,
                     )
                     if recut_ok:
                         _drop_uncovered_pass2_ads(

--- a/src/main_app/processing.py
+++ b/src/main_app/processing.py
@@ -1484,6 +1484,16 @@ def _reconcile_pass2_cut_actions(processed_cuts, original_cuts, pass1_cuts):
         [pair[0] for pair in remove_pairs],
         [pair[1] for pair in remove_pairs],
     )
+    for beep_processed, beep_original in beep_pairs:
+        if any(
+            beep_processed['start'] < remove_processed_ad['end']
+            and beep_processed['end'] > remove_processed_ad['start']
+            for remove_processed_ad in remove_processed
+        ):
+            # This beep is the boundary that preserves its contested audio,
+            # so it must survive the renderer's short-cut confidence floor.
+            beep_processed['_trusted_split_fragment'] = True
+            beep_original['_trusted_split_fragment'] = True
     remove_processed, remove_original = _split_pass2_candidates_around_spans(
         remove_processed,
         remove_original,

--- a/src/main_app/processing.py
+++ b/src/main_app/processing.py
@@ -128,6 +128,7 @@ from main_app.verification_reconciliation import (
     _drop_uncovered_pass2_ads,
     _exclude_kept_spans_from_verification,
     _gate_verification_ads_by_confidence,
+    _pass2_keep_barriers_processed,
     _proposed_span_agrees,  # noqa: F401 re-exported for processing.<name> test patch targets
 )
 # Singletons created in main_app/__init__.py before this submodule is
@@ -2387,6 +2388,11 @@ def _run_verification_pass(ctx, processed_path, pass1_cuts,
             category_kept_processed,
             pass1_cuts,
         )
+        keep_barriers_processed = _pass2_keep_barriers_processed(
+            pass1_kept_markers,
+            pass1_cuts,
+            category_kept_processed,
+        )
 
         had_verification_candidates = bool(verification_ads_processed)
         if verification_ads_processed:
@@ -2410,7 +2416,7 @@ def _run_verification_pass(ctx, processed_path, pass1_cuts,
                     cue_gate_enabled=cue_gate_enabled,
                     podcast_id=ctx.podcast_id,
                     segment_actions=segment_actions,
-                    keep_barriers_processed=category_kept_processed,
+                    keep_barriers_processed=keep_barriers_processed,
                 )
 
             if verification_ads_processed:
@@ -2452,7 +2458,7 @@ def _run_verification_pass(ctx, processed_path, pass1_cuts,
                     processed_path, recut_applied, recut_ok = _recut_processed_audio(
                         slug, episode_id, processed_path, v_ads_to_cut,
                         local_audio_processor,
-                        cut_barriers=category_kept_processed,
+                        cut_barriers=keep_barriers_processed,
                     )
                     if recut_ok:
                         _drop_uncovered_pass2_ads(

--- a/src/main_app/processing.py
+++ b/src/main_app/processing.py
@@ -2155,7 +2155,8 @@ def _pass2_cuts_in_original(recut_applied, pass1_cuts):
 
 
 def _recut_processed_audio(slug, episode_id, processed_path, v_ads_to_cut,
-                            local_audio_processor):
+                            local_audio_processor,
+                            end_extension_barriers=None):
     """Re-cut the pass-1 processed audio with verification ads.
 
     Returns (processed_path, recut_applied, recut_ok) where recut_applied is
@@ -2167,7 +2168,9 @@ def _recut_processed_audio(slug, episode_id, processed_path, v_ads_to_cut,
     # instead of silently falling back to a full remove.
     audio_segments = [dict(ad, beep=(ad.get('action_applied') == 'beep'))
                       for ad in v_ads_to_cut]
-    recut_result = local_audio_processor.process_episode(processed_path, audio_segments)
+    recut_result = local_audio_processor.process_episode(
+        processed_path, audio_segments,
+        end_extension_barriers=end_extension_barriers)
     if recut_result:
         recut_path, recut_applied = recut_result
         if os.path.exists(processed_path):
@@ -2379,6 +2382,7 @@ def _run_verification_pass(ctx, processed_path, pass1_cuts,
                     processed_path, recut_applied, recut_ok = _recut_processed_audio(
                         slug, episode_id, processed_path, v_ads_to_cut,
                         local_audio_processor,
+                        end_extension_barriers=category_kept_processed,
                     )
                     if recut_ok:
                         _drop_uncovered_pass2_ads(

--- a/src/main_app/processing.py
+++ b/src/main_app/processing.py
@@ -1362,23 +1362,18 @@ def _partition_pass2_category_actions(processed_ads, original_ads, actions_map):
             kept_processed, kept_original)
 
 
-def _exclude_category_kept_spans(processed_ads, original_ads,
-                                  kept_processed, pass1_cuts):
-    """Subtract category-kept pass-2 spans from the remaining candidates.
-
-    Heuristic roll detection can overlap an LLM marker whose category action
-    is keep. Split the candidate on the processed timeline, then remap each
-    surviving fragment to original coordinates so validation, recutting, and
-    the UI retain paired markers without cutting through the kept audio.
-    """
-    if not kept_processed:
+def _split_pass2_candidates_around_spans(processed_ads, original_ads,
+                                          barriers_processed, pass1_cuts,
+                                          barrier_label):
+    """Split paired pass-2 candidates around protected processed spans."""
+    if not barriers_processed:
         return processed_ads, original_ads
     if len(processed_ads) != len(original_ads):
         raise ValueError(
             'Pass-2 processed/original marker lists must stay paired')
 
     barriers = sorted(
-        ((marker['start'], marker['end']) for marker in kept_processed),
+        ((marker['start'], marker['end']) for marker in barriers_processed),
         key=lambda span: span[0],
     )
     timestamp_map = _build_timestamp_map(pass1_cuts)
@@ -1407,7 +1402,7 @@ def _exclude_category_kept_spans(processed_ads, original_ads,
 
         audio_logger.info(
             f"Pass-2 candidate {processed['start']:.1f}s-"
-            f"{processed['end']:.1f}s split around category-kept audio into "
+            f"{processed['end']:.1f}s split around {barrier_label} into "
             f"{len(fragments)} removable fragment(s)")
         for start, end in fragments:
             fragment_processed = dict(processed, start=start, end=end)
@@ -1424,6 +1419,20 @@ def _exclude_category_kept_spans(processed_ads, original_ads,
     return surviving_processed, surviving_original
 
 
+def _exclude_category_kept_spans(processed_ads, original_ads,
+                                  kept_processed, pass1_cuts):
+    """Subtract category-kept pass-2 spans from remaining candidates.
+
+    Heuristic roll detection can overlap an LLM marker whose category action
+    is keep. Split the candidate on the processed timeline, then remap each
+    surviving fragment to original coordinates so validation, recutting, and
+    the UI retain paired markers without cutting through the kept audio.
+    """
+    return _split_pass2_candidates_around_spans(
+        processed_ads, original_ads, kept_processed, pass1_cuts,
+        'category-kept audio')
+
+
 def _stamp_pass2_cut_actions(processed_cuts, original_cuts, actions_map):
     """Stamp remove/beep only after pass-2 candidates become actual cuts.
 
@@ -1437,6 +1446,47 @@ def _stamp_pass2_cut_actions(processed_cuts, original_cuts, actions_map):
         if action not in ('remove', 'beep'):
             action = DEFAULT_SEGMENT_ACTION
         marker['action_applied'] = action
+
+
+def _reconcile_pass2_cut_actions(processed_cuts, original_cuts, pass1_cuts):
+    """Make actual pass-2 cuts disjoint when their render actions differ.
+
+    A beep preserves timeline duration while remove shrinks it, so overlapping
+    spans cannot both reach ffmpeg. Beep is explicit protected replacement
+    intent: split remove candidates around the beep spans, then restore a
+    time-ordered paired list for recutting and UI persistence.
+    """
+    if len(processed_cuts) != len(original_cuts):
+        raise ValueError(
+            'Pass-2 processed/original cut lists must stay paired')
+
+    beep_pairs = [
+        (processed, original)
+        for processed, original in zip(processed_cuts, original_cuts)
+        if processed.get('action_applied') == 'beep'
+    ]
+    if not beep_pairs:
+        return processed_cuts, original_cuts
+    remove_pairs = [
+        (processed, original)
+        for processed, original in zip(processed_cuts, original_cuts)
+        if processed.get('action_applied') != 'beep'
+    ]
+    remove_processed, remove_original = (
+        [pair[0] for pair in remove_pairs],
+        [pair[1] for pair in remove_pairs],
+    )
+    remove_processed, remove_original = _split_pass2_candidates_around_spans(
+        remove_processed,
+        remove_original,
+        [pair[0] for pair in beep_pairs],
+        pass1_cuts,
+        'beep-replacement audio',
+    )
+    reconciled = [*beep_pairs, *zip(remove_processed, remove_original)]
+    reconciled.sort(key=lambda pair: pair[0]['start'])
+    return ([pair[0] for pair in reconciled],
+            [pair[1] for pair in reconciled])
 
 
 def _refine_and_validate(slug, episode_id, all_ads, segments, audio_path,
@@ -2446,6 +2496,8 @@ def _run_verification_pass(ctx, processed_path, pass1_cuts,
 
                 _stamp_pass2_cut_actions(
                     v_ads_to_cut, v_ads_for_ui, segment_actions)
+                v_ads_to_cut, v_ads_for_ui = _reconcile_pass2_cut_actions(
+                    v_ads_to_cut, v_ads_for_ui, pass1_cuts)
 
                 if v_ads_to_cut:
                     audio_logger.info(

--- a/src/main_app/processing.py
+++ b/src/main_app/processing.py
@@ -1335,7 +1335,7 @@ def _partition_pass2_category_actions(processed_ads, original_ads, actions_map):
     if len(processed_ads) != len(original_ads):
         raise ValueError(
             'Pass-2 processed/original marker lists must stay paired')
-    for processed, original in zip(processed_ads, original_ads):
+    for processed, original in zip(processed_ads, original_ads, strict=True):
         category = normalize_segment_category(
             processed.get('category', original.get('category')))
         action = actions_map.get(category, DEFAULT_SEGMENT_ACTION)
@@ -1382,7 +1382,7 @@ def _split_pass2_candidates_around_spans(processed_ads, original_ads,
     surviving_processed = []
     surviving_original = []
 
-    for processed, original in zip(processed_ads, original_ads):
+    for processed, original in zip(processed_ads, original_ads, strict=True):
         fragments = [(processed['start'], processed['end'])]
         for barrier_start, barrier_end in barriers:
             next_fragments = []
@@ -1475,14 +1475,14 @@ def _reconcile_pass2_cut_actions(processed_cuts, original_cuts, pass1_cuts):
 
     beep_pairs = [
         (processed, original)
-        for processed, original in zip(processed_cuts, original_cuts)
+        for processed, original in zip(processed_cuts, original_cuts, strict=True)
         if processed.get('action_applied') == 'beep'
     ]
     if not beep_pairs:
         return processed_cuts, original_cuts
     remove_pairs = [
         (processed, original)
-        for processed, original in zip(processed_cuts, original_cuts)
+        for processed, original in zip(processed_cuts, original_cuts, strict=True)
         if processed.get('action_applied') != 'beep'
     ]
     remove_processed, remove_original = (
@@ -1506,7 +1506,7 @@ def _reconcile_pass2_cut_actions(processed_cuts, original_cuts, pass1_cuts):
         pass1_cuts,
         'beep-replacement audio',
     )
-    reconciled = [*beep_pairs, *zip(remove_processed, remove_original)]
+    reconciled = [*beep_pairs, *zip(remove_processed, remove_original, strict=True)]
     reconciled.sort(key=lambda pair: pair[0]['start'])
     return ([pair[0] for pair in reconciled],
             [pair[1] for pair in reconciled])

--- a/src/main_app/processing.py
+++ b/src/main_app/processing.py
@@ -1318,14 +1318,17 @@ def _partition_pass2_category_actions(processed_ads, original_ads, actions_map):
     Pass 2 has parallel processed/original coordinate lists, so its keep
     partition cannot reuse the single-list pass-1 helper. Kept candidates are
     removed from both detection lists before validation and reviewer routing;
-    their original-coordinate marker is returned for persistence. Remaining
-    candidates remain unstamped until confidence gating and review decide
-    which ones the recut will actually render.
+    both coordinate copies are returned so the processed marker can protect a
+    kept tail from the validator's end-of-episode extension while the original
+    marker is persisted. Remaining candidates remain unstamped until confidence
+    gating and review decide which ones the recut will actually render.
 
-    Returns ``(remaining_processed, remaining_original, kept_original)``.
+    Returns ``(remaining_processed, remaining_original, kept_processed,
+    kept_original)``.
     """
     remaining_processed = []
     remaining_original = []
+    kept_processed = []
     kept_original = []
     if len(processed_ads) != len(original_ads):
         raise ValueError(
@@ -1344,6 +1347,7 @@ def _partition_pass2_category_actions(processed_ads, original_ads, actions_map):
                     marker['hold_cleared_reason'] = marker.get('hold_reason')
                     marker['held_for_review'] = False
                     marker.pop('hold_reason', None)
+            kept_processed.append(processed)
             kept_original.append(original)
             continue
 
@@ -1353,7 +1357,8 @@ def _partition_pass2_category_actions(processed_ads, original_ads, actions_map):
         remaining_processed.append(processed)
         remaining_original.append(original)
 
-    return remaining_processed, remaining_original, kept_original
+    return (remaining_processed, remaining_original,
+            kept_processed, kept_original)
 
 
 def _stamp_pass2_cut_actions(processed_cuts, original_cuts, actions_map):
@@ -1936,7 +1941,8 @@ def _validate_verification_ads(slug, episode_id, verification_ads_processed,
                                 processed_duration=None,
                                 max_ad_duration_override=None,
                                 cue_gate_enabled=False, podcast_id=None,
-                                segment_actions=None):
+                                segment_actions=None,
+                                keep_barriers_processed=None):
     """Validate pass-2 ad candidates against processed-coordinate validator.
 
     Maps pass-1 user FP corrections from original to processed coordinates,
@@ -1950,6 +1956,11 @@ def _validate_verification_ads(slug, episode_id, verification_ads_processed,
     verification ads can never carry cue evidence (snap is pass-1 only), so on
     a cue-gated feed every pass-2 proposal will be held -- intended conservative
     behavior.
+
+    ``keep_barriers_processed`` contains category-kept pass-2 markers removed
+    from the cut candidates. Validator-only copies stay in the ordered span
+    list so a removable candidate before a kept tail cannot be extended through
+    that tail to the end of the episode.
 
     Returns (verification_ads_processed, verification_ads_original).
     """
@@ -1999,8 +2010,16 @@ def _validate_verification_ads(slug, episode_id, verification_ads_processed,
     for proc, orig in zip(verification_ads_processed, verification_ads_original, strict=True):
         proc['_orig_twin'] = orig
 
+    validation_input = list(verification_ads_processed)
+    for marker in keep_barriers_processed or []:
+        barrier = marker.copy()
+        barrier['_pass2_keep_barrier'] = True
+        # Also prevent a merge when validation is called without an action map.
+        barrier['held_for_review'] = True
+        validation_input.append(barrier)
+
     v_validation = v_validator.validate(
-        verification_ads_processed, actions_map=segment_actions)
+        validation_input, actions_map=segment_actions)
 
     # validate() worked on copies; strip the key from the input dicts too so
     # no later consumer of the raw verification result can serialize it.
@@ -2009,6 +2028,8 @@ def _validate_verification_ads(slug, episode_id, verification_ads_processed,
 
     kept_processed, kept_original = [], []
     for ad in v_validation.ads:
+        if ad.pop('_pass2_keep_barrier', False):
+            continue
         # Strip the pairing key from every validator output (rejected ones
         # included) so it can never leak into serialized payloads.
         orig = ad.pop('_orig_twin', None)
@@ -2281,6 +2302,7 @@ def _run_verification_pass(ctx, processed_path, pass1_cuts,
 
         (verification_ads_processed,
          verification_ads_original,
+         category_kept_processed,
          category_kept) = _partition_pass2_category_actions(
             verification_ads_processed,
             verification_ads_original,
@@ -2315,6 +2337,7 @@ def _run_verification_pass(ctx, processed_path, pass1_cuts,
                     cue_gate_enabled=cue_gate_enabled,
                     podcast_id=ctx.podcast_id,
                     segment_actions=segment_actions,
+                    keep_barriers_processed=category_kept_processed,
                 )
 
             if verification_ads_processed:

--- a/src/main_app/processing.py
+++ b/src/main_app/processing.py
@@ -1405,11 +1405,14 @@ def _split_pass2_candidates_around_spans(processed_ads, original_ads,
             f"Pass-2 candidate {processed['start']:.1f}s-"
             f"{processed['end']:.1f}s split around {barrier_label} into "
             f"{len(fragments)} removable fragment(s)")
+        trusted_fragment = (
+            processed.get('_trusted_split_fragment')
+            or processed['end'] - processed['start']
+            >= MIN_AD_DURATION_FOR_REMOVAL
+        )
         for start, end in fragments:
             fragment_processed = dict(processed, start=start, end=end)
-            if (processed.get('_trusted_split_fragment')
-                    or processed['end'] - processed['start']
-                    >= MIN_AD_DURATION_FOR_REMOVAL):
+            if trusted_fragment:
                 # The parent cleared the renderer's duration floor before a
                 # protected keep/beep span carved it into smaller pieces.
                 # Validation still decides whether each piece is a cut.
@@ -1421,6 +1424,8 @@ def _split_pass2_candidates_around_spans(processed_ads, original_ads,
                 end=_map_to_original(
                     end, timestamp_map, replacement_duration),
             )
+            if trusted_fragment:
+                fragment_original['_trusted_split_fragment'] = True
             surviving_processed.append(fragment_processed)
             surviving_original.append(fragment_original)
 

--- a/src/main_app/processing.py
+++ b/src/main_app/processing.py
@@ -1312,6 +1312,55 @@ def _stamp_pass2_marker_categories(markers):
     return markers
 
 
+def _partition_pass2_category_actions(processed_ads, original_ads, actions_map):
+    """Apply the feed's category actions to paired pass-2 candidates.
+
+    Pass 2 has parallel processed/original coordinate lists, so its keep
+    partition cannot reuse the single-list pass-1 helper. Kept candidates are
+    removed from both detection lists before validation and reviewer routing;
+    their original-coordinate marker is returned for persistence. Remaining
+    candidates are stamped remove/beep in both coordinate spaces so the recut
+    renders the configured action.
+
+    Returns ``(remaining_processed, remaining_original, kept_original)``.
+    """
+    remaining_processed = []
+    remaining_original = []
+    kept_original = []
+    if len(processed_ads) != len(original_ads):
+        raise ValueError(
+            'Pass-2 processed/original marker lists must stay paired')
+    for processed, original in zip(processed_ads, original_ads):
+        category = normalize_segment_category(
+            processed.get('category', original.get('category')))
+        action = actions_map.get(category, DEFAULT_SEGMENT_ACTION)
+        pattern_defined = bool(
+            processed.get('pattern_defined') or original.get('pattern_defined'))
+        if action == 'keep' and not pattern_defined:
+            for marker in (processed, original):
+                marker['was_cut'] = False
+                marker['action_applied'] = 'keep'
+                if marker.get('held_for_review'):
+                    marker['hold_cleared_reason'] = marker.get('hold_reason')
+                    marker['held_for_review'] = False
+                    marker.pop('hold_reason', None)
+            kept_original.append(original)
+            continue
+
+        if action == 'keep':
+            action = DEFAULT_SEGMENT_ACTION
+            processed['keep_overridden_by_pattern'] = True
+            original['keep_overridden_by_pattern'] = True
+        if action not in ('remove', 'beep'):
+            action = DEFAULT_SEGMENT_ACTION
+        processed['action_applied'] = action
+        original['action_applied'] = action
+        remaining_processed.append(processed)
+        remaining_original.append(original)
+
+    return remaining_processed, remaining_original, kept_original
+
+
 def _refine_and_validate(slug, episode_id, all_ads, segments, audio_path,
                           episode_description, episode_duration, min_cut_confidence,
                           podcast_name, skip_patterns=False, positional_prior=None,
@@ -1876,7 +1925,8 @@ def _validate_verification_ads(slug, episode_id, verification_ads_processed,
                                 min_cut_confidence, db,
                                 processed_duration=None,
                                 max_ad_duration_override=None,
-                                cue_gate_enabled=False, podcast_id=None):
+                                cue_gate_enabled=False, podcast_id=None,
+                                segment_actions=None):
     """Validate pass-2 ad candidates against processed-coordinate validator.
 
     Maps pass-1 user FP corrections from original to processed coordinates,
@@ -1939,7 +1989,8 @@ def _validate_verification_ads(slug, episode_id, verification_ads_processed,
     for proc, orig in zip(verification_ads_processed, verification_ads_original, strict=True):
         proc['_orig_twin'] = orig
 
-    v_validation = v_validator.validate(verification_ads_processed)
+    v_validation = v_validator.validate(
+        verification_ads_processed, actions_map=segment_actions)
 
     # validate() worked on copies; strip the key from the input dicts too so
     # no later consumer of the raw verification result can serialize it.
@@ -2106,7 +2157,7 @@ def _run_verification_pass(ctx, processed_path, pass1_cuts,
                             original_segments=None, reuse_transcript=False,
                             max_ad_duration_override=None, cue_gate_enabled=False,
                             pass1_held_markers=None, pass1_kept_markers=None,
-                            skip_verification=False):
+                            skip_verification=False, segment_actions=None):
     """Pipeline stage: Run verification (second pass) on processed audio.
 
     ``pass1_cuts`` must be the cuts ffmpeg actually applied (see
@@ -2147,6 +2198,8 @@ def _run_verification_pass(ctx, processed_path, pass1_cuts,
     verification_cue_count = 0
     v_corroborated_count = 0
     clear_fallback(episode_id, PASS_AD_DETECTION_2)
+    if segment_actions is None:
+        segment_actions = db.resolve_segment_actions(slug)
 
     # Read once per verification pass: standalone-miss hold/autocut floors
     # for _gate_verification_ads_by_confidence (registry defaults when unset).
@@ -2204,6 +2257,20 @@ def _run_verification_pass(ctx, processed_path, pass1_cuts,
             pass1_cuts, podcast_name, skip_patterns,
         )
 
+        (verification_ads_processed,
+         verification_ads_original,
+         category_kept) = _partition_pass2_category_actions(
+            verification_ads_processed,
+            verification_ads_original,
+            segment_actions,
+        )
+        if category_kept:
+            v_ads_held.extend(category_kept)
+            audio_logger.info(
+                f"[{slug}:{episode_id}] Verification kept "
+                f"{len(category_kept)} segment(s) by category action"
+            )
+
         if verification_ads_processed:
             audio_logger.info(f"[{slug}:{episode_id}] Verification found {len(verification_ads_processed)} missed ads")
 
@@ -2224,6 +2291,7 @@ def _run_verification_pass(ctx, processed_path, pass1_cuts,
                     max_ad_duration_override=max_ad_duration_override,
                     cue_gate_enabled=cue_gate_enabled,
                     podcast_id=ctx.podcast_id,
+                    segment_actions=segment_actions,
                 )
 
             # Kept-span exclusion: must run before any finding is routed to
@@ -2234,13 +2302,15 @@ def _run_verification_pass(ctx, processed_path, pass1_cuts,
             )
             if verification_ads_processed:
                 # Confidence gate and re-cut
-                v_ads_to_cut, v_ads_for_ui, v_ads_held, v_corroborated_count = _gate_verification_ads_by_confidence(
+                (v_ads_to_cut, v_ads_for_ui, gated_held,
+                 v_corroborated_count) = _gate_verification_ads_by_confidence(
                     verification_ads_processed, verification_ads_original,
                     min_cut_confidence,
                     pass1_held_markers=pass1_held_markers,
                     verification_miss_hold_min_confidence=verification_miss_hold_min_confidence,
                     verification_miss_autocut_min_confidence=verification_miss_autocut_min_confidence,
                 )
+                v_ads_held.extend(gated_held)
 
                 # Pass 2 reviewer operates on original-coord ads (the prompt
                 # context window comes from the original transcript). Adjust
@@ -2279,11 +2349,10 @@ def _run_verification_pass(ctx, processed_path, pass1_cuts,
                     else:
                         v_ads_for_ui = []
 
-            # Added after the gate assigns v_ads_held, so the reassignment
-            # above cannot discard them. Held ads must never also enter
-            # v_ads_for_ui or the marker is saved twice.
+            # Kept conflicts are disjoint from the gate output. Uncut markers
+            # must never also enter v_ads_for_ui or they would be saved twice.
             v_ads_held.extend(kept_conflicts)
-        else:
+        elif not category_kept:
             audio_logger.info(f"[{slug}:{episode_id}] Verification: clean")
 
         verification_ok = True
@@ -4097,6 +4166,7 @@ def process_episode(slug: str, episode_id: str, episode_url: str,
                 pass1_held_markers=pass1_held_markers,
                 pass1_kept_markers=pass1_kept_markers,
                 skip_verification=skip_detection or skip_second_pass or cue_only,
+                segment_actions=segment_actions,
             )
             # Detection-event accounting, not unique cues (issue #350): a cue
             # in a region pass 1 left in the audio is re-detected here and
@@ -4133,10 +4203,10 @@ def process_episode(slug: str, episode_id: str, episode_url: str,
             _check_cancel(cancel_event, slug, episode_id)
 
             # Merge pass 2 ads into combined list for UI.
-            # v_ads_held (held-for-review originals) merge here too so they
-            # survive into persisted markers with was_cut=False; they are kept
-            # separate from v_ads_for_ui so the reviewer pool and asset mapping
-            # are never contaminated with held ads.
+            # v_ads_held (held-for-review and category-kept originals) merge
+            # here too so every uncut pass-2 marker survives persistence. They
+            # stay separate from v_ads_for_ui so the reviewer pool and asset
+            # mapping are never contaminated with uncut ads.
             merge_v = _dedupe_pass2_markers(
                 _stamp_pass2_marker_categories(v_ads_for_ui + v_ads_held))
             # Corroboration stamps mutated markers already in

--- a/src/main_app/processing.py
+++ b/src/main_app/processing.py
@@ -3441,16 +3441,24 @@ def _build_recut_ad_list(slug, episode_id, segments, episode_duration,
         all_ads, audio_analysis=audio_analysis, actions_map=segment_actions)
 
     # Force previously-cut markers back to ACCEPT so the gate cuts them again,
-    # overriding any hold/review outcome from re-validation. FP/confirm rejects
-    # (early-returns in the validator) clear the stamp is not involved -- a
-    # user's later FP rejection is a REJECT, not a resurrection, and the stamp
-    # only fires for ads the validator did not early-reject. Guard: never
-    # override a fresh REJECT so a new FP correction still wins.
+    # overriding any hold/review outcome from re-validation. A trusted fragment
+    # split from a validated cut also survives the validator's short-duration
+    # rejection. Other fresh REJECTs, including later FP corrections, still win.
     for ad in validation_result.ads:
         if ad.pop('_saved_was_cut', False):
             decision = ad.get('validation', {}).get('decision')
             if decision == Decision.REJECT.value:
-                continue
+                error_flags = [
+                    flag for flag in ad.get('validation', {}).get('flags', [])
+                    if flag.startswith('ERROR:')
+                ]
+                trusted_duration_reject = (
+                    ad.get('_trusted_split_fragment')
+                    and error_flags
+                    and all('Very short' in flag for flag in error_flags)
+                )
+                if not trusted_duration_reject:
+                    continue
             ad.pop('held_for_review', None)
             ad.pop('hold_reason', None)
             ad.setdefault('validation', {})['decision'] = Decision.ACCEPT.value

--- a/src/main_app/processing.py
+++ b/src/main_app/processing.py
@@ -37,6 +37,7 @@ from utils.time import (
 from verification_pass import _build_timestamp_map, _map_correction_to_processed, _map_to_original
 from config import (
     MIN_CUT_CONFIDENCE, MAX_EPISODE_RETRIES,
+    MIN_AD_DURATION_FOR_REMOVAL,
     MIN_CONTENT_BETWEEN_ADS_SECONDS,
     AUDIO_CUE_PAIR_CONFIDENCE, AUDIO_CUE_PAIR_ORIENT_WINDOW_SECONDS,
     CORRECTION_MATCH_MIN_COVERAGE,
@@ -1406,6 +1407,13 @@ def _split_pass2_candidates_around_spans(processed_ads, original_ads,
             f"{len(fragments)} removable fragment(s)")
         for start, end in fragments:
             fragment_processed = dict(processed, start=start, end=end)
+            if (processed.get('_trusted_split_fragment')
+                    or processed['end'] - processed['start']
+                    >= MIN_AD_DURATION_FOR_REMOVAL):
+                # The parent cleared the renderer's duration floor before a
+                # protected keep/beep span carved it into smaller pieces.
+                # Validation still decides whether each piece is a cut.
+                fragment_processed['_trusted_split_fragment'] = True
             fragment_original = dict(
                 original,
                 start=_map_to_original(

--- a/src/main_app/processing.py
+++ b/src/main_app/processing.py
@@ -1319,8 +1319,8 @@ def _partition_pass2_category_actions(processed_ads, original_ads, actions_map):
     partition cannot reuse the single-list pass-1 helper. Kept candidates are
     removed from both detection lists before validation and reviewer routing;
     their original-coordinate marker is returned for persistence. Remaining
-    candidates are stamped remove/beep in both coordinate spaces so the recut
-    renders the configured action.
+    candidates remain unstamped until confidence gating and review decide
+    which ones the recut will actually render.
 
     Returns ``(remaining_processed, remaining_original, kept_original)``.
     """
@@ -1348,17 +1348,27 @@ def _partition_pass2_category_actions(processed_ads, original_ads, actions_map):
             continue
 
         if action == 'keep':
-            action = DEFAULT_SEGMENT_ACTION
             processed['keep_overridden_by_pattern'] = True
             original['keep_overridden_by_pattern'] = True
-        if action not in ('remove', 'beep'):
-            action = DEFAULT_SEGMENT_ACTION
-        processed['action_applied'] = action
-        original['action_applied'] = action
         remaining_processed.append(processed)
         remaining_original.append(original)
 
     return remaining_processed, remaining_original, kept_original
+
+
+def _stamp_pass2_cut_actions(processed_cuts, original_cuts, actions_map):
+    """Stamp remove/beep only after pass-2 candidates become actual cuts.
+
+    Validation and review may still divert a candidate into a hold or reject
+    it. Delaying the stamp keeps those uncut markers from advertising a cut
+    seam or replacement range to downstream chapter generation.
+    """
+    for marker in [*processed_cuts, *original_cuts]:
+        category = normalize_segment_category(marker.get('category'))
+        action = actions_map.get(category, DEFAULT_SEGMENT_ACTION)
+        if action not in ('remove', 'beep'):
+            action = DEFAULT_SEGMENT_ACTION
+        marker['action_applied'] = action
 
 
 def _refine_and_validate(slug, episode_id, all_ads, segments, audio_path,
@@ -2257,6 +2267,18 @@ def _run_verification_pass(ctx, processed_path, pass1_cuts,
             pass1_cuts, podcast_name, skip_patterns,
         )
 
+        # A pass-1 keep is operator intent. Divert overlaps before category
+        # partitioning so a same-category keep does not become a duplicate
+        # pass-2 marker and no conflicting finding can reach validation.
+        (verification_ads_processed,
+         verification_ads_original,
+         kept_conflicts) = _exclude_kept_spans_from_verification(
+            verification_ads_processed,
+            verification_ads_original,
+            pass1_kept_markers,
+            pass1_cuts,
+        )
+
         (verification_ads_processed,
          verification_ads_original,
          category_kept) = _partition_pass2_category_actions(
@@ -2271,6 +2293,7 @@ def _run_verification_pass(ctx, processed_path, pass1_cuts,
                 f"{len(category_kept)} segment(s) by category action"
             )
 
+        had_verification_candidates = bool(verification_ads_processed)
         if verification_ads_processed:
             audio_logger.info(f"[{slug}:{episode_id}] Verification found {len(verification_ads_processed)} missed ads")
 
@@ -2294,12 +2317,6 @@ def _run_verification_pass(ctx, processed_path, pass1_cuts,
                     segment_actions=segment_actions,
                 )
 
-            # Kept-span exclusion: must run before any finding is routed to
-            # a cut, a hold, or a dropped-miss log line.
-            verification_ads_processed, verification_ads_original, kept_conflicts = _exclude_kept_spans_from_verification(
-                verification_ads_processed, verification_ads_original,
-                pass1_kept_markers, pass1_cuts,
-            )
             if verification_ads_processed:
                 # Confidence gate and re-cut
                 (v_ads_to_cut, v_ads_for_ui, gated_held,
@@ -2325,6 +2342,9 @@ def _run_verification_pass(ctx, processed_path, pass1_cuts,
                     cue_gate_enabled=cue_gate_enabled,
                 )
 
+                _stamp_pass2_cut_actions(
+                    v_ads_to_cut, v_ads_for_ui, segment_actions)
+
                 if v_ads_to_cut:
                     audio_logger.info(
                         f"[{slug}:{episode_id}] Re-cutting pass 1 output for "
@@ -2349,10 +2369,12 @@ def _run_verification_pass(ctx, processed_path, pass1_cuts,
                     else:
                         v_ads_for_ui = []
 
-            # Kept conflicts are disjoint from the gate output. Uncut markers
-            # must never also enter v_ads_for_ui or they would be saved twice.
-            v_ads_held.extend(kept_conflicts)
-        elif not category_kept:
+        # Kept conflicts are disjoint from the category and confidence output.
+        # They remain uncut and must never also enter v_ads_for_ui.
+        v_ads_held.extend(kept_conflicts)
+        if (not had_verification_candidates
+                and not category_kept
+                and not kept_conflicts):
             audio_logger.info(f"[{slug}:{episode_id}] Verification: clean")
 
         verification_ok = True

--- a/src/main_app/verification_reconciliation.py
+++ b/src/main_app/verification_reconciliation.py
@@ -345,9 +345,10 @@ def _drop_uncovered_pass2_ads(slug, episode_id, v_ads_to_cut, v_ads_for_ui,
                                      verification_ads_original, strict=True)}
     # Action reconciliation can replace a candidate with split copies after
     # validation. Prefer the final cut/UI pairing so a short split fragment
-    # filtered by AudioProcessor also removes its exact UI marker.
+    # filtered by AudioProcessor also removes its exact UI marker. Not
+    # strict: a cut can legitimately lack a UI twin (e.g. merged spans).
     twin.update({id(p): o for p, o in zip(v_ads_to_cut, v_ads_for_ui,
-                                          strict=True)})
+                                          strict=False)})
     for ad in [a for a in v_ads_to_cut
                if not _covered_by_cuts(a, recut_applied, total_duration)]:
         v_ads_to_cut.remove(ad)

--- a/src/main_app/verification_reconciliation.py
+++ b/src/main_app/verification_reconciliation.py
@@ -113,6 +113,23 @@ def _corroborated_span(hold, orig_ad):
     }
 
 
+def _pass2_keep_barriers_processed(pass1_kept_markers, pass1_cuts,
+                                    category_kept_processed=None):
+    """Collect every keep marker on the pass-1 processed timeline."""
+    replacement_duration = get_replacement_duration()
+    pass1_processed = [
+        dict(
+            marker,
+            start=adjust_timestamp(
+                marker['start'], pass1_cuts, replacement_duration),
+            end=adjust_timestamp(
+                marker['end'], pass1_cuts, replacement_duration),
+        )
+        for marker in pass1_kept_markers or []
+    ]
+    return [*pass1_processed, *(category_kept_processed or [])]
+
+
 def _exclude_kept_spans_from_verification(verification_ads_processed,
                                            verification_ads_original,
                                            pass1_kept_markers, pass1_cuts):
@@ -135,11 +152,10 @@ def _exclude_kept_spans_from_verification(verification_ads_processed,
     """
     if not pass1_kept_markers:
         return verification_ads_processed, verification_ads_original, []
-    replacement_duration = get_replacement_duration()
     kept_spans_processed = [
-        (adjust_timestamp(m['start'], pass1_cuts, replacement_duration),
-         adjust_timestamp(m['end'], pass1_cuts, replacement_duration))
-        for m in pass1_kept_markers
+        (marker['start'], marker['end'])
+        for marker in _pass2_keep_barriers_processed(
+            pass1_kept_markers, pass1_cuts)
     ]
     surviving_processed = []
     surviving_original = []

--- a/src/main_app/verification_reconciliation.py
+++ b/src/main_app/verification_reconciliation.py
@@ -343,6 +343,11 @@ def _drop_uncovered_pass2_ads(slug, episode_id, v_ads_to_cut, v_ads_for_ui,
     """
     twin = {id(p): o for p, o in zip(verification_ads_processed,
                                      verification_ads_original, strict=True)}
+    # Action reconciliation can replace a candidate with split copies after
+    # validation. Prefer the final cut/UI pairing so a short split fragment
+    # filtered by AudioProcessor also removes its exact UI marker.
+    twin.update({id(p): o for p, o in zip(v_ads_to_cut, v_ads_for_ui,
+                                          strict=True)})
     for ad in [a for a in v_ads_to_cut
                if not _covered_by_cuts(a, recut_applied, total_duration)]:
         v_ads_to_cut.remove(ad)

--- a/src/verification_pass.py
+++ b/src/verification_pass.py
@@ -13,7 +13,6 @@ coordinates for cutting.
 import logging
 
 from audio_processor import get_replacement_duration
-from config import DEFAULT_SEGMENT_ACTION, normalize_segment_category
 from transcript_generator import TranscriptGenerator
 from utils.errors import ServiceUnavailableError, AudioExtractionError
 from utils.language import get_feed_language_override
@@ -199,29 +198,12 @@ class VerificationPass:
                 f"confidence={ad.get('confidence', 'N/A')}"
             )
 
-        # Feed only action-eligible missed ads back to pattern learning. A
-        # category configured as keep is intentional content, not a false
-        # negative; learning it can create a pattern_defined marker that later
-        # overrides the keep action and cuts the same content.
-        action_map = verification_result.get('segment_actions')
-        learning_ads = original_ads
-        if action_map is not None:
-            learning_ads = [
-                ad for ad in original_ads
-                if action_map.get(
-                    normalize_segment_category(ad.get('category')),
-                    DEFAULT_SEGMENT_ACTION,
-                ) != 'keep'
-            ]
-            skipped = len(original_ads) - len(learning_ads)
-            if skipped:
-                logger.info(
-                    f"[{slug}:{episode_id}] Verification: excluded {skipped} "
-                    f"category-kept detection(s) from miss learning")
-        if self.pattern_service and learning_ads:
+        # Match first-pass learning: a kept marker still represents a real ad
+        # read and remains eligible for pattern learning.
+        if self.pattern_service and original_ads:
             try:
                 self.pattern_service.record_verification_misses(
-                    slug, episode_id, learning_ads, segments=original_segments
+                    slug, episode_id, original_ads, segments=original_segments
                 )
             except Exception as e:
                 logger.warning(f"[{slug}:{episode_id}] Failed to record verification misses: {e}")

--- a/src/verification_pass.py
+++ b/src/verification_pass.py
@@ -13,6 +13,7 @@ coordinates for cutting.
 import logging
 
 from audio_processor import get_replacement_duration
+from config import DEFAULT_SEGMENT_ACTION, normalize_segment_category
 from transcript_generator import TranscriptGenerator
 from utils.errors import ServiceUnavailableError, AudioExtractionError
 from utils.language import get_feed_language_override
@@ -198,11 +199,29 @@ class VerificationPass:
                 f"confidence={ad.get('confidence', 'N/A')}"
             )
 
-        # Feed missed ads back to pattern service for learning
-        if self.pattern_service and original_ads:
+        # Feed only action-eligible missed ads back to pattern learning. A
+        # category configured as keep is intentional content, not a false
+        # negative; learning it can create a pattern_defined marker that later
+        # overrides the keep action and cuts the same content.
+        action_map = verification_result.get('segment_actions')
+        learning_ads = original_ads
+        if action_map is not None:
+            learning_ads = [
+                ad for ad in original_ads
+                if action_map.get(
+                    normalize_segment_category(ad.get('category')),
+                    DEFAULT_SEGMENT_ACTION,
+                ) != 'keep'
+            ]
+            skipped = len(original_ads) - len(learning_ads)
+            if skipped:
+                logger.info(
+                    f"[{slug}:{episode_id}] Verification: excluded {skipped} "
+                    f"category-kept detection(s) from miss learning")
+        if self.pattern_service and learning_ads:
             try:
                 self.pattern_service.record_verification_misses(
-                    slug, episode_id, original_ads, segments=original_segments
+                    slug, episode_id, learning_ads, segments=original_segments
                 )
             except Exception as e:
                 logger.warning(f"[{slug}:{episode_id}] Failed to record verification misses: {e}")

--- a/tests/unit/test_ad_detector.py
+++ b/tests/unit/test_ad_detector.py
@@ -662,7 +662,7 @@ class TestSplitConflictingActionSpan:
         assert new_last['_trusted_split_fragment'] is True
         assert entries[1]['_trusted_split_fragment'] is True
 
-    def test_defined_pattern_owns_overlap_with_later_keep(self):
+    def test_later_keep_owns_overlap_with_defined_remove_pattern(self):
         last = {
             'start': 100.0, 'end': 150.0, 'category': 'sponsor',
             'pattern_defined': True,
@@ -674,11 +674,10 @@ class TestSplitConflictingActionSpan:
         new_last, entries = split_conflicting_action_span(
             last, current, 'remove', 'keep')
 
-        assert new_last == last
-        assert entries[0]['start'] == 150.0
-        assert entries[0]['end'] == 170.0
+        assert new_last['end'] == 130.0
+        assert entries == [current]
 
-    def test_later_defined_pattern_owns_overlap_with_keep(self):
+    def test_keep_owns_overlap_with_later_defined_remove_pattern(self):
         last = {
             'start': 100.0, 'end': 150.0, 'category': 'self_promo',
         }
@@ -690,8 +689,25 @@ class TestSplitConflictingActionSpan:
         new_last, entries = split_conflicting_action_span(
             last, current, 'keep', 'remove')
 
-        assert new_last['end'] == 130.0
-        assert entries == [current]
+        assert new_last == last
+        assert entries[0]['start'] == 150.0
+        assert entries[0]['end'] == 170.0
+
+    def test_keep_owns_overlap_with_later_defined_beep_pattern(self):
+        last = {
+            'start': 100.0, 'end': 150.0, 'category': 'self_promo',
+        }
+        current = {
+            'start': 130.0, 'end': 170.0, 'category': 'outro',
+            'pattern_defined': True,
+        }
+
+        new_last, entries = split_conflicting_action_span(
+            last, current, 'keep', 'beep')
+
+        assert new_last == last
+        assert entries[0]['start'] == 150.0
+        assert entries[0]['end'] == 170.0
 
     def test_defined_pattern_yields_overlap_to_beep(self):
         last = {

--- a/tests/unit/test_ad_detector.py
+++ b/tests/unit/test_ad_detector.py
@@ -623,6 +623,28 @@ class TestSplitConflictingActionSpan:
         assert entries[0]['start'] == 25.0
         assert entries[0]['end'] == 30.0
 
+    def test_later_keep_owns_partial_overlap_with_remove(self):
+        last = {'start': 100.0, 'end': 150.0, 'category': 'sponsor'}
+        current = {'start': 130.0, 'end': 170.0, 'category': 'self_promo'}
+
+        new_last, entries = split_conflicting_action_span(
+            last, current, 'remove', 'keep')
+
+        assert new_last['start'] == 100.0
+        assert new_last['end'] == 130.0
+        assert entries == [current]
+
+    def test_later_remove_yields_partial_overlap_to_keep(self):
+        last = {'start': 100.0, 'end': 150.0, 'category': 'self_promo'}
+        current = {'start': 130.0, 'end': 170.0, 'category': 'sponsor'}
+
+        new_last, entries = split_conflicting_action_span(
+            last, current, 'keep', 'remove')
+
+        assert new_last == last
+        assert entries[0]['start'] == 150.0
+        assert entries[0]['end'] == 170.0
+
     def test_current_nested_inside_last_splits_last_around_it(self):
         """The DTNS 5317 shape: a longer remove-resolving pattern match
         fully containing a shorter keep-resolving LLM span (e.g. an intro

--- a/tests/unit/test_ad_detector.py
+++ b/tests/unit/test_ad_detector.py
@@ -662,6 +662,37 @@ class TestSplitConflictingActionSpan:
         assert new_last['_trusted_split_fragment'] is True
         assert entries[1]['_trusted_split_fragment'] is True
 
+    def test_defined_pattern_owns_overlap_with_later_keep(self):
+        last = {
+            'start': 100.0, 'end': 150.0, 'category': 'sponsor',
+            'pattern_defined': True,
+        }
+        current = {
+            'start': 130.0, 'end': 170.0, 'category': 'self_promo',
+        }
+
+        new_last, entries = split_conflicting_action_span(
+            last, current, 'remove', 'keep')
+
+        assert new_last == last
+        assert entries[0]['start'] == 150.0
+        assert entries[0]['end'] == 170.0
+
+    def test_later_defined_pattern_owns_overlap_with_keep(self):
+        last = {
+            'start': 100.0, 'end': 150.0, 'category': 'self_promo',
+        }
+        current = {
+            'start': 130.0, 'end': 170.0, 'category': 'sponsor',
+            'pattern_defined': True,
+        }
+
+        new_last, entries = split_conflicting_action_span(
+            last, current, 'keep', 'remove')
+
+        assert new_last['end'] == 130.0
+        assert entries == [current]
+
     def test_current_nested_inside_last_splits_last_around_it(self):
         """The DTNS 5317 shape: a longer remove-resolving pattern match
         fully containing a shorter keep-resolving LLM span (e.g. an intro

--- a/tests/unit/test_ad_detector.py
+++ b/tests/unit/test_ad_detector.py
@@ -693,6 +693,21 @@ class TestSplitConflictingActionSpan:
         assert new_last['end'] == 130.0
         assert entries == [current]
 
+    def test_defined_pattern_yields_overlap_to_beep(self):
+        last = {
+            'start': 100.0, 'end': 150.0, 'category': 'sponsor',
+            'pattern_defined': True,
+        }
+        current = {
+            'start': 130.0, 'end': 170.0, 'category': 'self_promo',
+        }
+
+        new_last, entries = split_conflicting_action_span(
+            last, current, 'remove', 'beep')
+
+        assert new_last['end'] == 130.0
+        assert entries == [current]
+
     def test_current_nested_inside_last_splits_last_around_it(self):
         """The DTNS 5317 shape: a longer remove-resolving pattern match
         fully containing a shorter keep-resolving LLM span (e.g. an intro

--- a/tests/unit/test_ad_detector.py
+++ b/tests/unit/test_ad_detector.py
@@ -645,6 +645,23 @@ class TestSplitConflictingActionSpan:
         assert entries[0]['start'] == 150.0
         assert entries[0]['end'] == 170.0
 
+    def test_nested_keep_split_marks_short_remove_fragments_trusted(self):
+        last = {
+            'start': 100.0, 'end': 126.0, 'category': 'sponsor',
+            'confidence': 0.85,
+        }
+        current = {
+            'start': 108.0, 'end': 118.0, 'category': 'self_promo',
+        }
+
+        new_last, entries = split_conflicting_action_span(
+            last, current, 'remove', 'keep')
+
+        assert (new_last['start'], new_last['end']) == (100.0, 108.0)
+        assert (entries[1]['start'], entries[1]['end']) == (118.0, 126.0)
+        assert new_last['_trusted_split_fragment'] is True
+        assert entries[1]['_trusted_split_fragment'] is True
+
     def test_current_nested_inside_last_splits_last_around_it(self):
         """The DTNS 5317 shape: a longer remove-resolving pattern match
         fully containing a shorter keep-resolving LLM span (e.g. an intro

--- a/tests/unit/test_ad_detector.py
+++ b/tests/unit/test_ad_detector.py
@@ -708,6 +708,21 @@ class TestSplitConflictingActionSpan:
         assert new_last['end'] == 130.0
         assert entries == [current]
 
+    def test_defined_keep_pattern_yields_overlap_to_beep(self):
+        last = {
+            'start': 100.0, 'end': 150.0, 'category': 'self_promo',
+            'pattern_defined': True,
+        }
+        current = {
+            'start': 130.0, 'end': 170.0, 'category': 'sponsor',
+        }
+
+        new_last, entries = split_conflicting_action_span(
+            last, current, 'keep', 'beep')
+
+        assert new_last['end'] == 130.0
+        assert entries == [current]
+
     def test_current_nested_inside_last_splits_last_around_it(self):
         """The DTNS 5317 shape: a longer remove-resolving pattern match
         fully containing a shorter keep-resolving LLM span (e.g. an intro

--- a/tests/unit/test_compute_applied_cuts.py
+++ b/tests/unit/test_compute_applied_cuts.py
@@ -71,7 +71,7 @@ def test_kept_tail_blocks_end_of_episode_extension(processor):
     beep = processor.get_beep_duration()
     cuts = processor.compute_applied_cuts(
         [{'start': 100.0, 'end': 140.0}], 170.0,
-        end_extension_barriers=[{'start': 145.0, 'end': 165.0}],
+        cut_barriers=[{'start': 145.0, 'end': 165.0}],
     )
 
     assert cuts == [
@@ -83,11 +83,25 @@ def test_earlier_keep_does_not_block_trailing_extension(processor):
     beep = processor.get_beep_duration()
     cuts = processor.compute_applied_cuts(
         [{'start': 130.0, 'end': 165.0}], 170.0,
-        end_extension_barriers=[{'start': 100.0, 'end': 120.0}],
+        cut_barriers=[{'start': 100.0, 'end': 120.0}],
     )
 
     assert cuts == [
         {'start': 130.0, 'end': 170.0, 'replacement_duration': beep},
+    ]
+
+
+def test_keep_barrier_prevents_cut_fragments_from_remerging(processor):
+    beep = processor.get_beep_duration()
+    cuts = processor.compute_applied_cuts(
+        [{'start': 100.0, 'end': 112.0},
+         {'start': 112.5, 'end': 125.0}], 600.0,
+        cut_barriers=[{'start': 112.0, 'end': 112.5}],
+    )
+
+    assert cuts == [
+        {'start': 100.0, 'end': 112.0, 'replacement_duration': beep},
+        {'start': 112.5, 'end': 125.0, 'replacement_duration': beep},
     ]
 
 

--- a/tests/unit/test_compute_applied_cuts.py
+++ b/tests/unit/test_compute_applied_cuts.py
@@ -169,6 +169,19 @@ def test_short_cut_without_trust_fields_dropped(processor):
     assert cuts == []
 
 
+def test_short_fragment_split_from_valid_cut_is_kept(processor):
+    cuts = processor.compute_applied_cuts(
+        [{'start': 100.0, 'end': 108.0, 'confidence': 0.85,
+          '_trusted_split_fragment': True}],
+        600.0,
+    )
+
+    assert len(cuts) == 1
+    assert cuts[0]['start'] == 100.0
+    assert cuts[0]['end'] == 108.0
+    assert '_trusted_split_fragment' not in cuts[0]
+
+
 def test_merge_carries_strongest_trust_signal(processor):
     # Two sub-10s spans merge into one >10s span; survives the floor anyway,
     # but the merged dict must carry the max confidence and fingerprint stage

--- a/tests/unit/test_compute_applied_cuts.py
+++ b/tests/unit/test_compute_applied_cuts.py
@@ -41,6 +41,16 @@ def test_contained_cut_merges_to_outer_end(processor):
     assert cuts == [{'start': 100.0, 'end': 160.0, 'replacement_duration': beep}]
 
 
+def test_overlapping_cuts_merge_despite_surrounding_barrier(processor):
+    beep = processor.get_beep_duration()
+    cuts = processor.compute_applied_cuts(
+        [{'start': 100.0, 'end': 160.0}, {'start': 110.0, 'end': 120.0}],
+        600.0,
+        cut_barriers=[{'start': 90.0, 'end': 170.0}],
+    )
+    assert cuts == [{'start': 100.0, 'end': 160.0, 'replacement_duration': beep}]
+
+
 def test_short_cut_dropped(processor):
     beep = processor.get_beep_duration()
     cuts = processor.compute_applied_cuts(
@@ -70,8 +80,8 @@ def test_end_of_episode_cut_extends_to_total_duration(processor):
 def test_kept_tail_blocks_end_of_episode_extension(processor):
     beep = processor.get_beep_duration()
     cuts = processor.compute_applied_cuts(
-        [{'start': 100.0, 'end': 140.0}], 170.0,
-        cut_barriers=[{'start': 145.0, 'end': 165.0}],
+        [{'start': 100.0, 'end': 140.0}], 165.0,
+        cut_barriers=[{'start': 145.0, 'end': 160.0}],
     )
 
     assert cuts == [

--- a/tests/unit/test_compute_applied_cuts.py
+++ b/tests/unit/test_compute_applied_cuts.py
@@ -67,6 +67,30 @@ def test_end_of_episode_cut_extends_to_total_duration(processor):
     assert requested[0]['end'] == 580.0
 
 
+def test_kept_tail_blocks_end_of_episode_extension(processor):
+    beep = processor.get_beep_duration()
+    cuts = processor.compute_applied_cuts(
+        [{'start': 100.0, 'end': 140.0}], 170.0,
+        end_extension_barriers=[{'start': 145.0, 'end': 165.0}],
+    )
+
+    assert cuts == [
+        {'start': 100.0, 'end': 140.0, 'replacement_duration': beep},
+    ]
+
+
+def test_earlier_keep_does_not_block_trailing_extension(processor):
+    beep = processor.get_beep_duration()
+    cuts = processor.compute_applied_cuts(
+        [{'start': 130.0, 'end': 165.0}], 170.0,
+        end_extension_barriers=[{'start': 100.0, 'end': 120.0}],
+    )
+
+    assert cuts == [
+        {'start': 130.0, 'end': 170.0, 'replacement_duration': beep},
+    ]
+
+
 def test_no_end_trim_when_enough_content_remains(processor):
     beep = processor.get_beep_duration()
     cuts = processor.compute_applied_cuts([{'start': 500.0, 'end': 560.0}], 600.0)

--- a/tests/unit/test_cut_partition.py
+++ b/tests/unit/test_cut_partition.py
@@ -328,7 +328,10 @@ class TestProcessEpisodeCallSiteUniformity:
 
     def test_every_call_site_passes_audio_segments(self):
         source = inspect.getsource(processing)
-        calls = re.findall(r'\.process_episode\(\s*[^,]+,\s*(\w+)\)', source)
+        calls = re.findall(
+            r'\.process_episode\(\s*[^,]+,\s*(\w+)(?:,\s*[^)]*)?\)',
+            source,
+        )
         assert len(calls) >= 3, (
             f"expected at least the pass-1, pass-2-recut, and recut-mode "
             f"call sites, found {calls}")

--- a/tests/unit/test_cut_partition.py
+++ b/tests/unit/test_cut_partition.py
@@ -20,9 +20,9 @@ Under test:
 - call-site uniformity: every AudioProcessor.process_episode call in
   processing.py derives 'beep' from action_applied
 """
+import ast
 import filecmp
 import inspect
-import re
 import shutil
 import subprocess
 import time
@@ -328,14 +328,21 @@ class TestProcessEpisodeCallSiteUniformity:
 
     def test_every_call_site_passes_audio_segments(self):
         source = inspect.getsource(processing)
-        calls = re.findall(
-            r'\.process_episode\(\s*[^,]+,\s*(\w+)(?:,\s*[^)]*)?\)',
-            source,
-        )
+        calls = [
+            node for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == 'process_episode'
+        ]
         assert len(calls) >= 3, (
             f"expected at least the pass-1, pass-2-recut, and recut-mode "
             f"call sites, found {calls}")
-        assert all(name == 'audio_segments' for name in calls), calls
+        assert all(
+            len(call.args) >= 2
+            and isinstance(call.args[1], ast.Name)
+            and call.args[1].id == 'audio_segments'
+            for call in calls
+        ), calls
 
 
 def _beep_marker(start=10.0, end=25.0):

--- a/tests/unit/test_keep_bypass.py
+++ b/tests/unit/test_keep_bypass.py
@@ -737,6 +737,42 @@ class TestPartitionPass2CategoryActions:
         assert barriers[1] is pass2_keep
         assert (pass1_keep['start'], pass1_keep['end']) == (100.0, 120.0)
 
+    def test_remove_candidate_splits_around_beep_candidate(self):
+        remove_processed = {
+            'start': 100.0, 'end': 180.0, 'action_applied': 'remove',
+        }
+        remove_original = {
+            'start': 119.0, 'end': 199.0, 'action_applied': 'remove',
+        }
+        beep_processed = {
+            'start': 130.0, 'end': 150.0, 'action_applied': 'beep',
+        }
+        beep_original = {
+            'start': 149.0, 'end': 169.0, 'action_applied': 'beep',
+        }
+        pass1_cuts = [
+            {'start': 50.0, 'end': 70.0, 'replacement_duration': 1.0},
+        ]
+
+        out_p, out_o = processing._reconcile_pass2_cut_actions(
+            [remove_processed, beep_processed],
+            [remove_original, beep_original],
+            pass1_cuts,
+        )
+
+        assert [(ad['start'], ad['end'], ad['action_applied'])
+                for ad in out_p] == [
+            (100.0, 130.0, 'remove'),
+            (130.0, 150.0, 'beep'),
+            (150.0, 180.0, 'remove'),
+        ]
+        assert [(ad['start'], ad['end'], ad['action_applied'])
+                for ad in out_o] == [
+            (119.0, 149.0, 'remove'),
+            (149.0, 169.0, 'beep'),
+            (169.0, 199.0, 'remove'),
+        ]
+
     def test_run_verification_persists_keep_without_recut(self):
         ctx = types.SimpleNamespace(
             slug='pass2-actions', episode_id='ep1', podcast_id=1,

--- a/tests/unit/test_keep_bypass.py
+++ b/tests/unit/test_keep_bypass.py
@@ -25,6 +25,7 @@ from unittest.mock import patch
 
 import main_app.processing as processing
 from api.patterns import _matches_held_marker
+from audio_processor import AudioProcessor
 from config import count_pending_review, HOLD_REASON_VERIFICATION_KEPT_CONFLICT
 
 SEGMENTS = [{'start': 0.0, 'end': 5.0, 'text': 'hello'},
@@ -773,6 +774,33 @@ class TestPartitionPass2CategoryActions:
             (149.0, 169.0, 'beep'),
             (169.0, 199.0, 'remove'),
         ]
+
+    def test_short_beep_barrier_stays_eligible_for_recut(self):
+        remove_processed = {
+            'start': 100.0, 'end': 130.0, 'action_applied': 'remove',
+        }
+        remove_original = {
+            'start': 100.0, 'end': 130.0, 'action_applied': 'remove',
+        }
+        beep_processed = {
+            'start': 110.0, 'end': 118.0, 'action_applied': 'beep',
+            'confidence': 0.85,
+        }
+        beep_original = dict(beep_processed)
+
+        out_p, out_o = processing._reconcile_pass2_cut_actions(
+            [remove_processed, beep_processed],
+            [remove_original, beep_original], [],
+        )
+
+        short_beep = next(ad for ad in out_p if ad['action_applied'] == 'beep')
+        assert short_beep['_trusted_split_fragment'] is True
+        applied = AudioProcessor().compute_applied_cuts(
+            [dict(short_beep, beep=True)], 200.0)
+        assert [(ad['start'], ad['end'], ad['replacement_duration'])
+                for ad in applied] == [(110.0, 118.0, 8.0)]
+        assert next(ad for ad in out_o if ad['action_applied'] == 'beep')[
+            '_trusted_split_fragment'] is True
 
     def test_run_verification_persists_keep_without_recut(self):
         ctx = types.SimpleNamespace(

--- a/tests/unit/test_keep_bypass.py
+++ b/tests/unit/test_keep_bypass.py
@@ -721,6 +721,22 @@ class TestPartitionPass2CategoryActions:
         assert out_p == []
         assert out_o == []
 
+    def test_pass1_and_pass2_keeps_share_processed_barrier_list(self):
+        pass1_keep = {'start': 100.0, 'end': 120.0, 'action_applied': 'keep'}
+        pass2_keep = {'start': 200.0, 'end': 220.0, 'action_applied': 'keep'}
+        pass1_cuts = [
+            {'start': 20.0, 'end': 40.0, 'replacement_duration': 1.0},
+        ]
+
+        barriers = processing._pass2_keep_barriers_processed(
+            [pass1_keep], pass1_cuts, [pass2_keep])
+
+        assert [(marker['start'], marker['end']) for marker in barriers] == [
+            (81.0, 101.0), (200.0, 220.0),
+        ]
+        assert barriers[1] is pass2_keep
+        assert (pass1_keep['start'], pass1_keep['end']) == (100.0, 120.0)
+
     def test_run_verification_persists_keep_without_recut(self):
         ctx = types.SimpleNamespace(
             slug='pass2-actions', episode_id='ep1', podcast_id=1,

--- a/tests/unit/test_keep_bypass.py
+++ b/tests/unit/test_keep_bypass.py
@@ -636,7 +636,7 @@ class TestPartitionPass2CategoryActions:
 
     @pytest.mark.parametrize(
         ('category', 'expected'), [('sponsor', 'remove'), ('outro', 'beep')])
-    def test_cut_actions_are_stamped_in_both_coordinate_spaces(
+    def test_cut_actions_are_delayed_until_candidate_reaches_recut(
             self, category, expected):
         processed, original = self._pair(category)
 
@@ -646,6 +646,11 @@ class TestPartitionPass2CategoryActions:
         assert out_p == [processed]
         assert out_o == [original]
         assert kept == []
+        assert 'action_applied' not in processed
+        assert 'action_applied' not in original
+
+        processing._stamp_pass2_cut_actions(out_p, out_o, self.ACTIONS)
+
         assert processed['action_applied'] == expected
         assert original['action_applied'] == expected
 
@@ -659,8 +664,12 @@ class TestPartitionPass2CategoryActions:
         assert out_o == [original]
         assert kept == []
         for marker in (processed, original):
-            assert marker['action_applied'] == 'remove'
+            assert 'action_applied' not in marker
             assert marker['keep_overridden_by_pattern'] is True
+
+        processing._stamp_pass2_cut_actions(out_p, out_o, self.ACTIONS)
+        assert processed['action_applied'] == 'remove'
+        assert original['action_applied'] == 'remove'
 
     def test_missing_category_uses_conservative_sponsor_action(self):
         processed = {'start': 10.0, 'end': 20.0}
@@ -672,6 +681,10 @@ class TestPartitionPass2CategoryActions:
         assert out_p == [processed]
         assert out_o == [original]
         assert kept == []
+        assert 'action_applied' not in processed
+        assert 'action_applied' not in original
+
+        processing._stamp_pass2_cut_actions(out_p, out_o, self.ACTIONS)
         assert processed['action_applied'] == 'remove'
         assert original['action_applied'] == 'remove'
 
@@ -711,6 +724,48 @@ class TestPartitionPass2CategoryActions:
         assert result[6] is True
         assert original['action_applied'] == 'keep'
         assert original['was_cut'] is False
+
+    def test_pass1_keep_overlap_is_diverted_before_category_keep_partition(self):
+        ctx = types.SimpleNamespace(
+            slug='pass2-actions', episode_id='ep1', podcast_id=1,
+            podcast_name='Test Show', episode_title='Episode',
+            episode_description=None, podcast_description=None,
+        )
+        processed = {
+            'start': 110.0, 'end': 120.0, 'confidence': 0.95,
+            'category': 'self_promo',
+        }
+        original = dict(processed)
+
+        with ExitStack() as stack:
+            db = stack.enter_context(patch.object(processing, 'db'))
+            stack.enter_context(patch.object(processing, 'storage'))
+            stack.enter_context(patch.object(
+                processing, '_apply_pass2_heuristic_rolls'))
+            verifier_cls = stack.enter_context(
+                patch('verification_pass.VerificationPass'))
+            verifier_cls.return_value.verify.return_value = {
+                'ads': [original],
+                'ads_processed': [processed],
+                'segments': SEGMENTS,
+                'status': 'success',
+            }
+            db.get_setting_float.return_value = 0.6
+
+            result = processing._run_verification_pass(
+                ctx, '/tmp/pass2-actions.mp3', [], False, 0.8,
+                types.SimpleNamespace(), None,
+                pass1_kept_markers=[{
+                    'start': 110.0, 'end': 120.0,
+                    'action_applied': 'keep',
+                }],
+                segment_actions=self.ACTIONS,
+            )
+
+        assert result[1] == []
+        assert result[3] == [original]
+        assert original['hold_reason'] == 'verification_kept_conflict'
+        assert 'action_applied' not in original
 
 
 def test_dedupe_pass2_markers_collapses_repeats():

--- a/tests/unit/test_keep_bypass.py
+++ b/tests/unit/test_keep_bypass.py
@@ -706,6 +706,7 @@ class TestPartitionPass2CategoryActions:
         assert [(ad['start'], ad['end']) for ad in out_p] == [
             (100.0, 130.0), (150.0, 180.0),
         ]
+        assert all(ad['_trusted_split_fragment'] is True for ad in out_p)
         assert [(ad['start'], ad['end']) for ad in out_o] == [
             (119.0, 149.0), (169.0, 199.0),
         ]

--- a/tests/unit/test_keep_bypass.py
+++ b/tests/unit/test_keep_bypass.py
@@ -711,6 +711,7 @@ class TestPartitionPass2CategoryActions:
         assert [(ad['start'], ad['end']) for ad in out_o] == [
             (119.0, 149.0), (169.0, 199.0),
         ]
+        assert all(ad['_trusted_split_fragment'] is True for ad in out_o)
         assert all(ad['reason'] == 'heuristic roll' for ad in out_p + out_o)
 
     def test_kept_audio_covering_candidate_drops_it(self):

--- a/tests/unit/test_keep_bypass.py
+++ b/tests/unit/test_keep_bypass.py
@@ -14,6 +14,8 @@ import tempfile
 import types
 from contextlib import ExitStack
 
+import pytest
+
 os.environ.setdefault('MINUSPOD_DATA_DIR', tempfile.mkdtemp(prefix='keepbypass_test_'))
 os.environ.setdefault('SECRET_KEY', 'test-secret')
 
@@ -596,6 +598,119 @@ class TestStampPass2MarkerCategories:
 
         assert markers[0]['category'] == 'cross_promo'
         assert 'category' not in markers[1]
+
+
+class TestPartitionPass2CategoryActions:
+    ACTIONS = {
+        'sponsor': 'remove',
+        'cross_promo': 'remove',
+        'self_promo': 'keep',
+        'interaction': 'keep',
+        'intro': 'keep',
+        'outro': 'beep',
+        'recap': 'keep',
+    }
+
+    @staticmethod
+    def _pair(category, **extra):
+        processed = {'start': 10.0, 'end': 20.0, 'category': category, **extra}
+        original = {'start': 110.0, 'end': 120.0, 'category': category, **extra}
+        return processed, original
+
+    def test_keep_action_removes_pair_from_cut_pipeline(self):
+        processed, original = self._pair(
+            'self_promo', held_for_review=True, hold_reason='max_duration')
+
+        out_p, out_o, kept = processing._partition_pass2_category_actions(
+            [processed], [original], self.ACTIONS)
+
+        assert out_p == []
+        assert out_o == []
+        assert kept == [original]
+        for marker in (processed, original):
+            assert marker['action_applied'] == 'keep'
+            assert marker['was_cut'] is False
+            assert marker['held_for_review'] is False
+            assert marker['hold_cleared_reason'] == 'max_duration'
+            assert 'hold_reason' not in marker
+
+    @pytest.mark.parametrize(
+        ('category', 'expected'), [('sponsor', 'remove'), ('outro', 'beep')])
+    def test_cut_actions_are_stamped_in_both_coordinate_spaces(
+            self, category, expected):
+        processed, original = self._pair(category)
+
+        out_p, out_o, kept = processing._partition_pass2_category_actions(
+            [processed], [original], self.ACTIONS)
+
+        assert out_p == [processed]
+        assert out_o == [original]
+        assert kept == []
+        assert processed['action_applied'] == expected
+        assert original['action_applied'] == expected
+
+    def test_defined_pattern_overrides_keep(self):
+        processed, original = self._pair('self_promo', pattern_defined=True)
+
+        out_p, out_o, kept = processing._partition_pass2_category_actions(
+            [processed], [original], self.ACTIONS)
+
+        assert out_p == [processed]
+        assert out_o == [original]
+        assert kept == []
+        for marker in (processed, original):
+            assert marker['action_applied'] == 'remove'
+            assert marker['keep_overridden_by_pattern'] is True
+
+    def test_missing_category_uses_conservative_sponsor_action(self):
+        processed = {'start': 10.0, 'end': 20.0}
+        original = {'start': 110.0, 'end': 120.0}
+
+        out_p, out_o, kept = processing._partition_pass2_category_actions(
+            [processed], [original], self.ACTIONS)
+
+        assert out_p == [processed]
+        assert out_o == [original]
+        assert kept == []
+        assert processed['action_applied'] == 'remove'
+        assert original['action_applied'] == 'remove'
+
+    def test_run_verification_persists_keep_without_recut(self):
+        ctx = types.SimpleNamespace(
+            slug='pass2-actions', episode_id='ep1', podcast_id=1,
+            podcast_name='Test Show', episode_title='Episode',
+            episode_description=None, podcast_description=None,
+        )
+        processed, original = self._pair('self_promo')
+        audio_processor = types.SimpleNamespace()
+
+        with ExitStack() as stack:
+            db = stack.enter_context(patch.object(processing, 'db'))
+            stack.enter_context(patch.object(processing, 'storage'))
+            stack.enter_context(patch.object(
+                processing, '_apply_pass2_heuristic_rolls'))
+            verifier_cls = stack.enter_context(
+                patch('verification_pass.VerificationPass'))
+            verifier_cls.return_value.verify.return_value = {
+                'ads': [original],
+                'ads_processed': [processed],
+                'segments': SEGMENTS,
+                'status': 'success',
+            }
+            db.get_setting_float.return_value = 0.6
+
+            result = processing._run_verification_pass(
+                ctx, '/tmp/pass2-actions.mp3', [], False, 0.8,
+                audio_processor, None, segment_actions=self.ACTIONS,
+            )
+
+        assert result[0] == 0
+        assert result[1] == []
+        assert result[3] == [original]
+        assert result[4] == '/tmp/pass2-actions.mp3'
+        assert result[6] is True
+        assert original['action_applied'] == 'keep'
+        assert original['was_cut'] is False
 
 
 def test_dedupe_pass2_markers_collapses_repeats():

--- a/tests/unit/test_keep_bypass.py
+++ b/tests/unit/test_keep_bypass.py
@@ -692,6 +692,35 @@ class TestPartitionPass2CategoryActions:
         assert processed['action_applied'] == 'remove'
         assert original['action_applied'] == 'remove'
 
+    def test_overlapping_candidate_splits_around_kept_audio(self):
+        processed = {'start': 100.0, 'end': 180.0, 'reason': 'heuristic roll'}
+        original = {'start': 119.0, 'end': 199.0, 'reason': 'heuristic roll'}
+        kept = {'start': 130.0, 'end': 150.0, 'category': 'self_promo'}
+        pass1_cuts = [
+            {'start': 50.0, 'end': 70.0, 'replacement_duration': 1.0},
+        ]
+
+        out_p, out_o = processing._exclude_category_kept_spans(
+            [processed], [original], [kept], pass1_cuts)
+
+        assert [(ad['start'], ad['end']) for ad in out_p] == [
+            (100.0, 130.0), (150.0, 180.0),
+        ]
+        assert [(ad['start'], ad['end']) for ad in out_o] == [
+            (119.0, 149.0), (169.0, 199.0),
+        ]
+        assert all(ad['reason'] == 'heuristic roll' for ad in out_p + out_o)
+
+    def test_kept_audio_covering_candidate_drops_it(self):
+        processed, original = self._pair(None)
+        kept = {'start': 5.0, 'end': 25.0, 'category': 'self_promo'}
+
+        out_p, out_o = processing._exclude_category_kept_spans(
+            [processed], [original], [kept], [])
+
+        assert out_p == []
+        assert out_o == []
+
     def test_run_verification_persists_keep_without_recut(self):
         ctx = types.SimpleNamespace(
             slug='pass2-actions', episode_id='ep1', podcast_id=1,

--- a/tests/unit/test_keep_bypass.py
+++ b/tests/unit/test_keep_bypass.py
@@ -621,12 +621,13 @@ class TestPartitionPass2CategoryActions:
         processed, original = self._pair(
             'self_promo', held_for_review=True, hold_reason='max_duration')
 
-        out_p, out_o, kept = processing._partition_pass2_category_actions(
+        out_p, out_o, kept_p, kept_o = processing._partition_pass2_category_actions(
             [processed], [original], self.ACTIONS)
 
         assert out_p == []
         assert out_o == []
-        assert kept == [original]
+        assert kept_p == [processed]
+        assert kept_o == [original]
         for marker in (processed, original):
             assert marker['action_applied'] == 'keep'
             assert marker['was_cut'] is False
@@ -640,12 +641,13 @@ class TestPartitionPass2CategoryActions:
             self, category, expected):
         processed, original = self._pair(category)
 
-        out_p, out_o, kept = processing._partition_pass2_category_actions(
+        out_p, out_o, kept_p, kept_o = processing._partition_pass2_category_actions(
             [processed], [original], self.ACTIONS)
 
         assert out_p == [processed]
         assert out_o == [original]
-        assert kept == []
+        assert kept_p == []
+        assert kept_o == []
         assert 'action_applied' not in processed
         assert 'action_applied' not in original
 
@@ -657,12 +659,13 @@ class TestPartitionPass2CategoryActions:
     def test_defined_pattern_overrides_keep(self):
         processed, original = self._pair('self_promo', pattern_defined=True)
 
-        out_p, out_o, kept = processing._partition_pass2_category_actions(
+        out_p, out_o, kept_p, kept_o = processing._partition_pass2_category_actions(
             [processed], [original], self.ACTIONS)
 
         assert out_p == [processed]
         assert out_o == [original]
-        assert kept == []
+        assert kept_p == []
+        assert kept_o == []
         for marker in (processed, original):
             assert 'action_applied' not in marker
             assert marker['keep_overridden_by_pattern'] is True
@@ -675,12 +678,13 @@ class TestPartitionPass2CategoryActions:
         processed = {'start': 10.0, 'end': 20.0}
         original = {'start': 110.0, 'end': 120.0}
 
-        out_p, out_o, kept = processing._partition_pass2_category_actions(
+        out_p, out_o, kept_p, kept_o = processing._partition_pass2_category_actions(
             [processed], [original], self.ACTIONS)
 
         assert out_p == [processed]
         assert out_o == [original]
-        assert kept == []
+        assert kept_p == []
+        assert kept_o == []
         assert 'action_applied' not in processed
         assert 'action_applied' not in original
 

--- a/tests/unit/test_recut_ad_list.py
+++ b/tests/unit/test_recut_ad_list.py
@@ -324,6 +324,40 @@ def test_build_recut_previously_cut_stays_cut_after_boundary_clamp(monkeypatch):
     )
 
 
+def test_build_recut_preserves_trusted_short_cut(monkeypatch):
+    ads = [{
+        'start': 100.0, 'end': 106.0, 'confidence': 0.85,
+        'reason': 'fragment split around beep audio', 'was_cut': True,
+        '_trusted_split_fragment': True,
+    }]
+    _stub_recut_db(monkeypatch, ads)
+
+    ads_to_remove, all_ads = processing._build_recut_ad_list(
+        'slug', 'ep', [], 3600.0, '', 0.80
+    )
+
+    assert ads_to_remove == all_ads
+    assert all_ads[0]['validation']['decision'] == 'ACCEPT'
+    assert all_ads[0]['was_cut'] is True
+
+
+def test_build_recut_trusted_short_cut_still_honors_fp(monkeypatch):
+    ads = [{
+        'start': 100.0, 'end': 106.0, 'confidence': 0.85,
+        'reason': 'fragment split around beep audio', 'was_cut': True,
+        '_trusted_split_fragment': True,
+    }]
+    _stub_recut_db(monkeypatch, ads, fp=[{'start': 100.0, 'end': 106.0}])
+
+    ads_to_remove, all_ads = processing._build_recut_ad_list(
+        'slug', 'ep', [], 3600.0, '', 0.80
+    )
+
+    assert ads_to_remove == []
+    assert all_ads[0]['validation']['decision'] == 'REJECT'
+    assert all_ads[0]['was_cut'] is False
+
+
 def test_build_recut_no_merge_across_saved_cut_status_keeps_both_outcomes(monkeypatch):
     # Must NOT merge: folding would let the previously-cut stamp force-accept
     # the whole span. Each keeps its own outcome.

--- a/tests/unit/test_segment_categories.py
+++ b/tests/unit/test_segment_categories.py
@@ -237,7 +237,7 @@ class TestMergeGatedOnResolvedAction:
         assert out[0]['start'] == 0.0
         assert out[0]['end'] == 30.0
 
-    def test_true_overlap_with_different_actions_clamps_instead_of_merging(self):
+    def test_true_overlap_gives_keep_action_the_contested_audio(self):
         det = self._det()
         action_map = dict(_all_remove_map(), interaction='keep')
         sponsor_ad = _ad(0.0, 25.0, 'text_pattern', category='sponsor')
@@ -249,10 +249,10 @@ class TestMergeGatedOnResolvedAction:
         assert len(out) == 2
         by_cat = {m['category']: m for m in out}
         assert by_cat['sponsor']['start'] == 0.0
-        assert by_cat['sponsor']['end'] == 25.0
-        # Clamped past the sponsor marker's end so the two spans no longer
-        # double-cut the same 20.0-25.0s audio.
-        assert by_cat['interaction']['start'] == 25.0
+        assert by_cat['sponsor']['end'] == 20.0
+        # Keep wins the contested 20.0-25.0s audio; otherwise the later keep
+        # partition cannot protect the portion already assigned to remove.
+        assert by_cat['interaction']['start'] == 20.0
         assert by_cat['interaction']['end'] == 30.0
 
 

--- a/tests/unit/test_segment_prompt.py
+++ b/tests/unit/test_segment_prompt.py
@@ -9,6 +9,7 @@ from unittest.mock import patch, MagicMock
 
 from ad_detector import AdDetector, WindowResult
 from config import SEGMENT_CATEGORIES, DEFAULT_SEGMENT_ACTION, normalize_segment_category
+from database import DEFAULT_VERIFICATION_PROMPT
 from utils.constants import DEFAULT_SYSTEM_PROMPT, SHOW_SEGMENTS_PROMPT_SECTION
 from ad_detector.prompts import (
     parse_ads_from_response, parse_category_repair_response,
@@ -78,6 +79,14 @@ class TestDefaultPromptCategoryInstructions:
         assert 0 < required_idx - schema_idx < 400
         assert 'is invalid' in DEFAULT_SYSTEM_PROMPT
 
+    def test_verification_prompt_requires_category(self):
+        schema_idx = DEFAULT_VERIFICATION_PROMPT.index('Each ad segment:')
+        required_idx = DEFAULT_VERIFICATION_PROMPT.index(
+            '"category" is REQUIRED on every object')
+        assert 0 < required_idx - schema_idx < 500
+        for category in SEGMENT_CATEGORIES:
+            assert category in DEFAULT_VERIFICATION_PROMPT
+
     def test_non_sponsor_worked_example_present(self):
         # Both worked examples used to be "sponsor"; the model needs to see
         # a non-sponsor category filled in at least once.
@@ -86,6 +95,27 @@ class TestDefaultPromptCategoryInstructions:
         non_sponsor_cats = ('cross_promo', 'self_promo', 'interaction')
         assert any(f'"category": "{cat}"' in examples_section
                    for cat in non_sponsor_cats)
+
+
+def test_verification_wires_category_actions_into_repair_and_dedup():
+    action_map = dict(_all_remove_map(), self_promo='keep', outro='beep')
+    detector = AdDetector(api_key='test-key')
+    detector.db = _FakeDb(segment_actions=action_map)
+    run_pass = MagicMock(return_value=([], [], 0, None, 0, 0, 0))
+
+    with patch.object(detector, 'initialize_client'), \
+         patch.object(detector, 'get_verification_prompt', return_value='verification'), \
+         patch.object(detector, 'get_verification_model', return_value='model'), \
+         patch.object(detector, '_build_known_pattern_hint', return_value=''), \
+         patch.object(detector, '_run_detection_pass', run_pass):
+        result = detector.run_verification_detection(
+            _WARNING_SEGMENTS, podcast_name='Test', episode_title='Ep',
+            slug='daily-tech-news-show', episode_id='ep1')
+
+    assert result['status'] == 'success'
+    kwargs = run_pass.call_args.kwargs
+    assert kwargs['action_map'] == action_map
+    assert kwargs['category_repair_enabled'] is True
 
 
 class TestShowSegmentsSection:

--- a/tests/unit/test_validate_verification_ads.py
+++ b/tests/unit/test_validate_verification_ads.py
@@ -41,11 +41,13 @@ def _segments(duration=600.0):
     return [_seg(t, t + 30.0) for t in range(0, int(duration), 30)]
 
 
-def _run(processed, original, duration=600.0):
+def _run(processed, original, duration=600.0, keep_barriers_processed=None):
     return _validate_verification_ads(
         'show', 'ep1', processed, original, _segments(duration),
         ads_to_remove=[], episode_description=None,
         min_cut_confidence=0.8, db=_db(),
+        processed_duration=duration,
+        keep_barriers_processed=keep_barriers_processed,
     )
 
 
@@ -123,6 +125,30 @@ def test_pairing_key_never_leaks_into_outputs():
 
     for ad in kept_proc + kept_orig + processed + original:
         assert '_orig_twin' not in ad
+
+
+def test_kept_tail_blocks_trailing_ad_extension():
+    processed = [
+        {'start': 100.0, 'end': 140.0, 'confidence': 0.9,
+         'category': 'sponsor'},
+    ]
+    original = [
+        {'start': 1100.0, 'end': 1140.0, 'marker': 'removable'},
+    ]
+    kept_tail = [
+        {'start': 145.0, 'end': 165.0, 'confidence': 0.9,
+         'category': 'self_promo', 'action_applied': 'keep'},
+    ]
+
+    kept_proc, kept_orig = _run(
+        processed, original, duration=170.0,
+        keep_barriers_processed=kept_tail,
+    )
+
+    assert len(kept_proc) == len(kept_orig) == 1
+    assert kept_proc[0]['end'] == 140.0
+    assert kept_orig[0]['marker'] == 'removable'
+    assert '_pass2_keep_barrier' not in kept_tail[0]
 
 
 def test_explicit_duration_is_validator_clamp_target():

--- a/tests/unit/test_validate_verification_ads.py
+++ b/tests/unit/test_validate_verification_ads.py
@@ -164,7 +164,7 @@ def test_recut_carries_kept_tail_to_applied_cut_computation():
 
     path, applied, ok = _recut_processed_audio(
         'show', 'ep1', '/tmp/nonexistent-pass2.mp3', cuts, processor,
-        end_extension_barriers=barriers,
+        cut_barriers=barriers,
     )
 
     assert path == '/tmp/nonexistent-pass2.mp3'
@@ -174,7 +174,7 @@ def test_recut_carries_kept_tail_to_applied_cut_computation():
         '/tmp/nonexistent-pass2.mp3',
         [{'start': 100.0, 'end': 140.0, 'action_applied': 'remove',
           'beep': False}],
-        end_extension_barriers=barriers,
+        cut_barriers=barriers,
     )
 
 

--- a/tests/unit/test_validate_verification_ads.py
+++ b/tests/unit/test_validate_verification_ads.py
@@ -19,6 +19,7 @@ _test_data_dir = bootstrap('validate_vads_test_')
 from main_app.processing import (
     _drop_uncovered_pass2_ads,
     _gate_verification_ads_by_confidence,
+    _recut_processed_audio,
     _validate_verification_ads,
 )
 import main_app.processing as processing_mod
@@ -149,6 +150,32 @@ def test_kept_tail_blocks_trailing_ad_extension():
     assert kept_proc[0]['end'] == 140.0
     assert kept_orig[0]['marker'] == 'removable'
     assert '_pass2_keep_barrier' not in kept_tail[0]
+
+
+def test_recut_carries_kept_tail_to_applied_cut_computation():
+    processor = MagicMock()
+    processor.process_episode.return_value = None
+    cuts = [
+        {'start': 100.0, 'end': 140.0, 'action_applied': 'remove'},
+    ]
+    barriers = [
+        {'start': 145.0, 'end': 165.0, 'action_applied': 'keep'},
+    ]
+
+    path, applied, ok = _recut_processed_audio(
+        'show', 'ep1', '/tmp/nonexistent-pass2.mp3', cuts, processor,
+        end_extension_barriers=barriers,
+    )
+
+    assert path == '/tmp/nonexistent-pass2.mp3'
+    assert applied is None
+    assert ok is False
+    processor.process_episode.assert_called_once_with(
+        '/tmp/nonexistent-pass2.mp3',
+        [{'start': 100.0, 'end': 140.0, 'action_applied': 'remove',
+          'beep': False}],
+        end_extension_barriers=barriers,
+    )
 
 
 def test_explicit_duration_is_validator_clamp_target():

--- a/tests/unit/test_validate_verification_ads.py
+++ b/tests/unit/test_validate_verification_ads.py
@@ -894,6 +894,26 @@ def test_drop_uncovered_handles_twinless_cut():
     assert filtered['was_cut'] is False
 
 
+def test_drop_uncovered_removes_split_cut_ui_twin():
+    covered = {'start': 100.0, 'end': 130.0}
+    filtered = {'start': 150.0, 'end': 155.0}
+    covered_ui = {'start': 1100.0, 'end': 1130.0}
+    filtered_ui = {'start': 1150.0, 'end': 1155.0}
+    v_ads_to_cut = [covered, filtered]
+    v_ads_for_ui = [covered_ui, filtered_ui]
+
+    _drop_uncovered_pass2_ads(
+        's', 'e', v_ads_to_cut, v_ads_for_ui,
+        [{'start': 100.0, 'end': 130.0}], [], [],
+        total_duration=600.0,
+    )
+
+    assert v_ads_to_cut == [covered]
+    assert v_ads_for_ui == [covered_ui]
+    assert filtered['was_cut'] is False
+    assert filtered_ui['was_cut'] is False
+
+
 def test_filing_respects_human_reject(monkeypatch):
     """A span the user explicitly rejected must never be auto-filed."""
     db = MagicMock()

--- a/tests/unit/test_validate_verification_ads.py
+++ b/tests/unit/test_validate_verification_ads.py
@@ -16,6 +16,7 @@ import pytest
 from tests.app_bootstrap import bootstrap
 
 _test_data_dir = bootstrap('validate_vads_test_')
+from audio_processor import AudioProcessor
 from main_app.processing import (
     _drop_uncovered_pass2_ads,
     _gate_verification_ads_by_confidence,
@@ -74,6 +75,24 @@ def test_merge_keeps_correct_twin_for_later_ad():
     # The far ad pairs with its own original, not B's.
     assert kept_proc[1]['start'] == 400.0
     assert kept_orig[1]['marker'] == 'C'
+
+
+def test_merge_preserves_later_trusted_split_fragment():
+    processed = [
+        {'start': 100.0, 'end': 102.0, 'confidence': 0.85},
+        {'start': 106.0, 'end': 108.0, 'confidence': 0.85,
+         '_trusted_split_fragment': True},
+    ]
+    original = [
+        {'start': 1100.0, 'end': 1102.0},
+        {'start': 1106.0, 'end': 1108.0},
+    ]
+
+    kept_proc, _ = _run(processed, original)
+
+    assert kept_proc[0]['_trusted_split_fragment'] is True
+    applied = AudioProcessor().compute_applied_cuts(kept_proc, 600.0)
+    assert [(cut['start'], cut['end']) for cut in applied] == [(100.0, 108.0)]
 
 
 def test_unsorted_input_pairs_by_identity_not_position():

--- a/tests/unit/test_validate_verification_ads.py
+++ b/tests/unit/test_validate_verification_ads.py
@@ -88,9 +88,14 @@ def test_merge_preserves_later_trusted_split_fragment():
         {'start': 1106.0, 'end': 1108.0},
     ]
 
-    kept_proc, _ = _run(processed, original)
+    kept_proc, kept_orig = _run(processed, original)
 
     assert kept_proc[0]['_trusted_split_fragment'] is True
+    assert kept_orig[0] == {
+        'start': 1100.0,
+        'end': 1108.0,
+        '_trusted_split_fragment': True,
+    }
     applied = AudioProcessor().compute_applied_cuts(kept_proc, 600.0)
     assert [(cut['start'], cut['end']) for cut in applied] == [(100.0, 108.0)]
 

--- a/tests/unit/test_verification_reuse_transcript.py
+++ b/tests/unit/test_verification_reuse_transcript.py
@@ -83,7 +83,7 @@ def test_no_cuts_reuses_transcript_directly_regardless_of_flag():
     assert [s['text'] for s in passed] == ['intro']
 
 
-def test_category_kept_detection_is_not_learned_as_a_miss():
+def test_category_kept_detection_is_learned_as_a_miss():
     v = _verifier()
     v.pattern_service = MagicMock()
     v.ad_detector.run_verification_detection.return_value = {
@@ -103,5 +103,4 @@ def test_category_kept_detection_is_not_learned_as_a_miss():
     v.verify(**_kwargs(pass1_cuts=[], original_segments=original))
 
     learned = v.pattern_service.record_verification_misses.call_args.args[2]
-    assert len(learned) == 1
-    assert learned[0]['category'] == 'sponsor'
+    assert [ad['category'] for ad in learned] == ['self_promo', 'sponsor']

--- a/tests/unit/test_verification_reuse_transcript.py
+++ b/tests/unit/test_verification_reuse_transcript.py
@@ -81,3 +81,27 @@ def test_no_cuts_reuses_transcript_directly_regardless_of_flag():
     v.transcriber.transcribe_chunked.assert_not_called()
     passed = v.ad_detector.run_verification_detection.call_args[0][0]
     assert [s['text'] for s in passed] == ['intro']
+
+
+def test_category_kept_detection_is_not_learned_as_a_miss():
+    v = _verifier()
+    v.pattern_service = MagicMock()
+    v.ad_detector.run_verification_detection.return_value = {
+        'ads': [
+            {'start': 10.0, 'end': 30.0, 'category': 'self_promo',
+             'sponsor': 'Own show'},
+            {'start': 40.0, 'end': 70.0, 'category': 'sponsor',
+             'sponsor': 'Acme'},
+        ],
+        'segment_actions': {
+            'self_promo': 'keep',
+            'sponsor': 'remove',
+        },
+    }
+    original = [_seg(0.0, 90.0, 'intro own show acme sponsor')]
+
+    v.verify(**_kwargs(pass1_cuts=[], original_segments=original))
+
+    learned = v.pattern_service.record_verification_misses.call_args.args[2]
+    assert len(learned) == 1
+    assert learned[0]['category'] == 'sponsor'


### PR DESCRIPTION
Ports kristofferR/MinusPod agent/pass2-mixed-actions (16 commits, original authorship preserved) plus one cherry-pick from agent/pass2-category-actions, onto current main.

## What it does
Upstream applied per-category segment actions (keep/beep/remove) only in pass 1; the verification pass ignored them. After this port:
- Verification detection resolves the action map (src/ad_detector/__init__.py) and carries category actions through pass 2.
- Paired processed/original pass-2 candidates are partitioned by action (_partition_pass2_category_actions in src/main_app/processing.py).
- Kept spans are injected as validator barriers so merges and end-extension cannot cut through them; keep barriers combine pass-1 kept markers with category-kept pass-2 markers (_pass2_keep_barriers_processed).
- Overlapping beep vs remove cuts are reconciled: beep wins contested audio, removes split around it.
- split_conflicting_action_span (src/ad_detector/boundaries.py) gains explicit keep > beep > remove precedence.
- cut_barriers thread through compute_applied_cuts/remove_ads/process_episode (src/audio_processor.py) so the audio recut also cannot cut through kept spans; trusted split fragments survive the short-cut duration floor.
- Cherry-pick 4b0005c0: crosses_barrier guard for degenerate end <= start spans, so overlapping cuts still merge inside a surrounding barrier.

## Port notes
- Main's 2.89.4 refactor moved the verification reconciliation helpers out of processing.py into verification_reconciliation.py. The fork's edits to _exclude_kept_spans_from_verification and _drop_uncovered_pass2_ads were transplanted there; _pass2_keep_barriers_processed is defined there and re-imported by processing.py.
- The fork's non-strict cut/UI twin zip is kept deliberately (a cut can legitimately lack a UI twin); other ported zips are strict=True.
- Legacy List[Dict]/Optional typing modernized to main's style.
- Deliberately NOT ported: agent/pass2-category-propagation's post-validation kept-span re-check (b576140c) — the barrier mechanism covers the same hazard at both the validation-merge and recut stages, and _exclude_category_kept_spans handles the roll-overlap case (a1c1e476/1b397d25).

## Test plan
- tests/unit: 5157 passed locally (includes ~490 new test lines: test_keep_bypass.py, test_compute_applied_cuts.py, test_validate_verification_ads.py, test_ad_detector.py, test_recut_ad_list.py, test_segment_prompt.py)
- ruff clean
- Rebased on main after #677/#678 merged; affected suites re-verified