### PR TITLE
Port DAI review-safeguards campaign from kristofferR fork

### DIFF
--- a/src/ad_detector/__init__.py
+++ b/src/ad_detector/__init__.py
@@ -24,7 +24,12 @@ from llm_client import (
 from run_log import run_in_worker_thread
 from utils.language import get_pattern_language
 from utils.llm_call import call_llm, call_llm_for_window
-from utils.markers import mark_distinct_merge, note_merged_members
+from utils.markers import (
+    DAI_CORE_SPANS,
+    mark_distinct_merge,
+    merge_dai_core_spans,
+    note_merged_members,
+)
 from utils.prompt import format_sponsor_block, render_prompt, apply_override
 from utils.text import truncate
 from utils.time import overlap_ratio, ranges_overlap
@@ -404,6 +409,11 @@ def dai_differential_ads(dai_differential, fp_pairs, corroborating_spans=None, *
             'detection_stage': 'dai_differential',
             # A dynamically inserted block is a paid ad by definition.
             'category': 'sponsor',
+            # Preserve the measured cross-fetch region independently from
+            # the candidate's mutable outer bounds. Later merges may widen
+            # start/end with coarse LLM spans, but the reviewer must not trim
+            # away audio that cross-fetch measured as inserted.
+            DAI_CORE_SPANS: [{'start': start, 'end': end}],
         }
         if stage_overlap:
             ad['reason'] = ('Dynamically inserted: audio differs across '
@@ -2395,6 +2405,7 @@ class AdDetector:
                         and current['start'] >= last['end']):
                     merged.append(_with_category_span(current.copy()))
                     continue
+                merge_dai_core_spans(last, current)
                 # Non-overlapping spans (touching or gapped) are distinct ads,
                 # not the same ad overlapping across stages. Touch counts too
                 # (LLM breaks are often exactly contiguous). Keep these
@@ -2599,6 +2610,7 @@ class AdDetector:
                                or sanitize_sponsor_label(other.get('sponsor')))
 
                     combined = a.copy()
+                    merge_dai_core_spans(combined, b)
                     combined['start'] = min(a['start'], b['start'])
                     combined['end'] = max(a['end'], b['end'])
                     combined['confidence'] = max(a_conf, b_conf)

--- a/src/ad_detector/boundaries.py
+++ b/src/ad_detector/boundaries.py
@@ -1540,11 +1540,26 @@ def _span_blocked_by_content(segments: list[dict], ads: list[dict],
         text = (seg.get('text') or '').strip()
         if not text:
             continue
-        covered = any(
-            ranges_overlap(seg_start, seg_end, m['start'], m['end'])
-            for m in ads
-            if m.get('start') is not None and m.get('end') is not None
-        )
+        # Only coverage inside the proposed extension matters. A long
+        # transcript segment may continue into a later marker after the
+        # candidate splice; that must not hide show speech before the splice.
+        relevant_start = max(seg_start, span_start)
+        relevant_end = min(seg_end, span_end)
+        covered_until = relevant_start
+        for marker in sorted(
+                (m for m in ads
+                 if m.get('start') is not None and m.get('end') is not None),
+                key=lambda m: m['start']):
+            marker_start = max(marker['start'], relevant_start)
+            marker_end = min(marker['end'], relevant_end)
+            if marker_end <= covered_until:
+                continue
+            if marker_start > covered_until:
+                break
+            covered_until = marker_end
+            if covered_until >= relevant_end:
+                break
+        covered = covered_until >= relevant_end
         if covered or _text_has_ad_content(text.lower(), ad_sponsors):
             continue
         return True

--- a/src/ad_detector/boundaries.py
+++ b/src/ad_detector/boundaries.py
@@ -1403,13 +1403,20 @@ def snap_extended_ad_tails_to_splice(ads: list[dict], segments: list[dict],
             continue
 
         original_end = ad_copy['end']
-        next_starts = [
-            marker['start'] for marker in coverage
-            if marker is not ad
-            and marker.get('start') is not None
-            and marker['start'] >= original_end
-        ]
-        end_cap = min([original_end + window_s] + next_starts)
+        barriers = []
+        for marker in coverage:
+            same_marker = marker is ad or (
+                marker.get('start') == ad_copy.get('start')
+                and marker.get('end') == original_end
+            )
+            if same_marker or marker.get('start') is None:
+                continue
+            if marker.get('end') is None or marker['end'] <= original_end:
+                continue
+            # An overlapping marker blocks immediately; a later marker caps
+            # the scan at its start.
+            barriers.append(max(original_end, marker['start']))
+        end_cap = min([original_end + window_s] + barriers)
         candidates = [
             event for event in splice_events
             if event.get('type') in ('digital_silence', 'deep_silence')

--- a/src/ad_detector/boundaries.py
+++ b/src/ad_detector/boundaries.py
@@ -1376,6 +1376,80 @@ def snap_terminal_ad_to_splice(ads: list[dict], segments: list[dict],
     return out
 
 
+def snap_extended_ad_tails_to_splice(ads: list[dict], segments: list[dict],
+                                     splice_events: list[dict],
+                                     window_s: float = BOUNDARY_EXTENSION_WINDOW,
+                                     coverage_ads: list[dict] | None = None,
+                                     podcast_name: str | None = None) -> list[dict]:
+    """Finish a content-extended ad at a nearby forward splice boundary.
+
+    The post-review tail sweep can recover a spoken CTA from transcript text,
+    but a short untranscribed sonic logo may follow it. Only markers that the
+    tail sweep already extended are eligible. From their new end, scan forward
+    for strong silence splice evidence without crossing another marker or any
+    transcribed content. This keeps the recovery narrow while preventing the
+    final few seconds of a DAI spot from leaking into the processed episode.
+    """
+    if not ads or not splice_events or window_s <= 0:
+        return ads
+
+    coverage = coverage_ads if coverage_ads is not None else ads
+    own_site = SponsorService.own_site_tokens(podcast_name)
+    out = []
+    for ad in ads:
+        ad_copy = ad.copy()
+        if not ad_copy.get('end_extended_by_content'):
+            out.append(ad_copy)
+            continue
+
+        original_end = ad_copy['end']
+        next_starts = [
+            marker['start'] for marker in coverage
+            if marker is not ad
+            and marker.get('start') is not None
+            and marker['start'] >= original_end
+        ]
+        end_cap = min([original_end + window_s] + next_starts)
+        candidates = [
+            event for event in splice_events
+            if event.get('type') in ('digital_silence', 'deep_silence')
+            and event.get('time') is not None
+            and original_end < event['time'] <= end_cap
+        ]
+        # The nearest strong splice is the conservative boundary. A later one
+        # could be a pause inside untranscribed show music; depth only breaks a
+        # same-time tie.
+        candidates.sort(key=lambda event: (
+            event['time'],
+            event['depth_dbfs'] if event.get('depth_dbfs') is not None else 0.0,
+        ))
+
+        ad_text = get_transcript_text_for_range(
+            segments, ad_copy['start'], original_end).lower()
+        ad_sponsors = extract_sponsor_names(
+            ad_text, ad_copy.get('reason'), exclude=own_site)
+        for event in candidates:
+            if _span_blocked_by_content(
+                    segments, coverage, ad_sponsors,
+                    original_end, event['time']):
+                continue
+            ad_copy['end'] = event['time']
+            ad_copy['tail_splice_snap'] = {
+                'original_end': original_end,
+                'event_time': event['time'],
+                'event_type': event['type'],
+                'depth_dbfs': event.get('depth_dbfs'),
+            }
+            logger.info(
+                f"Tail splice snap: ad end {original_end:.1f}s -> "
+                f"{event['time']:.1f}s ({event['type']}, "
+                f"depth {event.get('depth_dbfs')} dBFS)"
+            )
+            break
+        out.append(ad_copy)
+    return out
+
+
 def _span_blocked_by_content(segments: list[dict], ads: list[dict],
                              ad_sponsors: set,
                              span_start: float, span_end: float) -> bool:

--- a/src/ad_detector/boundaries.py
+++ b/src/ad_detector/boundaries.py
@@ -5,10 +5,12 @@ Split out of ``ad_detector/__init__.py`` for readability; behavior is
 unchanged from the pre-split module.
 """
 import logging
+import math
 import re
 
 from utils.markers import (
     clip_dai_core_spans,
+    invalidate_tail_provenance,
     mark_distinct_merge,
     merge_dai_core_spans,
     note_merged_members,
@@ -828,14 +830,18 @@ def _merge_ad_pair(current_ad: dict, next_ad: dict, gap_desc: str = "") -> None:
     ``gap_desc`` is appended to the merged reason when set (filler-gap pass).
     """
     mark_distinct_merge(current_ad, next_ad)
+    invalidate_tail_provenance(current_ad, next_ad['end'])
     current_ad['end'] = next_ad['end']
     # The tail-sweep marker describes how the *current end* was reached. Once
     # this merge replaces that edge, only the later fragment's flag remains
     # meaningful; retaining the earlier fragment's flag could snap past an
     # otherwise final, non-content-derived boundary.
-    current_ad.pop('end_extended_by_content', None)
     if next_ad.get('end_extended_by_content'):
         current_ad['end_extended_by_content'] = True
+    if next_ad.get('tail_splice_snap') is not None:
+        snap = next_ad['tail_splice_snap']
+        current_ad['tail_splice_snap'] = (
+            dict(snap) if isinstance(snap, dict) else snap)
     current_ad['confidence'] = max(current_ad.get('confidence', 0.0),
                                    next_ad.get('confidence', 0.0))
 
@@ -1424,7 +1430,14 @@ def transition_pair_silence_events(signals: list,
             end = span.get('end')
             if start is None or end is None or end <= start:
                 continue
-            duration = span.get('duration', end - start)
+            raw_duration = span.get('duration')
+            duration = (
+                raw_duration
+                if (isinstance(raw_duration, (int, float))
+                    and not isinstance(raw_duration, bool)
+                    and math.isfinite(raw_duration))
+                else end - start
+            )
             midpoint = (start + end) / 2.0
             distance = abs(midpoint - transition_start)
             if duration >= min_silence_s and distance <= max_distance_s:
@@ -1532,6 +1545,11 @@ def _span_blocked_by_content(segments: list[dict], ads: list[dict],
                              span_start: float, span_end: float) -> bool:
     """True when the span holds transcribed speech that is neither covered
     by a detected marker nor ad-like content."""
+    sorted_markers = sorted(
+        (marker for marker in ads
+         if marker.get('start') is not None
+         and marker.get('end') is not None),
+        key=lambda marker: marker['start'])
     for seg in segments:
         seg_start = seg.get('start', 0.0)
         seg_end = seg.get('end', 0.0)
@@ -1546,10 +1564,7 @@ def _span_blocked_by_content(segments: list[dict], ads: list[dict],
         relevant_start = max(seg_start, span_start)
         relevant_end = min(seg_end, span_end)
         covered_until = relevant_start
-        for marker in sorted(
-                (m for m in ads
-                 if m.get('start') is not None and m.get('end') is not None),
-                key=lambda m: m['start']):
+        for marker in sorted_markers:
             marker_start = max(marker['start'], relevant_start)
             marker_end = min(marker['end'], relevant_end)
             if marker_end <= covered_until:

--- a/src/ad_detector/boundaries.py
+++ b/src/ad_detector/boundaries.py
@@ -7,7 +7,12 @@ unchanged from the pre-split module.
 import logging
 import re
 
-from utils.markers import mark_distinct_merge, note_merged_members
+from utils.markers import (
+    clip_dai_core_spans,
+    mark_distinct_merge,
+    merge_dai_core_spans,
+    note_merged_members,
+)
 from utils.text import get_transcript_text_for_range
 from utils.time import overlap_seconds, ranges_overlap
 from sponsor_service import SponsorService
@@ -1151,6 +1156,7 @@ def split_conflicting_action_span(last: dict, current: dict,
                     'merged_protected_end'):
             clamped.pop(key, None)
         clamped['start'] = last['end']
+        clip_dai_core_spans(clamped, clamped['start'], clamped['end'])
         mark_trusted_fragment(clamped, current)
         return last, [clamped]
     current_wins = (
@@ -1177,17 +1183,22 @@ def split_conflicting_action_span(last: dict, current: dict,
         # narrower piece. Strip them so ad_reviewer's expand-only protection
         # can't float a boundary back out to a stale bound and re-absorb
         # audio this split just carved away.
-        before = {k: v for k, v in last.items()
-                  if k not in ('merged_distinct_ads', 'merged_protected_start',
-                               'merged_protected_end')}
+        base = {k: v for k, v in last.items()
+                if k not in ('merged_distinct_ads', 'merged_protected_start',
+                             'merged_protected_end')}
+        before = dict(base)
         before['end'] = current['start']
-        after = dict(before)
+        clip_dai_core_spans(before, before['start'], before['end'])
+        after = dict(base)
         after['start'] = current['end']
         after['end'] = last['end']
+        clip_dai_core_spans(after, after['start'], after['end'])
         mark_trusted_fragment(before, last)
         mark_trusted_fragment(after, last)
+        current_copy = current.copy()
+        clip_dai_core_spans(current_copy, current_copy['start'], current_copy['end'])
         new_last = before if before['start'] < before['end'] else None
-        entries = [current.copy()]
+        entries = [current_copy]
         if after['start'] < after['end']:
             entries.append(after)
         return new_last, entries
@@ -1197,6 +1208,8 @@ def split_conflicting_action_span(last: dict, current: dict,
                 'merged_protected_end'):
         shortened_last.pop(key, None)
     shortened_last['end'] = current['start']
+    clip_dai_core_spans(shortened_last, shortened_last['start'],
+                        shortened_last['end'])
     mark_trusted_fragment(shortened_last, last)
     if shortened_last['end'] <= shortened_last['start']:
         shortened_last = None
@@ -1257,6 +1270,7 @@ def deduplicate_window_ads(all_ads: list[dict], merge_threshold: float = 5.0,
                     f"actions) at window-dedup"
                 )
                 continue
+            merge_dai_core_spans(last, current)
             # Non-overlapping spans (touching or gapped) are distinct ads
             # chained together, not the same ad re-detected across an
             # overlapping window. LLM ad breaks are often exactly contiguous

--- a/src/ad_detector/boundaries.py
+++ b/src/ad_detector/boundaries.py
@@ -1411,6 +1411,11 @@ def transition_pair_silence_events(signals: list,
     precise boundary. Return splice-shaped events so the terminal content
     guard can apply its existing transcript safety checks.
     """
+    def is_finite_number(value):
+        return (isinstance(value, (int, float))
+                and not isinstance(value, bool)
+                and math.isfinite(value))
+
     events = []
     for signal in signals or []:
         signal_type = (signal.get('signal_type') if isinstance(signal, dict)
@@ -1420,22 +1425,24 @@ def transition_pair_silence_events(signals: list,
         transition_start = (signal.get('start') if isinstance(signal, dict)
                             else getattr(signal, 'start', None))
         if (signal_type != 'dai_transition_pair'
+                or not is_finite_number(confidence)
                 or confidence < min_confidence
-                or transition_start is None):
+                or not is_finite_number(transition_start)):
             continue
 
         candidates = []
         for span in silence_spans or []:
+            if not isinstance(span, dict):
+                continue
             start = span.get('start')
             end = span.get('end')
-            if start is None or end is None or end <= start:
+            if (not is_finite_number(start) or not is_finite_number(end)
+                    or end <= start):
                 continue
             raw_duration = span.get('duration')
             duration = (
                 raw_duration
-                if (isinstance(raw_duration, (int, float))
-                    and not isinstance(raw_duration, bool)
-                    and math.isfinite(raw_duration))
+                if is_finite_number(raw_duration)
                 else end - start
             )
             midpoint = (start + end) / 2.0

--- a/src/ad_detector/boundaries.py
+++ b/src/ad_detector/boundaries.py
@@ -1343,7 +1343,9 @@ def snap_terminal_ad_to_splice(ads: list[dict], segments: list[dict],
         if episode_duration - ad_copy['end'] <= eof_tolerance_s:
             candidates = [
                 e for e in splice_events
-                if e.get('type') in ('digital_silence', 'deep_silence')
+                if e.get('type') in (
+                    'digital_silence', 'deep_silence',
+                    'dai_transition_silence')
                 and e.get('time') is not None
                 and ad_copy['start'] - window_s <= e['time'] < ad_copy['start']
             ]
@@ -1374,6 +1376,59 @@ def snap_terminal_ad_to_splice(ads: list[dict], segments: list[dict],
                 break
         out.append(ad_copy)
     return out
+
+
+def transition_pair_silence_events(signals: list,
+                                   silence_spans: list[dict],
+                                   max_distance_s: float,
+                                   min_silence_s: float,
+                                   min_confidence: float = 0.9) -> list[dict]:
+    """Derive precise terminal-boundary evidence from a coarse DAI pair.
+
+    Transition pairs use five-second loudness frames, so their edge alone is
+    too coarse for a destructive snap. A nearby measured silence gives the
+    precise boundary. Return splice-shaped events so the terminal content
+    guard can apply its existing transcript safety checks.
+    """
+    events = []
+    for signal in signals or []:
+        signal_type = (signal.get('signal_type') if isinstance(signal, dict)
+                       else getattr(signal, 'signal_type', None))
+        confidence = (signal.get('confidence', 0.0) if isinstance(signal, dict)
+                      else getattr(signal, 'confidence', 0.0))
+        transition_start = (signal.get('start') if isinstance(signal, dict)
+                            else getattr(signal, 'start', None))
+        if (signal_type != 'dai_transition_pair'
+                or confidence < min_confidence
+                or transition_start is None):
+            continue
+
+        candidates = []
+        for span in silence_spans or []:
+            start = span.get('start')
+            end = span.get('end')
+            if start is None or end is None or end <= start:
+                continue
+            duration = span.get('duration', end - start)
+            midpoint = (start + end) / 2.0
+            distance = abs(midpoint - transition_start)
+            if duration >= min_silence_s and distance <= max_distance_s:
+                candidates.append((distance, midpoint, start, end, duration))
+        if not candidates:
+            continue
+
+        _, midpoint, start, end, duration = min(candidates)
+        events.append({
+            'time': midpoint,
+            'end_time': end,
+            'type': 'dai_transition_silence',
+            'depth_dbfs': None,
+            'duration_s': duration,
+            'transition_time': transition_start,
+            'silence_start': start,
+            'silence_end': end,
+        })
+    return events
 
 
 def snap_extended_ad_tails_to_splice(ads: list[dict], segments: list[dict],

--- a/src/ad_detector/boundaries.py
+++ b/src/ad_detector/boundaries.py
@@ -1317,6 +1317,7 @@ def snap_terminal_ad_to_splice(ads: list[dict], segments: list[dict],
                                episode_duration: float,
                                window_s: float,
                                coverage_ads: list[dict] | None = None,
+                               blocking_ads: list[dict] | None = None,
                                eof_tolerance_s: float = TERMINAL_SNAP_EOF_TOLERANCE_SECONDS,
                                podcast_name: str = None) -> list[dict]:
     """Snap a terminal ad's start back to the strongest deep-silence splice.
@@ -1357,6 +1358,13 @@ def snap_terminal_ad_to_splice(ads: list[dict], segments: list[dict],
             ad_sponsors = extract_sponsor_names(
                 ad_text, ad_copy.get('reason'), exclude=own_site)
             for event in candidates:
+                if any(
+                        blocker.get('start') is not None
+                        and blocker.get('end') is not None
+                        and blocker['start'] < ad_copy['start']
+                        and blocker['end'] > event['time']
+                        for blocker in (blocking_ads or [])):
+                    continue
                 if _span_blocked_by_content(segments, coverage, ad_sponsors,
                                             event['time'], ad_copy['start']):
                     continue

--- a/src/ad_detector/boundaries.py
+++ b/src/ad_detector/boundaries.py
@@ -829,6 +829,13 @@ def _merge_ad_pair(current_ad: dict, next_ad: dict, gap_desc: str = "") -> None:
     """
     mark_distinct_merge(current_ad, next_ad)
     current_ad['end'] = next_ad['end']
+    # The tail-sweep marker describes how the *current end* was reached. Once
+    # this merge replaces that edge, only the later fragment's flag remains
+    # meaningful; retaining the earlier fragment's flag could snap past an
+    # otherwise final, non-content-derived boundary.
+    current_ad.pop('end_extended_by_content', None)
+    if next_ad.get('end_extended_by_content'):
+        current_ad['end_extended_by_content'] = True
     current_ad['confidence'] = max(current_ad.get('confidence', 0.0),
                                    next_ad.get('confidence', 0.0))
 

--- a/src/ad_reviewer.py
+++ b/src/ad_reviewer.py
@@ -75,6 +75,9 @@ REVIEWER_CONTRADICTION_PATTERNS = (
     r'\bcontains?\s+only\s+the\s+(?:phrase|fragment|words?)\b',
     r'\btranscription\s+artifact\b',
     r'\b(?:is\s+|entirely\s+)organic\s+conversation\b',
+    r'\bnone\s+(?:of\s+(?:them|these|those)\s+)?(?:are|is)\s+'
+    r'(?:an?\s+)?ads?\b',
+    r'\b(?:they|these|those)\s+are\s+not\s+(?:an?\s+)?ads?\b',
 )
 
 _CONTRADICTION_RES = tuple(re.compile(p) for p in REVIEWER_CONTRADICTION_PATTERNS)
@@ -132,6 +135,17 @@ _EXPLICIT_BOUNDARY_TRIM_RE = re.compile(
     re.IGNORECASE,
 )
 
+_WHOLE_CANDIDATE_NEGATION_RE = re.compile(
+    r'\bnone\s+(?:of\s+(?:them|these|those)\s+)?(?:are|is)\s+'
+    r'(?:an?\s+)?ads?\b'
+    r'|\b(?:they|these|those)\s+are\s+not\s+(?:ads?|advertis\w*)\b'
+    r'|\b(?:this|it|the\s+)?(?:entire\s+|whole\s+|full\s+)?'
+    r'(?:candidate|span|segment|block)\s+(?:is|contains?)\s+'
+    r'(?:not\s+(?:an?\s+ad|advertis\w*)|no\s+(?:ad|advertis\w*))\b'
+    r'|\b(?:this|it)\s+is\s+not\s+(?:an?\s+ad|advertis\w*)\b',
+    re.IGNORECASE,
+)
+
 # In-range slack for recovered trim bounds. A recovered edge may sit up to
 # this far outside the original span (float noise from the model re-reading
 # timestamps) and is clamped back in; anything further out is rejected.
@@ -153,12 +167,21 @@ def reasoning_affirms_ad(reasoning: str | None) -> bool:
     if not reasoning:
         return False
     lowered = reasoning.lower()
+    whole_negations = list(_WHOLE_CANDIDATE_NEGATION_RE.finditer(lowered))
     for regex in _AFFIRMATION_RES:
         match = regex.search(lowered)
         if not match:
             continue
+        # A broad positive phrase such as "are ads" can be a substring of
+        # the explicit denial "none are ads". Never count text inside the
+        # denial itself as a separate affirmation.
+        if any(neg.start() <= match.start() and match.end() <= neg.end()
+               for neg in whole_negations):
+            continue
         if regex is _ELLIPTICAL_AFFIRMATION_RE:
             tail = lowered[match.end():]
+            if any(neg.start() >= match.end() for neg in whole_negations):
+                continue
             contradiction_positions = [
                 found.start()
                 for contradiction in _CONTRADICTION_RES

--- a/src/ad_reviewer.py
+++ b/src/ad_reviewer.py
@@ -103,10 +103,7 @@ REVIEWER_AFFIRMATION_PATTERNS = (
 )
 
 _AFFIRMATION_RES = tuple(re.compile(p) for p in REVIEWER_AFFIRMATION_PATTERNS)
-_NEGATED_ELLIPTICAL_AFFIRMATION_RE = re.compile(
-    r'^\s*(?:multiple|several)\s+(?:[\w-]+\s+){0,2}ads?(?!-)\b\s+'
-    r'(?:(?:are|were)\s+not|(?:aren|weren)[\'’]t)\b'
-)
+_ELLIPTICAL_AFFIRMATION_RE = _AFFIRMATION_RES[-1]
 
 # Trim-language precheck: only spend the recovery LLM call when the
 # reasoning describes a sub-span trim; plain "not an ad" skips it.
@@ -144,9 +141,23 @@ def reasoning_affirms_ad(reasoning: str | None) -> bool:
     if not reasoning:
         return False
     lowered = reasoning.lower()
-    if _NEGATED_ELLIPTICAL_AFFIRMATION_RE.search(lowered):
-        return False
-    return any(r.search(lowered) for r in _AFFIRMATION_RES)
+    for regex in _AFFIRMATION_RES:
+        match = regex.search(lowered)
+        if not match:
+            continue
+        if regex is _ELLIPTICAL_AFFIRMATION_RE:
+            tail = lowered[match.end():]
+            contradiction_positions = [
+                found.start()
+                for contradiction in _CONTRADICTION_RES
+                if (found := contradiction.search(tail)) is not None
+            ]
+            if contradiction_positions:
+                trim = _TRIM_LANGUAGE_RE.search(tail)
+                if trim is None or min(contradiction_positions) < trim.start():
+                    continue
+        return True
+    return False
 
 
 def reasoning_contradicts_cut(reasoning: str | None) -> bool:

--- a/src/ad_reviewer.py
+++ b/src/ad_reviewer.py
@@ -180,30 +180,28 @@ def reasoning_affirms_ad(reasoning: str | None) -> bool:
     lowered = reasoning.lower()
     whole_negations = list(_WHOLE_CANDIDATE_NEGATION_RE.finditer(lowered))
     for regex in _AFFIRMATION_RES:
-        match = regex.search(lowered)
-        if not match:
-            continue
-        # A broad positive phrase such as "are ads" can be a substring of
-        # the explicit denial "none are ads". Never count text inside the
-        # denial itself as a separate affirmation.
-        if any(neg.start() <= match.start() and match.end() <= neg.end()
-               for neg in whole_negations):
-            continue
-        if regex is _ELLIPTICAL_AFFIRMATION_RE:
-            tail = lowered[match.end():]
-            if any(neg.start() >= match.end() for neg in whole_negations):
+        for match in regex.finditer(lowered):
+            # A broad positive phrase such as "are ads" can be a substring
+            # of the explicit denial "none are ads". Ignore that occurrence,
+            # but keep scanning in case a later assertion is affirmative.
+            if any(neg.start() <= match.start() and match.end() <= neg.end()
+                   for neg in whole_negations):
                 continue
-            contradiction_positions = [
-                found.start()
-                for contradiction in _CONTRADICTION_RES
-                if (found := contradiction.search(tail)) is not None
-            ]
-            if contradiction_positions:
-                boundary_trim = _EXPLICIT_BOUNDARY_TRIM_RE.search(tail)
-                if (boundary_trim is None
-                        or min(contradiction_positions) < boundary_trim.start()):
+            if regex is _ELLIPTICAL_AFFIRMATION_RE:
+                tail = lowered[match.end():]
+                if any(neg.start() >= match.end() for neg in whole_negations):
                     continue
-        return True
+                contradiction_positions = [
+                    found.start()
+                    for contradiction in _CONTRADICTION_RES
+                    if (found := contradiction.search(tail)) is not None
+                ]
+                if contradiction_positions:
+                    boundary_trim = _EXPLICIT_BOUNDARY_TRIM_RE.search(tail)
+                    if (boundary_trim is None
+                            or min(contradiction_positions) < boundary_trim.start()):
+                        continue
+            return True
     return False
 
 

--- a/src/ad_reviewer.py
+++ b/src/ad_reviewer.py
@@ -31,7 +31,7 @@ from llm_client import (
 )
 from utils.llm_call import call_llm, call_llm_for_window
 from utils.llm_response import extract_json_ads_array, extract_json_object
-from utils.markers import dai_core_bounds
+from utils.markers import dai_core_bounds, invalidate_tail_provenance
 from utils.prompt import format_sponsor_block, render_prompt, apply_override
 from utils.text import (
     BOUNDARY_SNAP_TOLERANCE_S,
@@ -65,6 +65,13 @@ def _review_failure_reason(error: Exception) -> str:
 # as "confirmed" -- hold those for review, never auto-reject. Patterns are
 # assertion-shaped regexes ("is not advertising"), not bare nouns: an
 # affirming reasoning ("not a false positive") must not trigger a hold.
+_PLURAL_NEGATION_PATTERN = (
+    r'\bnone\s+(?:of\s+(?:them|these|those)\s+)?(?:are|is)\s+'
+    r'(?:an?\s+)?ads?\b'
+    r'|\b(?:they|these|those)\s+are\s+not\s+'
+    r'(?:an?\s+)?(?:ads?|advertis\w*)\b'
+)
+
 REVIEWER_CONTRADICTION_PATTERNS = (
     r'\bcontains?\s+no\s+advertis',            # "contain(s) no advertising content"
     r'\bis\s+not\s+(?:an?\s+)?(?:paid\s+)?advertis',  # "is not advertising"
@@ -75,9 +82,7 @@ REVIEWER_CONTRADICTION_PATTERNS = (
     r'\bcontains?\s+only\s+the\s+(?:phrase|fragment|words?)\b',
     r'\btranscription\s+artifact\b',
     r'\b(?:is\s+|entirely\s+)organic\s+conversation\b',
-    r'\bnone\s+(?:of\s+(?:them|these|those)\s+)?(?:are|is)\s+'
-    r'(?:an?\s+)?ads?\b',
-    r'\b(?:they|these|those)\s+are\s+not\s+(?:an?\s+)?ads?\b',
+    _PLURAL_NEGATION_PATTERN,
 )
 
 _CONTRADICTION_RES = tuple(re.compile(p) for p in REVIEWER_CONTRADICTION_PATTERNS)
@@ -93,6 +98,9 @@ _CONTRADICTION_RES = tuple(re.compile(p) for p in REVIEWER_CONTRADICTION_PATTERN
 # growing free-text heuristic (each pattern traces to a production episode).
 # The durable fix is a structured verdict field (e.g. is_ad plus trim bounds)
 # in the review prompt contract, so intent stops hiding in prose.
+_ELLIPTICAL_AFFIRMATION_PATTERN = (
+    r'^\s*(?:multiple|several)\s+(?:[\w-]+\s+){0,2}ads?(?!-)\b')
+
 REVIEWER_AFFIRMATION_PATTERNS = (
     r'\bis\s+an?\s+ad\s+break\b',
     r'\bis\s+an?\s+(?:genuine\s+|real\s+|actual\s+|paid\s+|'
@@ -102,11 +110,16 @@ REVIEWER_AFFIRMATION_PATTERNS = (
     # Elliptical reviewer prose often begins with the classification rather
     # than a verb: "Multiple Norwegian ads ... adjusted start to exclude ...".
     # This is still an explicit affirmation when paired with trim language.
-    r'^\s*(?:multiple|several)\s+(?:[\w-]+\s+){0,2}ads?(?!-)\b',
+    _ELLIPTICAL_AFFIRMATION_PATTERN,
 )
 
-_AFFIRMATION_RES = tuple(re.compile(p) for p in REVIEWER_AFFIRMATION_PATTERNS)
-_ELLIPTICAL_AFFIRMATION_RE = _AFFIRMATION_RES[-1]
+_AFFIRMATION_RES_BY_PATTERN = {
+    pattern: re.compile(pattern) for pattern in REVIEWER_AFFIRMATION_PATTERNS
+}
+_AFFIRMATION_RES = tuple(
+    _AFFIRMATION_RES_BY_PATTERN[p] for p in REVIEWER_AFFIRMATION_PATTERNS)
+_ELLIPTICAL_AFFIRMATION_RE = _AFFIRMATION_RES_BY_PATTERN[
+    _ELLIPTICAL_AFFIRMATION_PATTERN]
 
 # Trim-language precheck: only spend the recovery LLM call when the
 # reasoning describes a sub-span trim; plain "not an ad" skips it.
@@ -136,10 +149,8 @@ _EXPLICIT_BOUNDARY_TRIM_RE = re.compile(
 )
 
 _WHOLE_CANDIDATE_NEGATION_RE = re.compile(
-    r'\bnone\s+(?:of\s+(?:them|these|those)\s+)?(?:are|is)\s+'
-    r'(?:an?\s+)?ads?\b'
-    r'|\b(?:they|these|those)\s+are\s+not\s+(?:ads?|advertis\w*)\b'
-    r'|\b(?:this|it|the\s+)?(?:entire\s+|whole\s+|full\s+)?'
+    _PLURAL_NEGATION_PATTERN
+    + r'|\b(?:this|it|the\s+)?(?:entire\s+|whole\s+|full\s+)?'
     r'(?:candidate|span|segment|block)\s+(?:is|contains?)\s+'
     r'(?:not\s+(?:an?\s+ad|advertis\w*)|no\s+(?:ad|advertis\w*))\b'
     r'|\b(?:this|it)\s+is\s+not\s+(?:an?\s+ad|advertis\w*)\b',
@@ -222,14 +233,9 @@ def _adjusted_ad_copy(ad: dict, start: float, end: float,
     adjust paths (boundary-delta adjust, affirmed-confirm trim recovery)
     cannot drift on which fields they write."""
     updated = dict(ad)
+    invalidate_tail_provenance(updated, end)
     updated["start"] = start
     updated["end"] = end
-    if end != ad.get("end"):
-        # Content-tail provenance describes how the old edge was reached.
-        # A reviewer-selected end must earn any later sonic-tail extension
-        # from fresh content evidence instead of reusing stale eligibility.
-        updated.pop("end_extended_by_content", None)
-        updated.pop("tail_splice_snap", None)
     updated["reviewer_verdict"] = "adjust"
     updated["reviewer_original_start"] = original_start
     updated["reviewer_original_end"] = original_end

--- a/src/ad_reviewer.py
+++ b/src/ad_reviewer.py
@@ -1278,6 +1278,11 @@ class AdReviewer:
         if core_start is not None:
             start = min(start, core_start)
             end = max(end, core_end)
+        # Protected merge members or measured DAI evidence can widen the
+        # recovered proposal back to the full marker. That is no longer a
+        # trim, so neither review path should surface it as one.
+        if (start - o_start) + (o_end - end) <= _CONFIRMED_BOUNDARY_TOLERANCE_S:
+            return None
         return start, end
 
     @staticmethod

--- a/src/ad_reviewer.py
+++ b/src/ad_reviewer.py
@@ -31,6 +31,7 @@ from llm_client import (
 )
 from utils.llm_call import call_llm, call_llm_for_window
 from utils.llm_response import extract_json_ads_array, extract_json_object
+from utils.markers import dai_core_bounds
 from utils.prompt import format_sponsor_block, render_prompt, apply_override
 from utils.text import (
     BOUNDARY_SNAP_TOLERANCE_S,
@@ -1123,6 +1124,23 @@ class AdReviewer:
                 )
             clamped_start, clamped_end = floor_start, floor_end
 
+        # Cross-fetch evidence remains authoritative inside a merged
+        # candidate. The reviewer may trim coarse LLM/VAD extensions outside
+        # these measured regions, but cannot leave part of an inserted block
+        # in the published episode.
+        core_start, core_end = dai_core_bounds(ad)
+        if core_start is not None:
+            floor_start = min(clamped_start, core_start)
+            floor_end = max(clamped_end, core_end)
+            if floor_start != clamped_start or floor_end != clamped_end:
+                logger.info(
+                    f"[{slug}:{episode_id}] Reviewer inward shrink clamped "
+                    f"to DAI core @ {core_start:.1f}-{core_end:.1f}s: "
+                    f"{clamped_start:.1f}-{clamped_end:.1f} -> "
+                    f"{floor_start:.1f}-{floor_end:.1f}"
+                )
+            clamped_start, clamped_end = floor_start, floor_end
+
         if clamped_end <= clamped_start:
             clamped_start, clamped_end = original_start, original_end
         return clamped_start, clamped_end
@@ -1256,6 +1274,10 @@ class AdReviewer:
                 start = min(start, p_start)
             if p_end is not None:
                 end = max(end, p_end)
+        core_start, core_end = dai_core_bounds(ad)
+        if core_start is not None:
+            start = min(start, core_start)
+            end = max(end, core_end)
         return start, end
 
     @staticmethod

--- a/src/ad_reviewer.py
+++ b/src/ad_reviewer.py
@@ -103,6 +103,10 @@ REVIEWER_AFFIRMATION_PATTERNS = (
 )
 
 _AFFIRMATION_RES = tuple(re.compile(p) for p in REVIEWER_AFFIRMATION_PATTERNS)
+_NEGATED_ELLIPTICAL_AFFIRMATION_RE = re.compile(
+    r'^\s*(?:multiple|several)\s+(?:[\w-]+\s+){0,2}ads?(?!-)\b\s+'
+    r'(?:(?:are|were)\s+not|(?:aren|weren)[\'’]t)\b'
+)
 
 # Trim-language precheck: only spend the recovery LLM call when the
 # reasoning describes a sub-span trim; plain "not an ad" skips it.
@@ -140,6 +144,8 @@ def reasoning_affirms_ad(reasoning: str | None) -> bool:
     if not reasoning:
         return False
     lowered = reasoning.lower()
+    if _NEGATED_ELLIPTICAL_AFFIRMATION_RE.search(lowered):
+        return False
     return any(r.search(lowered) for r in _AFFIRMATION_RES)
 
 
@@ -171,6 +177,12 @@ def _adjusted_ad_copy(ad: dict, start: float, end: float,
     updated = dict(ad)
     updated["start"] = start
     updated["end"] = end
+    if end != ad.get("end"):
+        # Content-tail provenance describes how the old edge was reached.
+        # A reviewer-selected end must earn any later sonic-tail extension
+        # from fresh content evidence instead of reusing stale eligibility.
+        updated.pop("end_extended_by_content", None)
+        updated.pop("tail_splice_snap", None)
     updated["reviewer_verdict"] = "adjust"
     updated["reviewer_original_start"] = original_start
     updated["reviewer_original_end"] = original_end

--- a/src/ad_reviewer.py
+++ b/src/ad_reviewer.py
@@ -726,7 +726,10 @@ class AdReviewer:
         for verdict, updated_ad in accepted_results:
             # Human corrections are the highest-confidence signal. They are
             # deliberately omitted from the reviewer call and retain their
-            # validated bounds and cut decision unchanged.
+            # validated bounds and cut decision unchanged. Do not synthesize
+            # a ReviewVerdict here: ad_reviewer_log and its totalReviews stat
+            # count actual LLM calls. The persisted validation.user_confirmed
+            # field is the audit record for this human-authorized bypass.
             if verdict is None:
                 result.accepted_after_review.append(updated_ad)
                 continue

--- a/src/ad_reviewer.py
+++ b/src/ad_reviewer.py
@@ -99,7 +99,7 @@ REVIEWER_AFFIRMATION_PATTERNS = (
     # Elliptical reviewer prose often begins with the classification rather
     # than a verb: "Multiple Norwegian ads ... adjusted start to exclude ...".
     # This is still an explicit affirmation when paired with trim language.
-    r'^(?:multiple|several)\s+(?:[\w-]+\s+){0,2}ads?(?!-)\b',
+    r'^\s*(?:multiple|several)\s+(?:[\w-]+\s+){0,2}ads?(?!-)\b',
 )
 
 _AFFIRMATION_RES = tuple(re.compile(p) for p in REVIEWER_AFFIRMATION_PATTERNS)

--- a/src/ad_reviewer.py
+++ b/src/ad_reviewer.py
@@ -120,6 +120,18 @@ _TRIM_LANGUAGE_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Elliptical openings ("Multiple ads ...") need stronger scoping than a
+# generic word such as "excluded".  When their prose also contains a
+# negation, only an explicit edge adjustment establishes that the negation
+# describes preserved context rather than the whole candidate.
+_EXPLICIT_BOUNDARY_TRIM_RE = re.compile(
+    r'\b(?:adjust(?:ed|ing)?|move[sd]?|shift(?:ed|ing)?|trim(?:med|ming)?)\s+'
+    r'(?:the\s+)?(?:start|end|boundar(?:y|ies))\b'
+    r'|\b(?:start|end|boundar(?:y|ies))\s+(?:was\s+)?'
+    r'(?:adjusted|moved|shifted|trimmed)\b',
+    re.IGNORECASE,
+)
+
 # In-range slack for recovered trim bounds. A recovered edge may sit up to
 # this far outside the original span (float noise from the model re-reading
 # timestamps) and is clamped back in; anything further out is rejected.
@@ -153,8 +165,9 @@ def reasoning_affirms_ad(reasoning: str | None) -> bool:
                 if (found := contradiction.search(tail)) is not None
             ]
             if contradiction_positions:
-                trim = _TRIM_LANGUAGE_RE.search(tail)
-                if trim is None or min(contradiction_positions) < trim.start():
+                boundary_trim = _EXPLICIT_BOUNDARY_TRIM_RE.search(tail)
+                if (boundary_trim is None
+                        or min(contradiction_positions) < boundary_trim.start()):
                     continue
         return True
     return False

--- a/src/ad_reviewer.py
+++ b/src/ad_reviewer.py
@@ -96,6 +96,10 @@ REVIEWER_AFFIRMATION_PATTERNS = (
     r'dynamically\s+inserted\s+)?ad(?:vertisement)?(?!-)\b',
     r'\bare\s+(?:all\s+)?(?:genuine\s+|real\s+)?ads(?!-)\b',
     r'\bis\s+(?:genuine\s+|real\s+|paid\s+)?advertising\b',
+    # Elliptical reviewer prose often begins with the classification rather
+    # than a verb: "Multiple Norwegian ads ... adjusted start to exclude ...".
+    # This is still an explicit affirmation when paired with trim language.
+    r'^(?:multiple|several)\s+(?:[\w-]+\s+){0,2}ads?(?!-)\b',
 )
 
 _AFFIRMATION_RES = tuple(re.compile(p) for p in REVIEWER_AFFIRMATION_PATTERNS)
@@ -697,6 +701,12 @@ class AdReviewer:
             max_workers=parallel_ads,
         )
         for verdict, updated_ad in accepted_results:
+            # Human corrections are the highest-confidence signal. They are
+            # deliberately omitted from the reviewer call and retain their
+            # validated bounds and cut decision unchanged.
+            if verdict is None:
+                result.accepted_after_review.append(updated_ad)
+                continue
             result.verdicts.append(verdict)
             log_contradiction_event(
                 verdict, model=verdict.model_used,
@@ -845,6 +855,9 @@ class AdReviewer:
             return []
 
         def _run_one(idx):
+            if (pool == "accepted"
+                    and (ads[idx].get("validation") or {}).get("user_confirmed")):
+                return None, ads[idx]
             return self._review_single(
                 ad=ads[idx],
                 pool=pool,

--- a/src/ad_reviewer.py
+++ b/src/ad_reviewer.py
@@ -1243,28 +1243,6 @@ class AdReviewer:
         end = min(end, o_end)
         if end <= start:
             return None
-        # Must be a strict sub-span: a result that shrinks the span by less
-        # than the confirmed-boundary tolerance is indistinguishable from
-        # the full span and offers no trim worth surfacing.
-        if (start - o_start) + (o_end - end) <= _CONFIRMED_BOUNDARY_TOLERANCE_S:
-            return None
-        # Sanity floor: a recovered ad portion shorter than the minimum we would
-        # ever remove from audio is more likely a hallucinated sub-span than a
-        # real trim of a span the model itself flagged as an ad. Fall back to
-        # holding without bounds (today's behavior) rather than pre-fill the
-        # review UI with a bad one-tap trim.
-        if end - start < MIN_AD_DURATION_FOR_REMOVAL:
-            logger.info(
-                f"[{slug}:{episode_id}] {call_label} recovered trim "
-                f"{start:.1f}-{end:.1f}s is {end - start:.1f}s, under the "
-                f"{MIN_AD_DURATION_FOR_REMOVAL:.0f}s floor for span "
-                f"{o_start:.1f}-{o_end:.1f}s. Holding without bounds."
-            )
-            return None
-        logger.info(
-            f"[{slug}:{episode_id}] {call_label} recovered proposed trim "
-            f"{start:.1f}-{end:.1f}s from span {o_start:.1f}-{o_end:.1f}s"
-        )
         # Widen back out to the protected union so a tracked merged ad's
         # recovered trim cannot sever a transcript-anchored member.
         if ad.get('merged_distinct_ads'):
@@ -1283,6 +1261,21 @@ class AdReviewer:
         # trim, so neither review path should surface it as one.
         if (start - o_start) + (o_end - end) <= _CONFIRMED_BOUNDARY_TOLERANCE_S:
             return None
+        # Evaluate the render floor after protected bounds expand the model's
+        # raw proposal. A tiny proposal inside a substantial measured core is
+        # still a valid core-sized trim.
+        if end - start < MIN_AD_DURATION_FOR_REMOVAL:
+            logger.info(
+                f"[{slug}:{episode_id}] {call_label} recovered trim "
+                f"{start:.1f}-{end:.1f}s is {end - start:.1f}s, under the "
+                f"{MIN_AD_DURATION_FOR_REMOVAL:.0f}s floor for span "
+                f"{o_start:.1f}-{o_end:.1f}s. Holding without bounds."
+            )
+            return None
+        logger.info(
+            f"[{slug}:{episode_id}] {call_label} recovered proposed trim "
+            f"{start:.1f}-{end:.1f}s from span {o_start:.1f}-{o_end:.1f}s"
+        )
         return start, end
 
     @staticmethod

--- a/src/ad_reviewer.py
+++ b/src/ad_reviewer.py
@@ -189,7 +189,12 @@ def reasoning_affirms_ad(reasoning: str | None) -> bool:
                 continue
             if regex is _ELLIPTICAL_AFFIRMATION_RE:
                 tail = lowered[match.end():]
-                if any(neg.start() >= match.end() for neg in whole_negations):
+                boundary_trim = _EXPLICIT_BOUNDARY_TRIM_RE.search(tail)
+                scoped_trim = (
+                    boundary_trim is not None
+                    and _TRIM_LANGUAGE_RE.search(tail) is not None)
+                if (any(neg.start() >= match.end() for neg in whole_negations)
+                        and not scoped_trim):
                     continue
                 contradiction_positions = [
                     found.start()
@@ -197,8 +202,7 @@ def reasoning_affirms_ad(reasoning: str | None) -> bool:
                     if (found := contradiction.search(tail)) is not None
                 ]
                 if contradiction_positions:
-                    boundary_trim = _EXPLICIT_BOUNDARY_TRIM_RE.search(tail)
-                    if (boundary_trim is None
+                    if (not scoped_trim
                             or min(contradiction_positions) < boundary_trim.start()):
                         continue
             return True

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -428,17 +428,22 @@ class AdValidator:
 
         # A single approved span can overlap several fragments from one DAI
         # re-detection. Each would later restore to that exact same span, so
-        # retain only the first before merge protection keeps them separate.
+        # retain only the first overlapping fragment before merge protection
+        # keeps them separate. Fragments in user-kept content still need
+        # normal validation and must not consume the approved-span match.
         restored_corrections = set()
         deduplicated_ads = []
         for ad in ads:
             confirmed = ad.get('_pre_dai_restore_confirmed_correction')
+            span = confirmed.get('confirmed_span') if confirmed else None
+            overlaps_approved = (span is not None
+                                 and ad['start'] < span['end']
+                                 and ad['end'] > span['start'])
             correction_id = id(confirmed)
-            if (confirmed is not None
-                    and confirmed.get('confirmed_span')
+            if (overlaps_approved
                     and correction_id in restored_corrections):
                 continue
-            if confirmed is not None and confirmed.get('confirmed_span'):
+            if overlaps_approved:
                 restored_corrections.add(correction_id)
             deduplicated_ads.append(ad)
         ads = deduplicated_ads

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -537,6 +537,9 @@ class AdValidator:
                     'decision': Decision.ACCEPT.value,
                     'adjusted_confidence': 1.0,
                     'original_confidence': ad.get('confidence', 1.0),
+                    # Nested under the validator-owned result so an arbitrary
+                    # detector/model field cannot forge this trust signal.
+                    'user_confirmed': True,
                     'flags': flags,
                     'corrections': corrections
                 }

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -428,9 +428,10 @@ class AdValidator:
 
         # A single approved span can overlap several fragments from one DAI
         # re-detection. Each would later restore to that exact same span, so
-        # retain only the first overlapping fragment before merge protection
-        # keeps them separate. Fragments in user-kept content still need
-        # normal validation and must not consume the approved-span match.
+        # retain only the first eligible overlapping fragment before merge
+        # protection keeps them separate. Fragments in user-kept content or
+        # rejected as false positives still need normal validation and must
+        # not consume the approved-span match.
         restored_corrections = set()
         deduplicated_ads = []
         for ad in ads:
@@ -440,10 +441,13 @@ class AdValidator:
                                  and ad['start'] < span['end']
                                  and ad['end'] > span['start'])
             correction_id = id(confirmed)
-            if (overlaps_approved
+            can_restore_approved_span = (
+                overlaps_approved
+                and not ad.get('_matches_false_positive_correction'))
+            if (can_restore_approved_span
                     and correction_id in restored_corrections):
                 continue
-            if overlaps_approved:
+            if can_restore_approved_span:
                 restored_corrections.add(correction_id)
             deduplicated_ads.append(ad)
         ads = deduplicated_ads

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -399,8 +399,12 @@ class AdValidator:
         for ad in ads:
             ad['_matches_false_positive_correction'] = (
                 self._overlaps_false_positive(ad['start'], ad['end']))
-            ad['_pre_restore_confirmed_correction'] = (
-                self._matching_confirmed(ad['start'], ad['end']))
+            core_start, core_end = dai_core_bounds(ad)
+            if ((core_start is not None and core_start < ad['start'])
+                    or (core_end is not None and core_end > ad['end'])):
+                confirmed = self._matching_confirmed(ad['start'], ad['end'])
+                if confirmed is not None:
+                    ad['_pre_dai_restore_confirmed_correction'] = confirmed
 
         # Step 1: Auto-correct boundaries
         ads = self._clamp_boundaries(ads, result)
@@ -470,7 +474,7 @@ class AdValidator:
         matched_false_positive = ad.pop(
             '_matches_false_positive_correction', False)
         pre_restore_confirmed = ad.pop(
-            '_pre_restore_confirmed_correction', None)
+            '_pre_dai_restore_confirmed_correction', None)
         if (matched_false_positive
                 or self._overlaps_false_positive(ad['start'], ad['end'])):
             flags.append("INFO: User marked as false positive")
@@ -1120,8 +1124,8 @@ class AdValidator:
                     or current.get('vad_gap_requires_review')
                     or bool(last.get('differential_uncorroborated'))
                     != bool(current.get('differential_uncorroborated'))
-                    or last.get('_pre_restore_confirmed_correction') is not None
-                    or current.get('_pre_restore_confirmed_correction') is not None
+                    or last.get('_pre_dai_restore_confirmed_correction') is not None
+                    or current.get('_pre_dai_restore_confirmed_correction') is not None
                     or bool(last.get('_matches_false_positive_correction'))
                     != bool(current.get('_matches_false_positive_correction'))):
                 merged.append(current.copy())

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -499,6 +499,11 @@ class AdValidator:
                     flags.append("INFO: Clamped to user-approved span")
                     ad['start'] = new_start
                     ad['end'] = new_end
+                    # Human trims are authoritative. A measured DAI core may
+                    # have been clipped to the wider detected bounds earlier;
+                    # keep it inside the approved span so the reviewer cannot
+                    # later widen the marker back into user-kept content.
+                    clip_dai_core_spans(ad, new_start, new_end)
             if auto_accept:
                 flags.append("INFO: User confirmed as ad")
                 logger.info(

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -346,20 +346,16 @@ class AdValidator:
                             overlap_threshold: float = CORRECTION_MATCH_MIN_COVERAGE) -> dict | None:
         """Return a user-confirmed correction covering >= threshold of the
         range, or None. Mirrors _overlaps_confirmed but yields the match so
-        the caller can honor a trimmed approval's confirmed_span. A trimmed
-        approval wins over a plain confirm covering the same range -- it is
-        the more specific user intent and must not be shadowed."""
+        the caller can honor an exact ``confirmed_span``. Corrections arrive
+        newest first, so the latest overlapping user decision is authoritative.
+        """
         segment_duration = end - start
         if segment_duration < 0.001:
             return None
-        plain = None
         for corr in self.confirmed_corrections:
             if overlap_ratio(corr['start'], corr['end'], start, end) >= overlap_threshold:
-                if corr.get('confirmed_span'):
-                    return corr
-                if plain is None:
-                    plain = corr
-        return plain
+                return corr
+        return None
 
     def validate(self, ads: list[dict],
                  audio_analysis: dict | None = None,

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -25,7 +25,12 @@ from config import (
     MAX_ADJACENT_AUTO_EXTENSION_SECONDS,
     normalize_segment_category, DEFAULT_SEGMENT_ACTION,
 )
-from utils.markers import clip_dai_core_spans, dai_core_bounds, mark_distinct_merge
+from utils.markers import (
+    clip_dai_core_spans,
+    dai_core_bounds,
+    invalidate_tail_provenance,
+    mark_distinct_merge,
+)
 from utils.text import extract_text_from_segments
 from utils.time import overlap_ratio
 
@@ -536,12 +541,7 @@ class AdValidator:
                         f"to user-approved span {new_start:.1f}s-{new_end:.1f}s"
                     )
                     flags.append("INFO: Clamped to user-approved span")
-                    if new_end != ad['end']:
-                        # The old tail provenance belongs to the superseded
-                        # edge. Retaining it would let the final splice sweep
-                        # grow past a human-approved end.
-                        ad.pop('end_extended_by_content', None)
-                        ad.pop('tail_splice_snap', None)
+                    invalidate_tail_provenance(ad, new_end)
                     ad['start'] = new_start
                     ad['end'] = new_end
                     # Human trims are authoritative. A measured DAI core may

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -1250,7 +1250,9 @@ class AdValidator:
             # trimmed confirm so the confirmed_span clamp never fires and
             # trimmed-out audio gets cut. A false-positive-correction match
             # on only one side likewise blocks the fold: the match must keep
-            # describing exactly the span the human rejected.
+            # describing exactly the span the human rejected. A confirmed
+            # correction on either marker also blocks the merge: even a
+            # shared correction must not authorize the adjacent audio.
             if (last.get('held_for_review')
                     or current.get('held_for_review')
                     or last.get('vad_gap_requires_review')

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -25,7 +25,7 @@ from config import (
     MAX_ADJACENT_AUTO_EXTENSION_SECONDS,
     normalize_segment_category, DEFAULT_SEGMENT_ACTION,
 )
-from utils.markers import clip_dai_core_spans, mark_distinct_merge
+from utils.markers import clip_dai_core_spans, dai_core_bounds, mark_distinct_merge
 from utils.text import extract_text_from_segments
 from utils.time import overlap_ratio
 
@@ -952,6 +952,24 @@ class AdValidator:
             Ads with clamped boundaries
         """
         for ad in ads:
+            # Cue/silence snaps are advisory and may move inward before this
+            # validator runs. Measured DAI evidence is not advisory: restore
+            # any core portion an automatic snap crossed before applying the
+            # real file-range clamp. A later human-confirmed trim remains
+            # authoritative and clips the core in _validate_ad.
+            core_start, core_end = dai_core_bounds(ad)
+            if core_start is not None:
+                if core_start < ad['start']:
+                    result.corrections.append(
+                        f"Restored start {ad['start']:.1f}s to measured DAI "
+                        f"core {core_start:.1f}s")
+                    ad['start'] = core_start
+                if core_end > ad['end']:
+                    result.corrections.append(
+                        f"Restored end {ad['end']:.1f}s to measured DAI "
+                        f"core {core_end:.1f}s")
+                    ad['end'] = core_end
+
             if ad['start'] < 0:
                 original = ad['start']
                 ad['start'] = 0
@@ -972,6 +990,7 @@ class AdValidator:
                     and ad.get('merged_protected_end') is not None
                     and ad['merged_protected_end'] > self.episode_duration):
                 ad['merged_protected_end'] = self.episode_duration
+            # Only the physical episode bounds may truncate measured evidence.
             clip_dai_core_spans(ad, ad['start'], ad['end'])
         return ads
 

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -371,7 +371,18 @@ class AdValidator:
         if segment_duration < 0.001:
             return None
         for corr in self.confirmed_corrections:
-            if overlap_ratio(corr['start'], corr['end'], start, end) >= overlap_threshold:
+            confirmed_span = corr.get('confirmed_span')
+            matches_original = (
+                overlap_ratio(corr['start'], corr['end'], start, end)
+                >= overlap_threshold
+            )
+            matches_approved = (
+                confirmed_span
+                and overlap_ratio(
+                    confirmed_span['start'], confirmed_span['end'], start, end)
+                >= overlap_threshold
+            )
+            if matches_original or matches_approved:
                 return corr
         return None
 

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -489,7 +489,6 @@ class AdValidator:
             '_matches_false_positive_correction', False)
         pre_restore_confirmed = ad.pop(
             '_pre_dai_restore_confirmed_correction', None)
-        matched_before_dai_restore = pre_restore_confirmed is not None
         if (matched_false_positive
                 or self._overlaps_false_positive(ad['start'], ad['end'])):
             flags.append("INFO: User marked as false positive")
@@ -511,57 +510,36 @@ class AdValidator:
         confirmed = (pre_restore_confirmed
                      or self._matching_confirmed(ad['start'], ad['end']))
         if confirmed is not None:
-            # A trimmed approval confirmed only a sub-span as ad. Pull a
-            # boundary inward only when it falls in a trimmed-out zone (inside
-            # the reviewed original bounds but outside the approved span) so
-            # the content the user explicitly kept is never re-cut; parts of
-            # the detection beyond the reviewed bounds are new territory and
-            # are left alone.
+            # A trimmed approval confirms exactly one sub-span as ad. A later
+            # detection can be wider, but that must neither authorize the new
+            # territory nor prevent the known-positive span from being cut.
             span = confirmed.get('confirmed_span')
             auto_accept = True
             if span:
-                new_start, new_end = ad['start'], ad['end']
                 approved_start = max(0.0, span['start'])
                 approved_end = span['end']
                 if self.episode_duration > 0:
                     approved_end = min(approved_end, self.episode_duration)
                 overlaps_approved = (
-                    new_start < approved_end and new_end > approved_start)
-                if matched_before_dai_restore:
-                    # This correction matched the narrower span before a
-                    # persisted DAI core widened it. The confirmed span is
-                    # therefore authoritative over every restored edge.
-                    new_start = max(new_start, approved_start)
-                    new_end = min(new_end, approved_end)
-                else:
-                    if confirmed['start'] <= new_start < approved_start:
-                        new_start = approved_start
-                    if approved_end < new_end <= confirmed['end']:
-                        new_end = approved_end
-                    if overlaps_approved:
-                        # Every part of confirmed_span was explicitly approved
-                        # as ad audio. A later narrower detection must not
-                        # leave part of that known-positive span behind.
-                        new_start = min(new_start, approved_start)
-                        new_end = max(new_end, approved_end)
-                if new_end <= new_start:
+                    ad['start'] < approved_end and ad['end'] > approved_start)
+                if not overlaps_approved or approved_end <= approved_start:
                     # The detection lies entirely inside user-kept content;
                     # do not auto-accept -- let normal validation judge it.
                     auto_accept = False
-                elif (new_start, new_end) != (ad['start'], ad['end']):
+                elif (approved_start, approved_end) != (ad['start'], ad['end']):
                     logger.info(
                         f"Clamping confirmed segment {ad['start']:.1f}s-{ad['end']:.1f}s "
-                        f"to user-approved span {new_start:.1f}s-{new_end:.1f}s"
+                        f"to user-approved span {approved_start:.1f}s-{approved_end:.1f}s"
                     )
                     flags.append("INFO: Clamped to user-approved span")
-                    invalidate_tail_provenance(ad, new_end)
-                    ad['start'] = new_start
-                    ad['end'] = new_end
+                    invalidate_tail_provenance(ad, approved_end)
+                    ad['start'] = approved_start
+                    ad['end'] = approved_end
                     # Human trims are authoritative. A measured DAI core may
                     # have been clipped to the wider detected bounds earlier;
                     # keep it inside the approved span so the reviewer cannot
                     # later widen the marker back into user-kept content.
-                    clip_dai_core_spans(ad, new_start, new_end)
+                    clip_dai_core_spans(ad, approved_start, approved_end)
             if auto_accept:
                 approved = span or confirmed
                 tolerance = 0.01

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -43,6 +43,19 @@ def _vad_gap_adjacency_extension_seconds(ad: dict) -> float:
     return float(value) if isinstance(value, (int, float)) else 0.0
 
 
+def _adopt_later_marker_end(target: dict, source: dict) -> None:
+    """Extend a merged marker and carry provenance only from its new edge."""
+    if source['end'] <= target['end']:
+        return
+    invalidate_tail_provenance(target, source['end'])
+    target['end'] = source['end']
+    if source.get('end_extended_by_content'):
+        target['end_extended_by_content'] = True
+    if source.get('tail_splice_snap') is not None:
+        snap = source['tail_splice_snap']
+        target['tail_splice_snap'] = dict(snap) if isinstance(snap, dict) else snap
+
+
 class Decision(Enum):
     ACCEPT = "ACCEPT"
     REVIEW = "REVIEW"
@@ -1217,7 +1230,7 @@ class AdValidator:
                 # Always merge small gaps (< 5s)
                 mark_distinct_merge(last, current)
                 merge_original_twins(last, current)
-                last['end'] = max(last['end'], current['end'])
+                _adopt_later_marker_end(last, current)
                 if adjacency_extension:
                     last['vad_gap_adjacency_extension_seconds'] = adjacency_extension
                 if current.get('reason') and current['reason'] != last.get('reason'):
@@ -1233,7 +1246,7 @@ class AdValidator:
                 # Merge larger gaps if no speech in between
                 mark_distinct_merge(last, current)
                 merge_original_twins(last, current)
-                last['end'] = max(last['end'], current['end'])
+                _adopt_later_marker_end(last, current)
                 if adjacency_extension:
                     last['vad_gap_adjacency_extension_seconds'] = adjacency_extension
                 if current.get('reason') and current['reason'] != last.get('reason'):

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -429,9 +429,12 @@ class AdValidator:
         # A single approved span can overlap several fragments from one DAI
         # re-detection. Each would later restore to that exact same span, so
         # retain only the first eligible overlapping fragment before merge
-        # protection keeps them separate. Fragments in user-kept content or
-        # rejected as false positives still need normal validation and must
-        # not consume the approved-span match.
+        # protection keeps them separate. Judge false-positive overlap against
+        # the prospective restored DAI bounds: otherwise a retained fragment
+        # can expand into user-kept content and be rejected after consuming
+        # the approved span. Fragments in user-kept content or rejected as
+        # false positives still need normal validation and must not consume
+        # the approved-span match.
         restored_corrections = set()
         deduplicated_ads = []
         for ad in ads:
@@ -440,10 +443,20 @@ class AdValidator:
             overlaps_approved = (span is not None
                                  and ad['start'] < span['end']
                                  and ad['end'] > span['start'])
+            core_start, core_end = dai_core_bounds(ad)
+            restored_start = (
+                min(ad['start'], core_start)
+                if core_start is not None else ad['start'])
+            restored_end = (
+                max(ad['end'], core_end)
+                if core_end is not None else ad['end'])
+            restored_start = max(0.0, restored_start)
+            if self.episode_duration > 0:
+                restored_end = min(restored_end, self.episode_duration)
             correction_id = id(confirmed)
             can_restore_approved_span = (
                 overlaps_approved
-                and not ad.get('_matches_false_positive_correction'))
+                and not self._overlaps_false_positive(restored_start, restored_end))
             if (can_restore_approved_span
                     and correction_id in restored_corrections):
                 continue

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -507,17 +507,29 @@ class AdValidator:
             auto_accept = True
             if span:
                 new_start, new_end = ad['start'], ad['end']
+                approved_start = max(0.0, span['start'])
+                approved_end = span['end']
+                if self.episode_duration > 0:
+                    approved_end = min(approved_end, self.episode_duration)
+                overlaps_approved = (
+                    new_start < approved_end and new_end > approved_start)
                 if matched_before_dai_restore:
                     # This correction matched the narrower span before a
                     # persisted DAI core widened it. The confirmed span is
                     # therefore authoritative over every restored edge.
-                    new_start = max(new_start, span['start'])
-                    new_end = min(new_end, span['end'])
+                    new_start = max(new_start, approved_start)
+                    new_end = min(new_end, approved_end)
                 else:
-                    if confirmed['start'] <= new_start < span['start']:
-                        new_start = span['start']
-                    if span['end'] < new_end <= confirmed['end']:
-                        new_end = span['end']
+                    if confirmed['start'] <= new_start < approved_start:
+                        new_start = approved_start
+                    if approved_end < new_end <= confirmed['end']:
+                        new_end = approved_end
+                    if overlaps_approved:
+                        # Every part of confirmed_span was explicitly approved
+                        # as ad audio. A later narrower detection must not
+                        # leave part of that known-positive span behind.
+                        new_start = min(new_start, approved_start)
+                        new_end = max(new_end, approved_end)
                 if new_end <= new_start:
                     # The detection lies entirely inside user-kept content;
                     # do not auto-accept -- let normal validation judge it.
@@ -566,6 +578,10 @@ class AdValidator:
                     'corrections': corrections
                 }
                 return ad
+            duration = ad['end'] - ad['start']
+            position = (
+                ad['start'] / self.episode_duration
+                if self.episode_duration > 0 else 0)
 
         # Duration checks
         if duration < MIN_AD_DURATION:

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -475,6 +475,7 @@ class AdValidator:
             '_matches_false_positive_correction', False)
         pre_restore_confirmed = ad.pop(
             '_pre_dai_restore_confirmed_correction', None)
+        matched_before_dai_restore = pre_restore_confirmed is not None
         if (matched_false_positive
                 or self._overlaps_false_positive(ad['start'], ad['end'])):
             flags.append("INFO: User marked as false positive")
@@ -506,10 +507,17 @@ class AdValidator:
             auto_accept = True
             if span:
                 new_start, new_end = ad['start'], ad['end']
-                if confirmed['start'] <= new_start < span['start']:
-                    new_start = span['start']
-                if span['end'] < new_end <= confirmed['end']:
-                    new_end = span['end']
+                if matched_before_dai_restore:
+                    # This correction matched the narrower span before a
+                    # persisted DAI core widened it. The confirmed span is
+                    # therefore authoritative over every restored edge.
+                    new_start = max(new_start, span['start'])
+                    new_end = min(new_end, span['end'])
+                else:
+                    if confirmed['start'] <= new_start < span['start']:
+                        new_start = span['start']
+                    if span['end'] < new_end <= confirmed['end']:
+                        new_end = span['end']
                 if new_end <= new_start:
                     # The detection lies entirely inside user-kept content;
                     # do not auto-accept -- let normal validation judge it.

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -547,7 +547,7 @@ class AdValidator:
                     # keep it inside the approved span so the reviewer cannot
                     # later widen the marker back into user-kept content.
                     clip_dai_core_spans(ad, new_start, new_end)
-            if auto_accept and ad.get('merged_distinct_ads'):
+            if auto_accept:
                 approved = span or confirmed
                 tolerance = 0.01
                 fully_authorized = (
@@ -555,12 +555,12 @@ class AdValidator:
                     and ad['end'] <= approved['end'] + tolerance
                 )
                 if not fully_authorized:
-                    # A nearby detection may have merged with the confirmed
-                    # ad. Judge that wider marker normally and let the
-                    # reviewer inspect it; the human approved only a subset.
+                    # A new detection may extend beyond the confirmed ad even
+                    # without merge bookkeeping. Judge that wider marker
+                    # normally; the human approved only a subset.
                     auto_accept = False
                     flags.append(
-                        "INFO: User confirmation covers only part of merged segment")
+                        "INFO: User confirmation covers only part of segment")
             if auto_accept:
                 flags.append("INFO: User confirmed as ad")
                 logger.info(

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -426,6 +426,23 @@ class AdValidator:
                     and (confirmed.get('confirmed_span') or dai_will_expand)):
                 ad['_pre_dai_restore_confirmed_correction'] = confirmed
 
+        # A single approved span can overlap several fragments from one DAI
+        # re-detection. Each would later restore to that exact same span, so
+        # retain only the first before merge protection keeps them separate.
+        restored_corrections = set()
+        deduplicated_ads = []
+        for ad in ads:
+            confirmed = ad.get('_pre_dai_restore_confirmed_correction')
+            correction_id = id(confirmed)
+            if (confirmed is not None
+                    and confirmed.get('confirmed_span')
+                    and correction_id in restored_corrections):
+                continue
+            if confirmed is not None and confirmed.get('confirmed_span'):
+                restored_corrections.add(correction_id)
+            deduplicated_ads.append(ad)
+        ads = deduplicated_ads
+
         # Step 1: Auto-correct boundaries
         ads = self._clamp_boundaries(ads, result)
 

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -535,6 +535,20 @@ class AdValidator:
                     # keep it inside the approved span so the reviewer cannot
                     # later widen the marker back into user-kept content.
                     clip_dai_core_spans(ad, new_start, new_end)
+            if auto_accept and ad.get('merged_distinct_ads'):
+                approved = span or confirmed
+                tolerance = 0.01
+                fully_authorized = (
+                    ad['start'] >= approved['start'] - tolerance
+                    and ad['end'] <= approved['end'] + tolerance
+                )
+                if not fully_authorized:
+                    # A nearby detection may have merged with the confirmed
+                    # ad. Judge that wider marker normally and let the
+                    # reviewer inspect it; the human approved only a subset.
+                    auto_accept = False
+                    flags.append(
+                        "INFO: User confirmation covers only part of merged segment")
             if auto_accept:
                 flags.append("INFO: User confirmed as ad")
                 logger.info(

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -391,6 +391,15 @@ class AdValidator:
         # _orig_twin reference that must survive into the validated output.
         ads = [ad.copy() for ad in ads]
 
+        # Human false-positive decisions apply to the detected span the user
+        # actually reviewed. Preserve that match before measured DAI bounds
+        # restore portions removed by an automatic snap. Keep matching and
+        # non-matching markers separate so a nearby real ad is not rejected
+        # as collateral damage during the tiny-gap merge below.
+        for ad in ads:
+            ad['_matches_false_positive_correction'] = (
+                self._overlaps_false_positive(ad['start'], ad['end']))
+
         # Step 1: Auto-correct boundaries
         ads = self._clamp_boundaries(ads, result)
 
@@ -453,8 +462,13 @@ class AdValidator:
         duration = ad['end'] - ad['start']
         position = ad['start'] / self.episode_duration if self.episode_duration > 0 else 0
 
-        # Check for user-marked false positives first (highest priority)
-        if self._overlaps_false_positive(ad['start'], ad['end']):
+        # Check for user-marked false positives first (highest priority).
+        # The internal flag records a match before DAI-core restoration; pop
+        # it so validation-only bookkeeping is never persisted or returned.
+        matched_false_positive = ad.pop(
+            '_matches_false_positive_correction', False)
+        if (matched_false_positive
+                or self._overlaps_false_positive(ad['start'], ad['end'])):
             flags.append("INFO: User marked as false positive")
             logger.info(
                 f"Auto-rejecting segment {ad['start']:.1f}s-{ad['end']:.1f}s: "
@@ -1089,13 +1103,20 @@ class AdValidator:
 
             # Pending-review markers represent individual human decisions.
             # Never merge one with a cut marker or another hold: either fold
-            # can absorb content that was not part of the reviewed span.
+            # can absorb content that was not part of the reviewed span --
+            # and on an auto-approve recut it would grow the marker past its
+            # trimmed confirm so the confirmed_span clamp never fires and
+            # trimmed-out audio gets cut. A false-positive-correction match
+            # on only one side likewise blocks the fold: the match must keep
+            # describing exactly the span the human rejected.
             if (last.get('held_for_review')
                     or current.get('held_for_review')
                     or last.get('vad_gap_requires_review')
                     or current.get('vad_gap_requires_review')
                     or bool(last.get('differential_uncorroborated'))
-                    != bool(current.get('differential_uncorroborated'))):
+                    != bool(current.get('differential_uncorroborated'))
+                    or bool(last.get('_matches_false_positive_correction'))
+                    != bool(current.get('_matches_false_positive_correction'))):
                 merged.append(current.copy())
                 continue
 

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -413,12 +413,18 @@ class AdValidator:
         for ad in ads:
             ad['_matches_false_positive_correction'] = (
                 self._overlaps_false_positive(ad['start'], ad['end']))
+            confirmed = self._matching_confirmed(ad['start'], ad['end'])
             core_start, core_end = dai_core_bounds(ad)
-            if ((core_start is not None and core_start < ad['start'])
-                    or (core_end is not None and core_end > ad['end'])):
-                confirmed = self._matching_confirmed(ad['start'], ad['end'])
-                if confirmed is not None:
-                    ad['_pre_dai_restore_confirmed_correction'] = confirmed
+            dai_will_expand = (
+                (core_start is not None and core_start < ad['start'])
+                or (core_end is not None and core_end > ad['end']))
+            # Exact human-approved spans survive every automatic expansion,
+            # including tiny-gap merges and trailing extension. A plain
+            # confirmation is carried only across measured DAI restoration;
+            # allowing it across unrelated growth would authorize new audio.
+            if (confirmed is not None
+                    and (confirmed.get('confirmed_span') or dai_will_expand)):
+                ad['_pre_dai_restore_confirmed_correction'] = confirmed
 
         # Step 1: Auto-correct boundaries
         ads = self._clamp_boundaries(ads, result)

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -567,7 +567,7 @@ class AdValidator:
                     f"Auto-accepting segment {ad['start']:.1f}s-{ad['end']:.1f}s: "
                     f"overlaps with user-confirmed correction"
                 )
-                ad['validation'] = {
+                validation = {
                     'decision': Decision.ACCEPT.value,
                     'adjusted_confidence': 1.0,
                     'original_confidence': ad.get('confidence', 1.0),
@@ -577,6 +577,16 @@ class AdValidator:
                     'flags': flags,
                     'corrections': corrections
                 }
+                if span:
+                    # Carry the exact approved bounds through late reviewer
+                    # and tail mutations. Re-matching against a marker after
+                    # it has grown can fall below the correction overlap
+                    # threshold and lose the user's trim.
+                    validation['confirmed_span'] = {
+                        'start': approved_start,
+                        'end': approved_end,
+                    }
+                ad['validation'] = validation
                 return ad
             duration = ad['end'] - ad['start']
             position = (

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -410,10 +410,28 @@ class AdValidator:
         # restore portions removed by an automatic snap. Keep matching and
         # non-matching markers separate so a nearby real ad is not rejected
         # as collateral damage during the tiny-gap merge below.
+        confirmed_candidates = {}
         for ad in ads:
             ad['_matches_false_positive_correction'] = (
                 self._overlaps_false_positive(ad['start'], ad['end']))
             confirmed = self._matching_confirmed(ad['start'], ad['end'])
+            if confirmed is not None:
+                # A re-detection can split one user-approved span into
+                # multiple markers. Give the correction to the earliest
+                # matching marker and suppress the others below so action
+                # partitioning cannot render overlapping replacements.
+                ad['_has_confirmed_correction_candidate'] = True
+                existing = confirmed_candidates.get(id(confirmed))
+                if (existing is None
+                        or (ad['start'], ad['end']) < (
+                            existing[1]['start'], existing[1]['end'])):
+                    confirmed_candidates[id(confirmed)] = (confirmed, ad)
+
+        for confirmed, ad in confirmed_candidates.values():
+            ad['_confirmed_correction'] = confirmed
+
+        for ad in ads:
+            confirmed = ad.get('_confirmed_correction')
             core_start, core_end = dai_core_bounds(ad)
             dai_will_expand = (
                 (core_start is not None and core_start < ad['start'])
@@ -534,6 +552,9 @@ class AdValidator:
             '_matches_false_positive_correction', False)
         pre_restore_confirmed = ad.pop(
             '_pre_dai_restore_confirmed_correction', None)
+        confirmed = ad.pop('_confirmed_correction', None)
+        duplicate_confirmed = ad.pop(
+            '_has_confirmed_correction_candidate', False) and confirmed is None
         if (matched_false_positive
                 or self._overlaps_false_positive(ad['start'], ad['end'])):
             flags.append("INFO: User marked as false positive")
@@ -551,8 +572,19 @@ class AdValidator:
             }
             return ad
 
+        if duplicate_confirmed:
+            flags.append("INFO: Duplicate of user-confirmed span")
+            ad['validation'] = {
+                'decision': Decision.REJECT.value,
+                'adjusted_confidence': 0.0,
+                'original_confidence': ad.get('confidence', 1.0),
+                'flags': flags,
+                'corrections': corrections,
+            }
+            return ad
+
         # Check for user-confirmed corrections (second priority)
-        confirmed = (pre_restore_confirmed
+        confirmed = (pre_restore_confirmed or confirmed
                      or self._matching_confirmed(ad['start'], ad['end']))
         if confirmed is not None:
             # A trimmed approval confirms exactly one sub-span as ad. A later
@@ -1080,6 +1112,7 @@ class AdValidator:
                     result.corrections.append(
                         f"Restored end {ad['end']:.1f}s to measured DAI "
                         f"core {core_end:.1f}s")
+                    invalidate_tail_provenance(ad, core_end)
                     ad['end'] = core_end
 
             if ad['start'] < 0:

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -25,7 +25,7 @@ from config import (
     MAX_ADJACENT_AUTO_EXTENSION_SECONDS,
     normalize_segment_category, DEFAULT_SEGMENT_ACTION,
 )
-from utils.markers import mark_distinct_merge
+from utils.markers import clip_dai_core_spans, mark_distinct_merge
 from utils.text import extract_text_from_segments
 from utils.time import overlap_ratio
 
@@ -967,6 +967,7 @@ class AdValidator:
                     and ad.get('merged_protected_end') is not None
                     and ad['merged_protected_end'] > self.episode_duration):
                 ad['merged_protected_end'] = self.episode_duration
+            clip_dai_core_spans(ad, ad['start'], ad['end'])
         return ads
 
     def _extend_trailing_ad(self, ads: list[dict],

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -426,17 +426,41 @@ class AdValidator:
             ad['_matches_false_positive_correction'] = (
                 self._overlaps_false_positive(ad['start'], ad['end']))
             confirmed = self._matching_confirmed(ad['start'], ad['end'])
-            if confirmed is not None:
-                # A re-detection can split one user-approved span into
-                # multiple markers. Give the correction to the earliest
-                # matching marker and suppress the others below so action
-                # partitioning cannot render overlapping replacements.
-                ad['_has_confirmed_correction_candidate'] = True
-                existing = confirmed_candidates.get(id(confirmed))
-                if (existing is None
-                        or (ad['start'], ad['end']) < (
-                            existing[1]['start'], existing[1]['end'])):
-                    confirmed_candidates[id(confirmed)] = (confirmed, ad)
+            if confirmed is None:
+                continue
+            span = confirmed.get('confirmed_span')
+            if (span is not None
+                    and not (ad['start'] < span['end']
+                             and ad['end'] > span['start'])):
+                # Fragment lies wholly in trimmed-out (user-kept) content:
+                # it still needs normal validation and must not consume the
+                # approved-span match.
+                continue
+            # A re-detection can split one user-approved span into multiple
+            # markers. Give the correction to the earliest eligible marker
+            # and suppress the others below so action partitioning cannot
+            # render overlapping replacements.
+            ad['_has_confirmed_correction_candidate'] = True
+            # Judge false-positive overlap against the prospective restored
+            # DAI bounds: a fragment whose restoration would reach into
+            # audio the user rejected must not claim the approved span.
+            core_start, core_end = dai_core_bounds(ad)
+            restored_start = (
+                min(ad['start'], core_start)
+                if core_start is not None else ad['start'])
+            restored_end = (
+                max(ad['end'], core_end)
+                if core_end is not None else ad['end'])
+            restored_start = max(0.0, restored_start)
+            if self.episode_duration > 0:
+                restored_end = min(restored_end, self.episode_duration)
+            if self._overlaps_false_positive(restored_start, restored_end):
+                continue
+            existing = confirmed_candidates.get(id(confirmed))
+            if (existing is None
+                    or (ad['start'], ad['end']) < (
+                        existing[1]['start'], existing[1]['end'])):
+                confirmed_candidates[id(confirmed)] = (confirmed, ad)
 
         for confirmed, ad in confirmed_candidates.values():
             ad['_confirmed_correction'] = confirmed
@@ -454,45 +478,6 @@ class AdValidator:
             if (confirmed is not None
                     and (confirmed.get('confirmed_span') or dai_will_expand)):
                 ad['_pre_dai_restore_confirmed_correction'] = confirmed
-
-        # A single approved span can overlap several fragments from one DAI
-        # re-detection. Each would later restore to that exact same span, so
-        # retain only the first eligible overlapping fragment before merge
-        # protection keeps them separate. Judge false-positive overlap against
-        # the prospective restored DAI bounds: otherwise a retained fragment
-        # can expand into user-kept content and be rejected after consuming
-        # the approved span. Fragments in user-kept content or rejected as
-        # false positives still need normal validation and must not consume
-        # the approved-span match.
-        restored_corrections = set()
-        deduplicated_ads = []
-        for ad in ads:
-            confirmed = ad.get('_pre_dai_restore_confirmed_correction')
-            span = confirmed.get('confirmed_span') if confirmed else None
-            overlaps_approved = (span is not None
-                                 and ad['start'] < span['end']
-                                 and ad['end'] > span['start'])
-            core_start, core_end = dai_core_bounds(ad)
-            restored_start = (
-                min(ad['start'], core_start)
-                if core_start is not None else ad['start'])
-            restored_end = (
-                max(ad['end'], core_end)
-                if core_end is not None else ad['end'])
-            restored_start = max(0.0, restored_start)
-            if self.episode_duration > 0:
-                restored_end = min(restored_end, self.episode_duration)
-            correction_id = id(confirmed)
-            can_restore_approved_span = (
-                overlaps_approved
-                and not self._overlaps_false_positive(restored_start, restored_end))
-            if (can_restore_approved_span
-                    and correction_id in restored_corrections):
-                continue
-            if can_restore_approved_span:
-                restored_corrections.add(correction_id)
-            deduplicated_ads.append(ad)
-        ads = deduplicated_ads
 
         # Step 1: Auto-correct boundaries
         ads = self._clamp_boundaries(ads, result)

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -536,6 +536,12 @@ class AdValidator:
                         f"to user-approved span {new_start:.1f}s-{new_end:.1f}s"
                     )
                     flags.append("INFO: Clamped to user-approved span")
+                    if new_end != ad['end']:
+                        # The old tail provenance belongs to the superseded
+                        # edge. Retaining it would let the final splice sweep
+                        # grow past a human-approved end.
+                        ad.pop('end_extended_by_content', None)
+                        ad.pop('tail_splice_snap', None)
                     ad['start'] = new_start
                     ad['end'] = new_end
                     # Human trims are authoritative. A measured DAI core may

--- a/src/ad_validator.py
+++ b/src/ad_validator.py
@@ -399,6 +399,8 @@ class AdValidator:
         for ad in ads:
             ad['_matches_false_positive_correction'] = (
                 self._overlaps_false_positive(ad['start'], ad['end']))
+            ad['_pre_restore_confirmed_correction'] = (
+                self._matching_confirmed(ad['start'], ad['end']))
 
         # Step 1: Auto-correct boundaries
         ads = self._clamp_boundaries(ads, result)
@@ -467,6 +469,8 @@ class AdValidator:
         # it so validation-only bookkeeping is never persisted or returned.
         matched_false_positive = ad.pop(
             '_matches_false_positive_correction', False)
+        pre_restore_confirmed = ad.pop(
+            '_pre_restore_confirmed_correction', None)
         if (matched_false_positive
                 or self._overlaps_false_positive(ad['start'], ad['end'])):
             flags.append("INFO: User marked as false positive")
@@ -485,7 +489,8 @@ class AdValidator:
             return ad
 
         # Check for user-confirmed corrections (second priority)
-        confirmed = self._matching_confirmed(ad['start'], ad['end'])
+        confirmed = (pre_restore_confirmed
+                     or self._matching_confirmed(ad['start'], ad['end']))
         if confirmed is not None:
             # A trimmed approval confirmed only a sub-span as ad. Pull a
             # boundary inward only when it falls in a trimmed-out zone (inside
@@ -1115,6 +1120,8 @@ class AdValidator:
                     or current.get('vad_gap_requires_review')
                     or bool(last.get('differential_uncorroborated'))
                     != bool(current.get('differential_uncorroborated'))
+                    or last.get('_pre_restore_confirmed_correction') is not None
+                    or current.get('_pre_restore_confirmed_correction') is not None
                     or bool(last.get('_matches_false_positive_correction'))
                     != bool(current.get('_matches_false_positive_correction'))):
                 merged.append(current.copy())

--- a/src/api/patterns.py
+++ b/src/api/patterns.py
@@ -1368,6 +1368,13 @@ def _handle_adjust_correction(db, pattern_service, slug, episode_id, original_ad
             original_ad, label='adjusted',
         )
 
+    deleted = db.delete_conflicting_corrections(
+        episode_id, 'boundary_adjustment', original_start, original_end)
+    if deleted:
+        logger.info(
+            f"Deleted {deleted} conflicting false_positive correction(s) "
+            f"for {slug}/{episode_id}")
+
     db.create_pattern_correction(
         correction_type='boundary_adjustment',
         pattern_id=pattern_id,

--- a/src/database/patterns.py
+++ b/src/database/patterns.py
@@ -414,18 +414,19 @@ class PatternMixin:
                                         bounds_start: float, bounds_end: float) -> int:
         """Delete corrections that conflict with a new correction being submitted.
 
-        When user confirms an ad, delete false_positive corrections for same bounds.
+        When user confirms or adjusts an ad, delete false_positive corrections
+        for the same bounds.
         When user rejects an ad, delete confirm corrections for same bounds.
 
         Returns number of deleted rows.
         """
         # Determine the conflicting type
-        if correction_type == 'confirm':
+        if correction_type in ('confirm', 'boundary_adjustment'):
             conflicting_type = 'false_positive'
         elif correction_type == 'false_positive':
             conflicting_type = 'confirm'
         else:
-            return 0  # adjust doesn't conflict with either
+            return 0
 
         conn = self.get_connection()
         cursor = conn.execute(

--- a/src/database/patterns.py
+++ b/src/database/patterns.py
@@ -476,13 +476,13 @@ class PatternMixin:
         return [dict(row) for row in cursor.fetchall()]
 
     def get_episode_corrections(self, episode_id: str) -> list[dict]:
-        """Get all corrections for a specific episode."""
+        """Get all corrections for a specific episode, newest first."""
         conn = self.get_connection()
         cursor = conn.execute(
             """SELECT id, correction_type, original_bounds, corrected_bounds, created_at
                FROM pattern_corrections
                WHERE episode_id = ?
-               ORDER BY created_at DESC""",
+               ORDER BY id DESC""",
             (episode_id,)
         )
         results = []
@@ -547,15 +547,18 @@ class PatternMixin:
     def get_confirmed_corrections(self, episode_id: str) -> list[dict]:
         """Get confirmed corrections for an episode with parsed bounds.
 
-        Returns list of dicts with 'start' and 'end' keys for easy overlap
-        checking. A trimmed approval (confirm with corrected_bounds) also
-        carries a 'confirmed_span' dict -- the sub-span the user actually
-        confirmed as ad -- so the validator can clamp a re-detected span to it.
+        Results are newest first so the latest user decision wins when
+        corrections overlap. Both confirm and boundary_adjustment keep an ad;
+        a trimmed confirm or boundary adjustment also carries the exact
+        user-approved bounds in ``confirmed_span``.
         """
         conn = self.get_connection()
         cursor = conn.execute(
-            """SELECT original_bounds, corrected_bounds FROM pattern_corrections
-               WHERE episode_id = ? AND correction_type = 'confirm'""",
+            """SELECT correction_type, original_bounds, corrected_bounds
+               FROM pattern_corrections
+               WHERE episode_id = ?
+                 AND correction_type IN ('confirm', 'boundary_adjustment')
+               ORDER BY id DESC""",
             (episode_id,)
         )
         results = []
@@ -563,6 +566,9 @@ class PatternMixin:
             bounds = _parse_bounds(row['original_bounds'])
             if bounds:
                 confirmed_span = _parse_bounds(row['corrected_bounds'])
+                if (row['correction_type'] == 'boundary_adjustment'
+                        and not confirmed_span):
+                    continue
                 if confirmed_span:
                     bounds['confirmed_span'] = confirmed_span
                 results.append(bounds)

--- a/src/main_app/processing.py
+++ b/src/main_app/processing.py
@@ -2149,19 +2149,13 @@ def _finalize_user_confirmed_bounds(
         return ads_to_remove
     corrections = (confirmed_corrections if confirmed_corrections is not None
                    else db.get_confirmed_corrections(episode_id))
-    trimmed = [
-        corr for corr in corrections or []
-        if isinstance(corr.get('confirmed_span'), dict)
-    ]
-
     def matching_correction(marker):
-        matches = []
-        for corr in trimmed:
+        for corr in corrections or []:
             ratio = overlap_ratio(
                 corr['start'], corr['end'], marker['start'], marker['end'])
             if ratio >= CORRECTION_MATCH_MIN_COVERAGE:
-                matches.append((ratio, corr))
-        return max(matches, key=lambda item: item[0])[1] if matches else None
+                return corr
+        return None
 
     def approved_span(marker):
         validation = marker.get('validation') or {}
@@ -2171,7 +2165,9 @@ def _finalize_user_confirmed_bounds(
         if isinstance(carried, dict):
             return carried
         correction = matching_correction(marker)
-        return correction['confirmed_span'] if correction is not None else None
+        if correction is None:
+            return None
+        return correction.get('confirmed_span')
 
     def apply_span(marker, approved):
         target_start = max(0.0, float(approved['start']))
@@ -3469,7 +3465,7 @@ def _apply_boundary_adjustments(slug, episode_id, all_ads):
     corrections = db.get_episode_corrections(episode_id) or []
     adjusted = set()
     applied = 0
-    for c in corrections:  # newest first (ORDER BY created_at DESC)
+    for c in corrections:  # newest first (ORDER BY id DESC)
         if c.get('correction_type') != 'boundary_adjustment':
             continue
         orig = c.get('original_bounds') or {}

--- a/src/main_app/processing.py
+++ b/src/main_app/processing.py
@@ -19,7 +19,10 @@ from ad_detector import (
 from ad_detector.cue_boundary_snap import snap_ad_boundaries_to_cues
 from ad_detector.cue_pair_ads import synthesize_ads_from_cue_pairs
 from ad_detector.cue_telemetry import build_cue_detection_records
-from ad_detector.boundaries import snap_terminal_ad_to_splice
+from ad_detector.boundaries import (
+    snap_extended_ad_tails_to_splice,
+    snap_terminal_ad_to_splice,
+)
 from ad_detector.silence_boundary_snap import snap_ad_boundaries_to_silence
 from ad_yield import low_ad_yield
 from ad_reviewer import (
@@ -2019,7 +2022,7 @@ def _snap_terminal_starts(slug, episode_id, ads_to_remove, all_ads_with_validati
 
 def _complete_cut_tails(slug, episode_id, ads_to_remove, all_ads_with_validation,
                         segments, podcast_name=None):
-    """Re-run content-based end extension as the last step before cutting.
+    """Re-run content-based end extension late in the pre-cut pipeline.
 
     This sweep exists to undo reviewer end-pullbacks: the reviewer can pull a
     cut's end back to the detector boundary, and the pre-reviewer extension
@@ -2069,6 +2072,50 @@ def _complete_cut_tails(slug, episode_id, ads_to_remove, all_ads_with_validation
 
     storage.save_combined_ads(slug, episode_id, all_ads_with_validation)
     return extended
+
+
+def _snap_completed_cut_tails_to_splice(
+        slug, episode_id, ads_to_remove, all_ads_with_validation,
+        segments, audio_analysis_result, podcast_name=None):
+    """Extend a recovered spoken tail through a nearby untranscribed logo."""
+    if not ads_to_remove:
+        return ads_to_remove
+    splice = getattr(audio_analysis_result, 'splice_evidence', None) or {}
+    if not isinstance(splice, dict):
+        return ads_to_remove
+    events = splice.get('events') or []
+    if not isinstance(events, list) or not events:
+        return ads_to_remove
+
+    snapped = snap_extended_ad_tails_to_splice(
+        ads_to_remove, segments, events,
+        coverage_ads=all_ads_with_validation,
+        podcast_name=podcast_name,
+    )
+    changed = False
+    for old, new in zip(ads_to_remove, snapped):
+        if new['end'] <= old['end']:
+            continue
+        changed = True
+        audio_logger.info(
+            f"[{slug}:{episode_id}] Tail splice snap: cut end "
+            f"{old['end']:.1f}s -> {new['end']:.1f}s "
+            f"(+{new['end'] - old['end']:.1f}s)"
+        )
+        master = _find_master(all_ads_with_validation, old)
+        if master is not None:
+            master['end'] = new['end']
+            master['tail_splice_snap'] = new['tail_splice_snap']
+        else:
+            audio_logger.warning(
+                f"[{slug}:{episode_id}] Tail splice snap: no master ad matched "
+                f"{old['start']:.1f}s-{old['end']:.1f}s; UI list will not show "
+                f"the extension"
+            )
+
+    if changed:
+        storage.save_combined_ads(slug, episode_id, all_ads_with_validation)
+    return snapped
 
 
 def _validate_verification_ads(slug, episode_id, verification_ads_processed,
@@ -4286,6 +4333,14 @@ def process_episode(slug: str, episode_id: str, episode_url: str,
             ads_to_remove = _complete_cut_tails(
                 slug, episode_id, ads_to_remove, all_ads_with_validation,
                 segments, podcast_name=podcast_name
+            )
+
+            # A transcript-guided tail extension can stop before an
+            # untranscribed sonic logo. Strong forward splice evidence closes
+            # that final gap without crossing speech or another marker.
+            ads_to_remove = _snap_completed_cut_tails_to_splice(
+                slug, episode_id, ads_to_remove, all_ads_with_validation,
+                segments, audio_analysis_result, podcast_name=podcast_name
             )
 
             # Backstop: the late keep partition above should already have

--- a/src/main_app/processing.py
+++ b/src/main_app/processing.py
@@ -2137,7 +2137,7 @@ def _snap_completed_cut_tails_to_splice(
 
 def _finalize_user_confirmed_bounds(
         slug, episode_id, ads_to_remove, all_ads_with_validation,
-        confirmed_corrections=None):
+        confirmed_corrections=None, episode_duration=None):
     """Make a human-approved trim the final authority before audio cutting.
 
     Validation normally applies ``confirmed_span`` already, but later pipeline
@@ -2153,8 +2153,6 @@ def _finalize_user_confirmed_bounds(
         corr for corr in corrections or []
         if isinstance(corr.get('confirmed_span'), dict)
     ]
-    if not trimmed:
-        return ads_to_remove
 
     def matching_correction(marker):
         matches = []
@@ -2165,9 +2163,21 @@ def _finalize_user_confirmed_bounds(
                 matches.append((ratio, corr))
         return max(matches, key=lambda item: item[0])[1] if matches else None
 
+    def approved_span(marker):
+        validation = marker.get('validation') or {}
+        if not validation.get('user_confirmed'):
+            return None
+        carried = validation.get('confirmed_span')
+        if isinstance(carried, dict):
+            return carried
+        correction = matching_correction(marker)
+        return correction['confirmed_span'] if correction is not None else None
+
     def apply_span(marker, approved):
         target_start = max(0.0, float(approved['start']))
         target_end = float(approved['end'])
+        if episode_duration is not None and episode_duration > 0:
+            target_end = min(target_end, float(episode_duration))
         if target_end <= target_start:
             return False
         old_start, old_end = marker['start'], marker['end']
@@ -2185,20 +2195,16 @@ def _finalize_user_confirmed_bounds(
 
     changed = False
     for ad in ads_to_remove:
-        if not (ad.get('validation') or {}).get('user_confirmed'):
+        approved = approved_span(ad)
+        if approved is None:
             continue
-        correction = matching_correction(ad)
-        if correction is None:
-            continue
-        approved = correction['confirmed_span']
         # Resolve the master before changing the cut-list key. A separate copy
-        # may already have drifted, so fall back to the same trusted correction.
+        # may already have drifted, so fall back to the same carried approval.
         master = _find_master(all_ads_with_validation, ad)
         if master is None:
             master = next((
                 candidate for candidate in all_ads_with_validation
-                if (candidate.get('validation') or {}).get('user_confirmed')
-                and matching_correction(candidate) is correction
+                if approved_span(candidate) == approved
             ), None)
         changed = apply_span(ad, approved) or changed
         if master is not None and master is not ad:
@@ -4438,7 +4444,8 @@ def process_episode(slug: str, episode_id: str, episode_url: str,
             # Run after every automated reviewer and tail mutation so neither
             # the audio cut nor its persisted marker can drift from approval.
             ads_to_remove = _finalize_user_confirmed_bounds(
-                slug, episode_id, ads_to_remove, all_ads_with_validation)
+                slug, episode_id, ads_to_remove, all_ads_with_validation,
+                episode_duration=episode_duration)
 
             # Backstop: the late keep partition above should already have
             # caught everything, so this normally finds nothing.

--- a/src/main_app/processing.py
+++ b/src/main_app/processing.py
@@ -2100,6 +2100,12 @@ def _snap_completed_cut_tails_to_splice(
     splice = getattr(audio_analysis_result, 'splice_evidence', None) or {}
     if not isinstance(splice, dict):
         return ads_to_remove
+    calibration = splice.get('calibration') or {}
+    if (not isinstance(calibration, dict)
+            or calibration.get('status') != 'calibrated'):
+        # Cold-start splice events may corroborate another detector, but they
+        # are not calibrated well enough to extend a destructive cut.
+        return ads_to_remove
     events = splice.get('events') or []
     if not isinstance(events, list) or not events:
         return ads_to_remove

--- a/src/main_app/processing.py
+++ b/src/main_app/processing.py
@@ -22,6 +22,7 @@ from ad_detector.cue_telemetry import build_cue_detection_records
 from ad_detector.boundaries import (
     snap_extended_ad_tails_to_splice,
     snap_terminal_ad_to_splice,
+    transition_pair_silence_events,
 )
 from ad_detector.silence_boundary_snap import snap_ad_boundaries_to_silence
 from ad_yield import low_ad_yield
@@ -1987,7 +1988,17 @@ def _snap_terminal_starts(slug, episode_id, ads_to_remove, all_ads_with_validati
     if not ads_to_remove or not episode_duration:
         return ads_to_remove
     splice = getattr(audio_analysis_result, 'splice_evidence', None) or {}
-    events = splice.get('events') or []
+    events = list(splice.get('events') or [])
+    silence_tunables = getattr(
+        audio_analysis_result, 'silence_tunables', None)
+    if silence_tunables is None:
+        silence_tunables = resolve_silence_snap_tunables(db)
+    events.extend(transition_pair_silence_events(
+        getattr(audio_analysis_result, 'signals', None) or [],
+        getattr(audio_analysis_result, 'silence_spans', None) or [],
+        max_distance_s=silence_tunables['max_distance_seconds'],
+        min_silence_s=silence_tunables['min_duration_seconds'],
+    ))
     if not events:
         return ads_to_remove
     window_s = db.get_setting_float('terminal_snap_window_seconds',

--- a/src/main_app/processing.py
+++ b/src/main_app/processing.py
@@ -30,6 +30,7 @@ from audio_processor import get_replacement_duration, AudioProcessor
 from cancel import ProcessingCancelled, _check_cancel, _cancel_events, _cancel_events_lock
 from differential_fetcher import fetch_and_diff, is_likely_dai_feed
 from utils.audio import get_audio_codec, get_audio_duration
+from utils.markers import clip_dai_core_spans
 from utils.time import (
     adjust_timestamp, merge_cut_spans, overlap_ratio,
     ranges_overlap, span_inside_any_cut, utc_now_iso,
@@ -3341,6 +3342,10 @@ def _apply_boundary_adjustments(slug, episode_id, all_ads):
             )
             continue
         match['start'], match['end'] = n_start, n_end
+        # Boundary adjustments are explicit user edits. Keep measured DAI
+        # evidence inside the approved range so validation cannot restore a
+        # stale automatic boundary over audio the user chose to preserve.
+        clip_dai_core_spans(match, n_start, n_end)
         adjusted.add(id(match))
         applied += 1
     if applied:

--- a/src/main_app/processing.py
+++ b/src/main_app/processing.py
@@ -34,7 +34,7 @@ from audio_processor import get_replacement_duration, AudioProcessor
 from cancel import ProcessingCancelled, _check_cancel, _cancel_events, _cancel_events_lock
 from differential_fetcher import fetch_and_diff, is_likely_dai_feed
 from utils.audio import get_audio_codec, get_audio_duration
-from utils.markers import clip_dai_core_spans
+from utils.markers import clip_dai_core_spans, invalidate_tail_provenance
 from utils.time import (
     adjust_timestamp, merge_cut_spans, overlap_ratio,
     ranges_overlap, span_inside_any_cut, utc_now_iso,
@@ -1869,9 +1869,7 @@ def _apply_reviewer_verdict_to_ad(ad, v):
     if v.verdict == 'adjust':
         ad['reviewer_original_start'] = v.original_start
         ad['reviewer_original_end'] = v.original_end
-        if v.adjusted_end != ad.get('end'):
-            ad.pop('end_extended_by_content', None)
-            ad.pop('tail_splice_snap', None)
+        invalidate_tail_provenance(ad, v.adjusted_end)
         ad['start'] = v.adjusted_start
         ad['end'] = v.adjusted_end
     elif v.verdict == 'reject':
@@ -2183,9 +2181,7 @@ def _finalize_user_confirmed_bounds(
         if target_end <= target_start:
             return False
         old_start, old_end = marker['start'], marker['end']
-        if old_end != target_end:
-            marker.pop('end_extended_by_content', None)
-            marker.pop('tail_splice_snap', None)
+        invalidate_tail_provenance(marker, target_end)
         marker['start'], marker['end'] = target_start, target_end
         clip_dai_core_spans(marker, target_start, target_end)
         flags = (marker.get('validation') or {}).get('flags')
@@ -2207,6 +2203,9 @@ def _finalize_user_confirmed_bounds(
             master = next((
                 candidate for candidate in all_ads_with_validation
                 if approved_span(candidate) == approved
+                and ranges_overlap(
+                    candidate['start'], candidate['end'],
+                    ad['start'], ad['end'])
             ), None)
         changed = apply_span(ad, approved) or changed
         if master is not None and master is not ad:

--- a/src/main_app/processing.py
+++ b/src/main_app/processing.py
@@ -2008,8 +2008,13 @@ def _snap_terminal_starts(slug, episode_id, ads_to_remove, all_ads_with_validati
     # cross. Rejected, held, and kept markers are explicit barriers, including
     # when their audio is untranscribed.
     coverage_ads = list(ads_to_remove)
+    cut_marker_ids = {id(marker) for marker in coverage_ads}
+    for marker in coverage_ads:
+        master = _find_master(all_ads_with_validation, marker)
+        if master is not None:
+            cut_marker_ids.add(id(master))
     blocking_ads = [m for m in all_ads_with_validation
-                    if m.get('was_cut') is False]
+                    if id(m) not in cut_marker_ids and not m.get('was_cut')]
     snapped = snap_terminal_ad_to_splice(
         ads_to_remove, segments, events, episode_duration, window_s,
         coverage_ads=coverage_ads, blocking_ads=blocking_ads,
@@ -2181,15 +2186,36 @@ def _finalize_user_confirmed_bounds(
         if target_end <= target_start:
             return False
         old_start, old_end = marker['start'], marker['end']
-        invalidate_tail_provenance(marker, target_end)
+        missing = object()
+        old_metadata = (
+            marker.get('end_extended_by_content', missing),
+            marker.get('tail_splice_snap', missing),
+            marker.get('dai_core_spans', missing),
+        )
+        # Final human authority supersedes how an automatic tail happened to
+        # reach even the same edge; do not let that stale provenance enable a
+        # later expansion on reload.
+        marker.pop('end_extended_by_content', None)
+        marker.pop('tail_splice_snap', None)
         marker['start'], marker['end'] = target_start, target_end
         clip_dai_core_spans(marker, target_start, target_end)
         flags = (marker.get('validation') or {}).get('flags')
+        note_added = False
         if isinstance(flags, list):
             note = 'INFO: Finalized to user-approved span'
             if note not in flags:
                 flags.append(note)
-        return (old_start, old_end) != (target_start, target_end)
+                note_added = True
+        new_metadata = (
+            marker.get('end_extended_by_content', missing),
+            marker.get('tail_splice_snap', missing),
+            marker.get('dai_core_spans', missing),
+        )
+        return (
+            (old_start, old_end) != (target_start, target_end)
+            or old_metadata != new_metadata
+            or note_added
+        )
 
     changed = False
     for ad in ads_to_remove:

--- a/src/main_app/processing.py
+++ b/src/main_app/processing.py
@@ -1869,6 +1869,9 @@ def _apply_reviewer_verdict_to_ad(ad, v):
     if v.verdict == 'adjust':
         ad['reviewer_original_start'] = v.original_start
         ad['reviewer_original_end'] = v.original_end
+        if v.adjusted_end != ad.get('end'):
+            ad.pop('end_extended_by_content', None)
+            ad.pop('tail_splice_snap', None)
         ad['start'] = v.adjusted_start
         ad['end'] = v.adjusted_end
     elif v.verdict == 'reject':

--- a/src/main_app/processing.py
+++ b/src/main_app/processing.py
@@ -2119,7 +2119,7 @@ def _snap_completed_cut_tails_to_splice(
         podcast_name=podcast_name,
     )
     changed = False
-    for old, new in zip(ads_to_remove, snapped):
+    for old, new in zip(ads_to_remove, snapped, strict=True):
         if new['end'] <= old['end']:
             continue
         changed = True

--- a/src/main_app/processing.py
+++ b/src/main_app/processing.py
@@ -2003,13 +2003,16 @@ def _snap_terminal_starts(slug, episode_id, ads_to_remove, all_ads_with_validati
         return ads_to_remove
     window_s = db.get_setting_float('terminal_snap_window_seconds',
                                     TERMINAL_SNAP_WINDOW_SECONDS)
-    # A kept marker must read as blocking, not as coverage, or the sweep
-    # could pull a terminal cut's start back into kept audio.
-    coverage_ads = [m for m in all_ads_with_validation
-                    if m.get('action_applied') != 'keep']
+    # Only markers that will actually be removed may make speech safe to
+    # cross. Rejected, held, and kept markers are explicit barriers, including
+    # when their audio is untranscribed.
+    coverage_ads = list(ads_to_remove)
+    blocking_ads = [m for m in all_ads_with_validation
+                    if m.get('was_cut') is False]
     snapped = snap_terminal_ad_to_splice(
         ads_to_remove, segments, events, episode_duration, window_s,
-        coverage_ads=coverage_ads, podcast_name=podcast_name,
+        coverage_ads=coverage_ads, blocking_ads=blocking_ads,
+        podcast_name=podcast_name,
     )
     changed = False
     for old, new in zip(ads_to_remove, snapped, strict=True):

--- a/src/main_app/processing.py
+++ b/src/main_app/processing.py
@@ -2135,6 +2135,80 @@ def _snap_completed_cut_tails_to_splice(
     return snapped
 
 
+def _finalize_user_confirmed_bounds(
+        slug, episode_id, ads_to_remove, all_ads_with_validation,
+        confirmed_corrections=None):
+    """Make a human-approved trim the final authority before audio cutting.
+
+    Validation normally applies ``confirmed_span`` already, but later pipeline
+    stages rebuild marker dicts and mutate boundaries. Re-assert the approved
+    span after every reviewer/tail operation and synchronize the master marker
+    so the rendered cut and UI audit trail cannot diverge.
+    """
+    if not ads_to_remove:
+        return ads_to_remove
+    corrections = (confirmed_corrections if confirmed_corrections is not None
+                   else db.get_confirmed_corrections(episode_id))
+    trimmed = [
+        corr for corr in corrections or []
+        if isinstance(corr.get('confirmed_span'), dict)
+    ]
+    if not trimmed:
+        return ads_to_remove
+
+    def matching_correction(marker):
+        matches = []
+        for corr in trimmed:
+            ratio = overlap_ratio(
+                corr['start'], corr['end'], marker['start'], marker['end'])
+            if ratio >= CORRECTION_MATCH_MIN_COVERAGE:
+                matches.append((ratio, corr))
+        return max(matches, key=lambda item: item[0])[1] if matches else None
+
+    def apply_span(marker, approved):
+        target_start = max(0.0, float(approved['start']))
+        target_end = float(approved['end'])
+        if target_end <= target_start:
+            return False
+        old_start, old_end = marker['start'], marker['end']
+        if old_end != target_end:
+            marker.pop('end_extended_by_content', None)
+            marker.pop('tail_splice_snap', None)
+        marker['start'], marker['end'] = target_start, target_end
+        clip_dai_core_spans(marker, target_start, target_end)
+        flags = (marker.get('validation') or {}).get('flags')
+        if isinstance(flags, list):
+            note = 'INFO: Finalized to user-approved span'
+            if note not in flags:
+                flags.append(note)
+        return (old_start, old_end) != (target_start, target_end)
+
+    changed = False
+    for ad in ads_to_remove:
+        if not (ad.get('validation') or {}).get('user_confirmed'):
+            continue
+        correction = matching_correction(ad)
+        if correction is None:
+            continue
+        approved = correction['confirmed_span']
+        # Resolve the master before changing the cut-list key. A separate copy
+        # may already have drifted, so fall back to the same trusted correction.
+        master = _find_master(all_ads_with_validation, ad)
+        if master is None:
+            master = next((
+                candidate for candidate in all_ads_with_validation
+                if (candidate.get('validation') or {}).get('user_confirmed')
+                and matching_correction(candidate) is correction
+            ), None)
+        changed = apply_span(ad, approved) or changed
+        if master is not None and master is not ad:
+            changed = apply_span(master, approved) or changed
+
+    if changed:
+        storage.save_combined_ads(slug, episode_id, all_ads_with_validation)
+    return ads_to_remove
+
+
 def _validate_verification_ads(slug, episode_id, verification_ads_processed,
                                 verification_ads_original, verification_segments,
                                 ads_to_remove, episode_description,
@@ -4359,6 +4433,12 @@ def process_episode(slug: str, episode_id: str, episode_url: str,
                 slug, episode_id, ads_to_remove, all_ads_with_validation,
                 segments, audio_analysis_result, podcast_name=podcast_name
             )
+
+            # Human-approved trim bounds are the final boundary authority.
+            # Run after every automated reviewer and tail mutation so neither
+            # the audio cut nor its persisted marker can drift from approval.
+            ads_to_remove = _finalize_user_confirmed_bounds(
+                slug, episode_id, ads_to_remove, all_ads_with_validation)
 
             # Backstop: the late keep partition above should already have
             # caught everything, so this normally finds nothing.

--- a/src/utils/markers.py
+++ b/src/utils/markers.py
@@ -19,9 +19,19 @@ def _valid_dai_core_spans(marker: dict) -> list[dict[str, float]]:
         if not isinstance(raw, dict):
             continue
         try:
-            start = float(raw['start'])
-            end = float(raw['end'])
+            raw_start = raw['start']
+            raw_end = raw['end']
         except (KeyError, OverflowError, TypeError, ValueError):
+            continue
+        # bool is a subclass of int, and float(True) silently becomes 1.0.
+        # Optional evidence with boolean endpoints is malformed, not a
+        # measured one-second span at the beginning of the episode.
+        if isinstance(raw_start, bool) or isinstance(raw_end, bool):
+            continue
+        try:
+            start = float(raw_start)
+            end = float(raw_end)
+        except (OverflowError, TypeError, ValueError):
             continue
         if math.isfinite(start) and math.isfinite(end) and end > start:
             spans.append({'start': start, 'end': end})

--- a/src/utils/markers.py
+++ b/src/utils/markers.py
@@ -21,7 +21,7 @@ def _valid_dai_core_spans(marker: dict) -> list[dict[str, float]]:
         try:
             start = float(raw['start'])
             end = float(raw['end'])
-        except (KeyError, TypeError, ValueError):
+        except (KeyError, OverflowError, TypeError, ValueError):
             continue
         if math.isfinite(start) and math.isfinite(end) and end > start:
             spans.append({'start': start, 'end': end})

--- a/src/utils/markers.py
+++ b/src/utils/markers.py
@@ -1,4 +1,62 @@
 """Marker-dict bookkeeping shared by the detector, validator, and reviewer."""
+DAI_CORE_SPANS = 'dai_core_spans'
+
+
+def _valid_dai_core_spans(marker: dict) -> list[dict[str, float]]:
+    """Return normalized measured DAI spans from a marker.
+
+    Invalid persisted values are ignored. Keeping this parser defensive lets
+    old markers and hand-edited JSON pass through unchanged.
+    """
+    spans = []
+    for raw in marker.get(DAI_CORE_SPANS) or []:
+        if not isinstance(raw, dict):
+            continue
+        try:
+            start = float(raw['start'])
+            end = float(raw['end'])
+        except (KeyError, TypeError, ValueError):
+            continue
+        if end > start:
+            spans.append({'start': start, 'end': end})
+    return spans
+
+
+def merge_dai_core_spans(target: dict, other: dict) -> None:
+    """Carry measured DAI regions through a marker merge."""
+    spans = _valid_dai_core_spans(target) + _valid_dai_core_spans(other)
+    if not spans:
+        return
+    spans.sort(key=lambda span: span['start'])
+    merged = [spans[0]]
+    for span in spans[1:]:
+        if span['start'] <= merged[-1]['end'] + 0.05:
+            merged[-1]['end'] = max(merged[-1]['end'], span['end'])
+        else:
+            merged.append(span)
+    target[DAI_CORE_SPANS] = merged
+
+
+def clip_dai_core_spans(marker: dict, start: float, end: float) -> None:
+    """Clip a marker's DAI evidence to a newly split/clamped range."""
+    clipped = []
+    for span in _valid_dai_core_spans(marker):
+        lo = max(start, span['start'])
+        hi = min(end, span['end'])
+        if hi > lo:
+            clipped.append({'start': lo, 'end': hi})
+    if clipped:
+        marker[DAI_CORE_SPANS] = clipped
+    else:
+        marker.pop(DAI_CORE_SPANS, None)
+
+
+def dai_core_bounds(marker: dict) -> tuple[float | None, float | None]:
+    """Return the outer bounds of measured DAI evidence, if present."""
+    spans = _valid_dai_core_spans(marker)
+    if not spans:
+        return None, None
+    return min(s['start'] for s in spans), max(s['end'] for s in spans)
 
 # Stages whose spans carry alignment-derived padding (especially tails)
 # rather than transcript- or splice-anchored bounds. Members from these
@@ -28,6 +86,7 @@ def note_merged_members(target: dict, other: dict) -> None:
     anchored) so the reviewer can tell a tracked merge from a legacy
     marker persisted by a pre-tracking release.
     """
+    merge_dai_core_spans(target, other)
     if 'merged_protected_start' not in target:
         target['merged_protected_start'], target['merged_protected_end'] = (
             _protected_bounds(target))

--- a/src/utils/markers.py
+++ b/src/utils/markers.py
@@ -11,8 +11,11 @@ def _valid_dai_core_spans(marker: dict) -> list[dict[str, float]]:
     Invalid persisted values are ignored. Keeping this parser defensive lets
     old markers and hand-edited JSON pass through unchanged.
     """
+    raw_spans = marker.get(DAI_CORE_SPANS)
+    if not isinstance(raw_spans, list):
+        return []
     spans = []
-    for raw in marker.get(DAI_CORE_SPANS) or []:
+    for raw in raw_spans:
         if not isinstance(raw, dict):
             continue
         try:

--- a/src/utils/markers.py
+++ b/src/utils/markers.py
@@ -1,4 +1,7 @@
 """Marker-dict bookkeeping shared by the detector, validator, and reviewer."""
+import math
+
+
 DAI_CORE_SPANS = 'dai_core_spans'
 
 
@@ -17,7 +20,7 @@ def _valid_dai_core_spans(marker: dict) -> list[dict[str, float]]:
             end = float(raw['end'])
         except (KeyError, TypeError, ValueError):
             continue
-        if end > start:
+        if math.isfinite(start) and math.isfinite(end) and end > start:
             spans.append({'start': start, 'end': end})
     return spans
 

--- a/src/utils/markers.py
+++ b/src/utils/markers.py
@@ -5,6 +5,18 @@ import math
 DAI_CORE_SPANS = 'dai_core_spans'
 
 
+def invalidate_tail_provenance(marker: dict, new_end: float) -> None:
+    """Drop tail-growth eligibility when a stage selects a new end.
+
+    Content-tail provenance describes how the current edge was reached. A
+    reviewer or human-selected end must earn any later sonic-tail extension
+    from fresh evidence instead of reusing stale eligibility.
+    """
+    if marker.get('end') != new_end:
+        marker.pop('end_extended_by_content', None)
+        marker.pop('tail_splice_snap', None)
+
+
 def _valid_dai_core_spans(marker: dict) -> list[dict[str, float]]:
     """Return normalized measured DAI spans from a marker.
 

--- a/tests/unit/test_ad_detector.py
+++ b/tests/unit/test_ad_detector.py
@@ -794,6 +794,24 @@ class TestSplitConflictingActionSpan:
             assert 'merged_protected_start' not in piece
             assert 'merged_protected_end' not in piece
 
+    def test_nested_split_clips_dai_cores_to_each_remainder(self):
+        last = {
+            'start': 0.0,
+            'end': 100.0,
+            'category': 'sponsor',
+            'dai_core_spans': [
+                {'start': 10.0, 'end': 30.0},
+                {'start': 70.0, 'end': 90.0},
+            ],
+        }
+        current = {'start': 40.0, 'end': 60.0, 'category': 'interaction'}
+
+        new_last, entries = split_conflicting_action_span(last, current)
+
+        assert new_last['dai_core_spans'] == [{'start': 10.0, 'end': 30.0}]
+        assert 'dai_core_spans' not in entries[0]
+        assert entries[1]['dai_core_spans'] == [{'start': 70.0, 'end': 90.0}]
+
 
 class TestDeduplicateWindowAdsActionGate:
     """DTNS 5317: daily-tech-news-show episode 3c0b827ef2c5, reprocessed

--- a/tests/unit/test_ad_reviewer.py
+++ b/tests/unit/test_ad_reviewer.py
@@ -807,3 +807,19 @@ def test_clamp_legacy_merged_marker_stays_expand_only():
     s, e = r._clamp_proposed_bounds(ad, 110.0, 190.0, 100.0, 200.0,
                                     60.0, 'slug', 'ep')
     assert (s, e) == (100.0, 200.0)
+
+
+def test_clamp_preserves_dai_core_but_trims_outer_candidate():
+    r = _build_reviewer()
+    ad = {
+        'start': 80.0,
+        'end': 180.0,
+        'detection_stage': 'dai_differential',
+        'confidence': 0.95,
+        'dai_core_spans': [{'start': 100.0, 'end': 160.0}],
+    }
+
+    s, e = r._clamp_proposed_bounds(
+        ad, 120.0, 140.0, 80.0, 180.0, 60.0, 'slug', 'ep')
+
+    assert (s, e) == (100.0, 160.0)

--- a/tests/unit/test_ad_reviewer_contradiction.py
+++ b/tests/unit/test_ad_reviewer_contradiction.py
@@ -616,6 +616,14 @@ def test_elliptical_plural_affirmation_with_trim_is_not_contradiction():
     assert not reasoning_contradicts_cut(reason)
 
 
+def test_negated_elliptical_plural_is_a_contradiction():
+    reason = (
+        '  Several potential ads are not an ad and should be excluded from '
+        'the cut.')
+    assert not reasoning_affirms_ad(reason)
+    assert reasoning_contradicts_cut(reason)
+
+
 def test_user_confirmed_ad_bypasses_automated_reviewer():
     reviewer = _build_reviewer({
         'review_prompt': 'review', 'resurrect_prompt': 'resurrect',
@@ -721,6 +729,27 @@ def test_affirmed_confirm_with_trim_language_applies_recovered_trim():
     assert verdict.verdict == 'adjust'
     assert verdict.adjusted_start == 837.2
     assert verdict.adjusted_end == pytest.approx(1040.9)
+
+
+def test_reviewer_end_adjustment_clears_stale_tail_eligibility():
+    ad = {
+        'start': 837.2,
+        'end': 1068.5,
+        'confidence': 0.95,
+        'end_extended_by_content': True,
+        'tail_splice_snap': {'event_time': 1068.5},
+    }
+    result, _ = _run_affirmed_confirm(
+        _resp('{"ad_start": 837.2, "ad_end": 1040.9}'), ad=ad)
+
+    accepted = result.accepted_after_review[0]
+    assert 'end_extended_by_content' not in accepted
+    assert 'tail_splice_snap' not in accepted
+
+    processing._apply_reviewer_verdict_to_ad(ad, result.verdicts[0])
+    assert ad['end'] == pytest.approx(1040.9)
+    assert 'end_extended_by_content' not in ad
+    assert 'tail_splice_snap' not in ad
 
 
 def test_affirmed_confirm_with_move_phrasing_applies_recovered_trim():

--- a/tests/unit/test_ad_reviewer_contradiction.py
+++ b/tests/unit/test_ad_reviewer_contradiction.py
@@ -625,6 +625,16 @@ def test_elliptical_plural_affirmation_with_trim_is_not_contradiction():
     assert not reasoning_contradicts_cut(reason)
 
 
+def test_elliptical_plural_affirmation_scopes_plural_negation_to_trimmed_context():
+    reason = (
+        'Multiple sponsor ads were found. Adjusted the start to exclude the '
+        'host segments; these are not ads.'
+    )
+
+    assert reasoning_affirms_ad(reason)
+    assert not reasoning_contradicts_cut(reason)
+
+
 def test_negated_elliptical_plural_is_a_contradiction():
     reason = (
         '  Several potential ads are not an ad and should be excluded from '

--- a/tests/unit/test_ad_reviewer_contradiction.py
+++ b/tests/unit/test_ad_reviewer_contradiction.py
@@ -718,3 +718,19 @@ def test_dai_core_that_erases_recovered_trim_accepts_unchanged():
     accepted = result.accepted_after_review[0]
     assert (accepted['start'], accepted['end']) == (100.0, 200.0)
     assert result.verdicts[0].verdict == 'confirmed'
+
+
+def test_dai_core_widens_tiny_recovered_span_before_duration_floor():
+    ad = {
+        'start': 100.0, 'end': 200.0, 'confidence': 0.95,
+        'detection_stage': 'dai_differential',
+        'dai_core_spans': [{'start': 120.0, 'end': 150.0}],
+    }
+
+    result, llm = _run_affirmed_confirm(
+        _resp('{"ad_start": 130.0, "ad_end": 135.0}'), ad=ad)
+
+    assert llm.messages_create.call_count == 2
+    accepted = result.accepted_after_review[0]
+    assert (accepted['start'], accepted['end']) == (120.0, 150.0)
+    assert result.verdicts[0].verdict == 'adjust'

--- a/tests/unit/test_ad_reviewer_contradiction.py
+++ b/tests/unit/test_ad_reviewer_contradiction.py
@@ -572,6 +572,15 @@ def test_affirms_ad_requires_assertion_shape():
     assert not reasoning_affirms_ad("")
 
 
+def test_affirmation_scans_past_an_earlier_negated_match():
+    reason = (
+        'None are ads in the host introduction, but the two inserted spots '
+        'are ads and should be removed.'
+    )
+
+    assert reasoning_affirms_ad(reason)
+
+
 NEGATED_PHRASE_REASONS = [
     'This is not a genuine ad break; it contains no ad content and is a '
     'false positive from the pattern matcher.',

--- a/tests/unit/test_ad_reviewer_contradiction.py
+++ b/tests/unit/test_ad_reviewer_contradiction.py
@@ -624,6 +624,14 @@ def test_negated_elliptical_plural_is_a_contradiction():
     assert reasoning_contradicts_cut(reason)
 
 
+def test_indirectly_negated_elliptical_plural_is_a_contradiction():
+    reason = (
+        'Several potential ads appear to be not an ad and should be '
+        'excluded from the cut.')
+    assert not reasoning_affirms_ad(reason)
+    assert reasoning_contradicts_cut(reason)
+
+
 def test_user_confirmed_ad_bypasses_automated_reviewer():
     reviewer = _build_reviewer({
         'review_prompt': 'review', 'resurrect_prompt': 'resurrect',

--- a/tests/unit/test_ad_reviewer_contradiction.py
+++ b/tests/unit/test_ad_reviewer_contradiction.py
@@ -607,6 +607,62 @@ def test_gerund_affirmation_with_trim_note_is_not_contradiction():
     assert not reasoning_contradicts_cut(reason)
 
 
+def test_elliptical_plural_affirmation_with_trim_is_not_contradiction():
+    reason = (
+        'Multiple Norwegian ads with clear calls to action and URLs. '
+        'Adjusted start to exclude the host sign-off, which is not an ad.'
+    )
+    assert reasoning_affirms_ad(reason)
+    assert not reasoning_contradicts_cut(reason)
+
+
+def test_user_confirmed_ad_bypasses_automated_reviewer():
+    reviewer = _build_reviewer({
+        'review_prompt': 'review', 'resurrect_prompt': 'resurrect',
+    })
+    ad = {
+        'start': 120.0,
+        'end': 180.0,
+        'confidence': 0.95,
+        'reason': 'Human-confirmed DAI block',
+        'validation': {'decision': 'ACCEPT', 'user_confirmed': True},
+    }
+
+    result = reviewer.review(
+        accepted_ads=[ad], resurrection_eligible=[],
+        segments=_mock_segments(), episode_meta=_mock_episode_meta(),
+        pass_num=1, pass_model='claude-test',
+    )
+
+    assert result.accepted_after_review == [ad]
+    assert result.verdicts == []
+    reviewer._llm_client.messages_create.assert_not_called()
+
+
+def test_untrusted_top_level_confirm_flag_does_not_bypass_reviewer():
+    reviewer = _build_reviewer({
+        'review_prompt': 'review', 'resurrect_prompt': 'resurrect',
+    })
+    reviewer._llm_client.messages_create.return_value = _resp('[]')
+    ad = {
+        'start': 120.0,
+        'end': 180.0,
+        'confidence': 0.95,
+        'reason': 'Model-produced marker',
+        'user_confirmed': True,
+    }
+
+    result = reviewer.review(
+        accepted_ads=[ad], resurrection_eligible=[],
+        segments=_mock_segments(), episode_meta=_mock_episode_meta(),
+        pass_num=1, pass_model='claude-test',
+    )
+
+    assert result.accepted_after_review == []
+    assert result.verdicts[0].verdict == 'reject'
+    reviewer._llm_client.messages_create.assert_called_once()
+
+
 @pytest.mark.parametrize("reason", NEGATED_PHRASE_REASONS)
 def test_negated_phrases_are_not_affirmations(reason):
     assert not reasoning_affirms_ad(reason)

--- a/tests/unit/test_ad_reviewer_contradiction.py
+++ b/tests/unit/test_ad_reviewer_contradiction.py
@@ -701,3 +701,20 @@ def test_affirmed_confirm_recovery_failure_accepts_unchanged():
     assert accepted['start'] == 837.2
     assert accepted['end'] == 1068.5
     assert result.verdicts[0].verdict == 'confirmed'
+
+
+def test_dai_core_that_erases_recovered_trim_accepts_unchanged():
+    ad = {
+        'start': 100.0, 'end': 200.0, 'confidence': 0.95,
+        'detection_stage': 'dai_differential',
+        'dai_core_spans': [{'start': 100.0, 'end': 200.0}],
+    }
+
+    result, llm = _run_affirmed_confirm(
+        _resp('{"ad_start": 120.0, "ad_end": 180.0}'), ad=ad)
+
+    assert llm.messages_create.call_count == 2
+    assert result.held_by_contradiction == []
+    accepted = result.accepted_after_review[0]
+    assert (accepted['start'], accepted['end']) == (100.0, 200.0)
+    assert result.verdicts[0].verdict == 'confirmed'

--- a/tests/unit/test_ad_reviewer_contradiction.py
+++ b/tests/unit/test_ad_reviewer_contradiction.py
@@ -674,6 +674,40 @@ def test_user_confirmed_ad_bypasses_automated_reviewer():
     reviewer._llm_client.messages_create.assert_not_called()
 
 
+def test_user_confirmed_bypass_preserves_mixed_concurrent_order():
+    reviewer = _build_reviewer({
+        'review_prompt': 'review', 'resurrect_prompt': 'resurrect',
+    })
+    reviewer._llm_client.messages_create.return_value = _resp(
+        '[{"start": 240.0, "end": 300.0, "confidence": 0.95, '
+        '"reason": "This is a paid ad"}]')
+    confirmed = {
+        'start': 120.0,
+        'end': 180.0,
+        'confidence': 0.95,
+        'reason': 'Human-confirmed DAI block',
+        'validation': {'decision': 'ACCEPT', 'user_confirmed': True},
+    }
+    normal = {
+        'start': 240.0,
+        'end': 300.0,
+        'confidence': 0.95,
+        'reason': 'Paid sponsor read',
+    }
+
+    with patch('ad_reviewer._resolve_reviewer_parallel_ads', return_value=2):
+        result = reviewer.review(
+            accepted_ads=[confirmed, normal], resurrection_eligible=[],
+            segments=_mock_segments(), episode_meta=_mock_episode_meta(),
+            pass_num=1, pass_model='claude-test',
+        )
+
+    assert result.accepted_after_review == [confirmed, normal]
+    assert len(result.verdicts) == 1
+    assert result.verdicts[0].original_start == 240.0
+    reviewer._llm_client.messages_create.assert_called_once()
+
+
 def test_untrusted_top_level_confirm_flag_does_not_bypass_reviewer():
     reviewer = _build_reviewer({
         'review_prompt': 'review', 'resurrect_prompt': 'resurrect',

--- a/tests/unit/test_ad_reviewer_contradiction.py
+++ b/tests/unit/test_ad_reviewer_contradiction.py
@@ -632,6 +632,15 @@ def test_indirectly_negated_elliptical_plural_is_a_contradiction():
     assert reasoning_contradicts_cut(reason)
 
 
+@pytest.mark.parametrize('reason', [
+    'Several potential ads should be excluded because this is not advertising.',
+    'Multiple ads are excluded from the cut since the span is not an ad.',
+])
+def test_trailing_negation_without_boundary_adjustment_is_a_contradiction(reason):
+    assert not reasoning_affirms_ad(reason)
+    assert reasoning_contradicts_cut(reason)
+
+
 def test_user_confirmed_ad_bypasses_automated_reviewer():
     reviewer = _build_reviewer({
         'review_prompt': 'review', 'resurrect_prompt': 'resurrect',

--- a/tests/unit/test_ad_reviewer_contradiction.py
+++ b/tests/unit/test_ad_reviewer_contradiction.py
@@ -641,6 +641,16 @@ def test_trailing_negation_without_boundary_adjustment_is_a_contradiction(reason
     assert reasoning_contradicts_cut(reason)
 
 
+@pytest.mark.parametrize('reason', [
+    'Several potential ads adjusted the end, but none are ads; the entire '
+    'span is not advertising.',
+    'Multiple ads moved the start, but they are not ads and should be kept.',
+])
+def test_boundary_wording_does_not_mask_whole_span_negation(reason):
+    assert not reasoning_affirms_ad(reason)
+    assert reasoning_contradicts_cut(reason)
+
+
 def test_user_confirmed_ad_bypasses_automated_reviewer():
     reviewer = _build_reviewer({
         'review_prompt': 'review', 'resurrect_prompt': 'resurrect',

--- a/tests/unit/test_ad_reviewer_contradiction.py
+++ b/tests/unit/test_ad_reviewer_contradiction.py
@@ -609,7 +609,7 @@ def test_gerund_affirmation_with_trim_note_is_not_contradiction():
 
 def test_elliptical_plural_affirmation_with_trim_is_not_contradiction():
     reason = (
-        'Multiple Norwegian ads with clear calls to action and URLs. '
+        '  Multiple Norwegian ads with clear calls to action and URLs. '
         'Adjusted start to exclude the host sign-off, which is not an ad.'
     )
     assert reasoning_affirms_ad(reason)

--- a/tests/unit/test_ad_validator.py
+++ b/tests/unit/test_ad_validator.py
@@ -842,9 +842,8 @@ class TestConfirmedCorrections:
         assert 'INFO: Clamped to user-approved span' not in out['validation']['flags']
         assert out['start'] == 100.0 and out['end'] == 128.0  # bounds untouched
 
-    def test_clamp_keeps_extension_beyond_reviewed_bounds(self):
-        """A merged detection extending past the reviewed original bounds keeps
-        the extension (new ad territory); only the trimmed-out zone is pulled."""
+    def test_trimmed_confirm_clamps_extension_beyond_reviewed_bounds(self):
+        """Known ad audio is still cut when a new detection grows around it."""
         confirmed = [
             {'start': 100.0, 'end': 200.0,
              'confirmed_span': {'start': 130.0, 'end': 200.0}}
@@ -864,11 +863,38 @@ class TestConfirmedCorrections:
         result = validator.validate([ad])
         out = result.ads[0]
         assert out['start'] == 130.0
-        assert out['end'] == 240.0
+        assert out['end'] == 200.0
         assert out['validation']['decision'] == Decision.ACCEPT.value
-        assert 'user_confirmed' not in out['validation']
-        assert 'INFO: User confirmation covers only part of segment' in (
-            out['validation']['flags'])
+        assert out['validation']['user_confirmed'] is True
+        assert 'INFO: User confirmed as ad' in out['validation']['flags']
+
+    def test_df_wider_redetection_keeps_english_and_cuts_approved_ad(self):
+        validator = AdValidator(
+            episode_duration=5485.17,
+            segments=[],
+            confirmed_corrections=[{
+                'start': 1361.654,
+                'end': 1409.104,
+                'confirmed_span': {'start': 1361.5, 'end': 1408.93},
+            }],
+        )
+        ad = {
+            'start': 1355.9,
+            'end': 1408.93,
+            'confidence': 0.95,
+            'reason': 'Wider DAI re-detection after English show speech',
+            'detection_stage': 'dai_differential',
+            'dai_core_spans': [{'start': 1361.5, 'end': 1406.4}],
+        }
+
+        out = validator.validate([ad]).ads[0]
+
+        assert out['start'] == 1361.5
+        assert out['end'] == 1408.93
+        assert out['validation']['decision'] == Decision.ACCEPT.value
+        assert out['validation']['user_confirmed'] is True
+        assert out['validation']['confirmed_span'] == {
+            'start': 1361.5, 'end': 1408.93}
 
     def test_partial_confirm_does_not_authorize_adjacent_merged_ad(self):
         validator = AdValidator(

--- a/tests/unit/test_ad_validator.py
+++ b/tests/unit/test_ad_validator.py
@@ -749,12 +749,42 @@ class TestConfirmedCorrections:
             confirmed_corrections=confirmed
         )
         # Merged with an adjacent new ad reaching 240s.
-        ad = {'start': 100.0, 'end': 240.0, 'confidence': 0.95, 'reason': 'ad'}
+        ad = {
+            'start': 100.0,
+            'end': 240.0,
+            'confidence': 0.95,
+            'reason': 'ad',
+            'merged_distinct_ads': True,
+        }
         result = validator.validate([ad])
         out = result.ads[0]
         assert out['start'] == 130.0
         assert out['end'] == 240.0
         assert out['validation']['decision'] == Decision.ACCEPT.value
+        assert 'user_confirmed' not in out['validation']
+        assert 'INFO: User confirmation covers only part of merged segment' in (
+            out['validation']['flags'])
+
+    def test_partial_confirm_does_not_authorize_adjacent_merged_ad(self):
+        validator = AdValidator(
+            episode_duration=600.0,
+            segments=[],
+            confirmed_corrections=[{'start': 100.0, 'end': 130.0}],
+        )
+        ads = [
+            {'start': 100.0, 'end': 130.0, 'confidence': 0.95,
+             'reason': 'Confirmed sponsor ad'},
+            {'start': 132.0, 'end': 160.0, 'confidence': 0.95,
+             'reason': 'New adjacent candidate'},
+        ]
+
+        out = validator.validate(ads).ads[0]
+
+        assert out['start'] == 100.0
+        assert out['end'] == 160.0
+        assert out['merged_distinct_ads'] is True
+        assert out['validation']['decision'] == Decision.ACCEPT.value
+        assert 'user_confirmed' not in out['validation']
 
     def test_trimmed_confirm_preferred_over_plain(self):
         """A trimmed approval is not shadowed by a plain confirm row that

--- a/tests/unit/test_ad_validator.py
+++ b/tests/unit/test_ad_validator.py
@@ -283,6 +283,29 @@ class TestAdValidatorBoundaries:
         assert result.ads[0]['end'] == 300.0
         assert 'Clamped end' in ' '.join(result.corrections)
 
+    def test_automatic_snap_cannot_narrow_measured_dai_core(
+            self, sample_transcript):
+        validator = AdValidator(
+            episode_duration=300.0, segments=sample_transcript)
+        snapped_ad = {
+            'start': 110.0,
+            'end': 150.0,
+            'confidence': 0.95,
+            'reason': 'DAI candidate narrowed by cue snap',
+            'detection_stage': 'dai_differential',
+            'dai_core_spans': [{'start': 100.0, 'end': 160.0}],
+        }
+
+        result = validator.validate([snapped_ad])
+
+        assert result.ads[0]['start'] == 100.0
+        assert result.ads[0]['end'] == 160.0
+        assert result.ads[0]['dai_core_spans'] == [
+            {'start': 100.0, 'end': 160.0},
+        ]
+        assert 'Restored start' in ' '.join(result.corrections)
+        assert 'Restored end' in ' '.join(result.corrections)
+
 
 class TestAdValidatorResults:
     """Tests for validation result counts and structure."""

--- a/tests/unit/test_ad_validator.py
+++ b/tests/unit/test_ad_validator.py
@@ -365,6 +365,57 @@ class TestAdValidatorFalsePositives:
         assert result.rejected == 1
         assert 'false positive' in result.ads[0]['validation']['flags'][0].lower()
 
+    def test_false_positive_match_survives_dai_core_restoration(
+            self, sample_transcript):
+        validator = AdValidator(
+            episode_duration=300.0,
+            segments=sample_transcript,
+            false_positive_corrections=[{'start': 120.0, 'end': 140.0}],
+        )
+        narrowed_ad = {
+            'start': 120.0,
+            'end': 140.0,
+            'confidence': 0.95,
+            'reason': 'Automatically narrowed DAI candidate',
+            'detection_stage': 'dai_differential',
+            'dai_core_spans': [{'start': 100.0, 'end': 160.0}],
+        }
+
+        result = validator.validate([narrowed_ad])
+
+        assert result.rejected == 1
+        assert result.ads[0]['start'] == 100.0
+        assert result.ads[0]['end'] == 160.0
+        assert '_matches_false_positive_correction' not in result.ads[0]
+
+    def test_false_positive_does_not_merge_with_nearby_real_ad(
+            self, sample_transcript):
+        validator = AdValidator(
+            episode_duration=300.0,
+            segments=sample_transcript,
+            false_positive_corrections=[{'start': 120.0, 'end': 140.0}],
+        )
+        ads = [
+            {
+                'start': 120.0,
+                'end': 140.0,
+                'confidence': 0.95,
+                'reason': 'Rejected detection',
+            },
+            {
+                'start': 142.0,
+                'end': 170.0,
+                'confidence': 0.95,
+                'reason': 'Nearby real sponsor ad',
+            },
+        ]
+
+        result = validator.validate(ads)
+
+        assert len(result.ads) == 2
+        assert result.ads[0]['validation']['decision'] == Decision.REJECT.value
+        assert result.ads[1]['validation']['decision'] == Decision.ACCEPT.value
+
 
 class TestAdValidatorReasonQuality:
     """Tests for reason quality checks."""

--- a/tests/unit/test_ad_validator.py
+++ b/tests/unit/test_ad_validator.py
@@ -651,6 +651,29 @@ class TestConfirmedCorrections:
         assert 'INFO: User confirmed as ad' not in (
             result.ads[0]['validation']['flags'])
 
+    def test_trimmed_confirm_survives_trailing_extension(self):
+        validator = AdValidator(
+            episode_duration=200.0,
+            segments=[],
+            confirmed_corrections=[{
+                'start': 160.0,
+                'end': 170.0,
+                'confirmed_span': {'start': 160.0, 'end': 170.0},
+            }],
+        )
+        ad = {
+            'start': 160.0,
+            'end': 170.0,
+            'confidence': 0.4,
+            'reason': 'Human-trimmed tail ad',
+        }
+
+        out = validator.validate([ad]).ads[0]
+
+        assert out['start'] == 160.0
+        assert out['end'] == 170.0
+        assert out['validation']['user_confirmed'] is True
+
     def test_trimmed_confirm_clamps_wider_redetection(self):
         """A trimmed approval (confirmed_span) clamps a re-detected wider span
         so the trimmed-out content is never cut by a later reprocess."""
@@ -752,6 +775,7 @@ class TestConfirmedCorrections:
 
         out = validator.validate([ad]).ads[0]
 
+        assert out['start'] == 120.0
         assert out['end'] == 175.0
         assert out['validation']['confirmed_span'] == {
             'start': 120.0, 'end': 175.0}

--- a/tests/unit/test_ad_validator.py
+++ b/tests/unit/test_ad_validator.py
@@ -602,6 +602,34 @@ class TestConfirmedCorrections:
         assert result.ads[0]['validation']['adjusted_confidence'] == 1.0
         assert '_pre_dai_restore_confirmed_correction' not in result.ads[0]
 
+    def test_trimmed_confirm_remains_authoritative_after_dai_core_restoration(self):
+        validator = AdValidator(
+            episode_duration=300.0,
+            segments=[],
+            confirmed_corrections=[{
+                'start': 120.0,
+                'end': 140.0,
+                'confirmed_span': {'start': 120.0, 'end': 140.0},
+            }],
+        )
+        narrowed_ad = {
+            'start': 120.0,
+            'end': 140.0,
+            'confidence': 0.4,
+            'reason': 'Automatically narrowed DAI candidate',
+            'detection_stage': 'dai_differential',
+            'dai_core_spans': [{'start': 100.0, 'end': 160.0}],
+        }
+
+        result = validator.validate([narrowed_ad])
+
+        assert result.accepted == 1
+        assert result.ads[0]['start'] == 120.0
+        assert result.ads[0]['end'] == 140.0
+        assert result.ads[0]['dai_core_spans'] == [
+            {'start': 120.0, 'end': 140.0}]
+        assert result.ads[0]['validation']['user_confirmed'] is True
+
     def test_confirm_is_not_preserved_across_unrelated_tail_extension(self):
         validator = AdValidator(
             episode_duration=200.0,

--- a/tests/unit/test_ad_validator.py
+++ b/tests/unit/test_ad_validator.py
@@ -772,6 +772,26 @@ class TestConfirmedCorrections:
         assert result.ads[0]['start'] == 98.0
         assert result.ads[0]['end'] == 202.0
 
+    def test_plain_confirm_partly_covering_low_confidence_ad_requires_review(self):
+        validator = AdValidator(
+            episode_duration=600.0,
+            segments=[],
+            confirmed_corrections=[{'start': 100.0, 'end': 130.0}],
+        )
+        ad = {
+            'start': 100.0,
+            'end': 160.0,
+            'confidence': 0.4,
+            'reason': 'Wider low-confidence re-detection',
+        }
+
+        out = validator.validate([ad]).ads[0]
+
+        assert out['validation']['decision'] == Decision.REVIEW.value
+        assert 'user_confirmed' not in out['validation']
+        assert 'INFO: User confirmation covers only part of segment' in (
+            out['validation']['flags'])
+
     def test_no_intersection_with_confirmed_span_is_not_auto_accepted(self):
         """A re-detection entirely inside user-kept content must not be
         auto-accepted at confidence 1.0; it falls through to normal validation."""

--- a/tests/unit/test_ad_validator.py
+++ b/tests/unit/test_ad_validator.py
@@ -799,6 +799,43 @@ class TestConfirmedCorrections:
         assert result.ads[1]['end'] == 180.0
         assert result.ads[1]['validation']['user_confirmed'] is True
 
+    def test_confirmed_span_dedup_ignores_false_positive_fragment(self):
+        validator = AdValidator(
+            episode_duration=600.0,
+            segments=[],
+            false_positive_corrections=[{'start': 115.0, 'end': 125.0}],
+            confirmed_corrections=[{
+                'start': 100.0,
+                'end': 180.0,
+                'confirmed_span': {'start': 120.0, 'end': 180.0},
+            }],
+        )
+
+        result = validator.validate([
+            {
+                'start': 115.0,
+                'end': 125.0,
+                'confidence': 0.4,
+                'reason': 'False-positive fragment',
+                'detection_stage': 'dai_differential',
+            },
+            {
+                'start': 125.0,
+                'end': 180.0,
+                'confidence': 0.4,
+                'reason': 'Approved ad fragment',
+                'detection_stage': 'dai_differential',
+            },
+        ])
+
+        assert result.rejected == 1
+        assert result.accepted == 1
+        approved_ad = next(
+            ad for ad in result.ads
+            if ad['validation']['decision'] == Decision.ACCEPT.value)
+        assert approved_ad['start'] == 120.0
+        assert approved_ad['end'] == 180.0
+
     def test_newer_exact_correction_wins_over_older_trimmed_confirm(self):
         validator = AdValidator(
             episode_duration=600.0,

--- a/tests/unit/test_ad_validator.py
+++ b/tests/unit/test_ad_validator.py
@@ -416,6 +416,42 @@ class TestAdValidatorFalsePositives:
         assert result.ads[0]['validation']['decision'] == Decision.REJECT.value
         assert result.ads[1]['validation']['decision'] == Decision.ACCEPT.value
 
+    def test_dedup_keeps_fragment_that_does_not_restore_into_false_positive(
+            self, sample_transcript):
+        validator = AdValidator(
+            episode_duration=300.0,
+            segments=sample_transcript,
+            false_positive_corrections=[{'start': 100.0, 'end': 180.0}],
+            confirmed_corrections=[{
+                'start': 190.0,
+                'end': 200.0,
+                'confirmed_span': {'start': 190.0, 'end': 200.0},
+            }],
+        )
+        fragments = [
+            {
+                'start': 190.0,
+                'end': 200.0,
+                'confidence': 0.95,
+                'reason': 'DAI fragment expanded into user-kept content',
+                'dai_core_spans': [{'start': 100.0, 'end': 200.0}],
+            },
+            {
+                'start': 190.0,
+                'end': 200.0,
+                'confidence': 0.95,
+                'reason': 'DAI fragment within approved bounds',
+            },
+        ]
+
+        result = validator.validate(fragments)
+
+        assert len(result.ads) == 2
+        assert result.accepted == 1
+        assert result.rejected == 1
+        assert result.ads[1]['start'] == 190.0
+        assert result.ads[1]['end'] == 200.0
+
 
 class TestAdValidatorReasonQuality:
     """Tests for reason quality checks."""

--- a/tests/unit/test_ad_validator.py
+++ b/tests/unit/test_ad_validator.py
@@ -599,7 +599,27 @@ class TestConfirmedCorrections:
         assert result.ads[0]['start'] == 100.0
         assert result.ads[0]['end'] == 160.0
         assert result.ads[0]['validation']['adjusted_confidence'] == 1.0
-        assert '_pre_restore_confirmed_correction' not in result.ads[0]
+        assert '_pre_dai_restore_confirmed_correction' not in result.ads[0]
+
+    def test_confirm_is_not_preserved_across_unrelated_tail_extension(self):
+        validator = AdValidator(
+            episode_duration=200.0,
+            segments=[],
+            confirmed_corrections=[{'start': 160.0, 'end': 170.0}],
+        )
+        ad = {
+            'start': 160.0,
+            'end': 170.0,
+            'confidence': 0.4,
+            'reason': 'Low-confidence tail candidate',
+        }
+
+        result = validator.validate([ad])
+
+        assert result.accepted == 0
+        assert result.ads[0]['end'] == 200.0
+        assert 'INFO: User confirmed as ad' not in (
+            result.ads[0]['validation']['flags'])
 
     def test_trimmed_confirm_clamps_wider_redetection(self):
         """A trimmed approval (confirmed_span) clamps a re-detected wider span

--- a/tests/unit/test_ad_validator.py
+++ b/tests/unit/test_ad_validator.py
@@ -710,6 +710,74 @@ class TestConfirmedCorrections:
         assert out['end'] == 170.0
         assert out['validation']['user_confirmed'] is True
 
+    def test_expanded_boundary_adjustment_survives_trailing_extension(self):
+        validator = AdValidator(
+            episode_duration=200.0,
+            segments=[],
+            confirmed_corrections=[{
+                'start': 160.0,
+                'end': 170.0,
+                'confirmed_span': {'start': 140.0, 'end': 180.0},
+            }],
+        )
+        ad = {
+            'start': 140.0,
+            'end': 180.0,
+            'confidence': 0.4,
+            'reason': 'Human-expanded tail ad',
+        }
+
+        out = validator.validate([ad]).ads[0]
+
+        assert out['start'] == 140.0
+        assert out['end'] == 180.0
+        assert out['validation']['user_confirmed'] is True
+
+    def test_expanded_boundary_adjustment_claims_only_one_split_marker(self):
+        validator = AdValidator(
+            episode_duration=300.0,
+            segments=[],
+            confirmed_corrections=[{
+                'start': 160.0,
+                'end': 170.0,
+                'confirmed_span': {'start': 140.0, 'end': 180.0},
+            }],
+        )
+
+        result = validator.validate([
+            {'start': 140.0, 'end': 160.0, 'confidence': 0.95,
+             'reason': 'First half', 'category': 'sponsor'},
+            {'start': 160.0, 'end': 180.0, 'confidence': 0.95,
+             'reason': 'Second half', 'category': 'promotion'},
+        ], actions_map={'sponsor': 'remove', 'promotion': 'beep'})
+
+        accepted = [ad for ad in result.ads
+                    if ad['validation']['decision'] == Decision.ACCEPT.value]
+        rejected = [ad for ad in result.ads
+                    if ad['validation']['decision'] == Decision.REJECT.value]
+        assert [(ad['start'], ad['end']) for ad in accepted] == [(140.0, 180.0)]
+        assert len(rejected) == 1
+        assert 'INFO: Duplicate of user-confirmed span' in (
+            rejected[0]['validation']['flags'])
+
+    def test_dai_core_restoration_clears_tail_expansion_provenance(self):
+        validator = AdValidator(episode_duration=300.0, segments=[])
+        ad = {
+            'start': 100.0,
+            'end': 150.0,
+            'confidence': 0.95,
+            'reason': 'DAI candidate narrowed by a snap',
+            'dai_core_spans': [{'start': 100.0, 'end': 160.0}],
+            'end_extended_by_content': True,
+            'tail_splice_snap': {'original_end': 145.0, 'event_time': 150.0},
+        }
+
+        out = validator.validate([ad]).ads[0]
+
+        assert out['end'] == 160.0
+        assert 'end_extended_by_content' not in out
+        assert 'tail_splice_snap' not in out
+
     def test_trimmed_confirm_clamps_wider_redetection(self):
         """A trimmed approval (confirmed_span) clamps a re-detected wider span
         so the trimmed-out content is never cut by a later reprocess."""

--- a/tests/unit/test_ad_validator.py
+++ b/tests/unit/test_ad_validator.py
@@ -862,10 +862,21 @@ class TestConfirmedCorrections:
             },
         ])
 
+        # The first fragment claims the approved span; the second stays in
+        # the output as an audit-trail rejection rather than vanishing.
         assert result.accepted == 1
-        assert len(result.ads) == 1
-        assert result.ads[0]['start'] == 120.0
-        assert result.ads[0]['end'] == 180.0
+        assert result.rejected == 1
+        assert len(result.ads) == 2
+        accepted = next(
+            ad for ad in result.ads
+            if ad['validation']['decision'] == Decision.ACCEPT.value)
+        assert accepted['start'] == 120.0
+        assert accepted['end'] == 180.0
+        rejected = next(
+            ad for ad in result.ads
+            if ad['validation']['decision'] == Decision.REJECT.value)
+        assert 'INFO: Duplicate of user-confirmed span' in (
+            rejected['validation']['flags'])
 
     def test_confirmed_span_dedup_ignores_kept_content_fragment(self):
         validator = AdValidator(

--- a/tests/unit/test_ad_validator.py
+++ b/tests/unit/test_ad_validator.py
@@ -773,6 +773,8 @@ class TestConfirmedCorrections:
             'reason': 'Dynamically inserted ad',
             'detection_stage': 'dai_differential',
             'dai_core_spans': [{'start': 100.0, 'end': 160.0}],
+            'end_extended_by_content': True,
+            'tail_splice_snap': {'original_end': 150.0, 'event_time': 160.0},
         }
 
         out = validator.validate([ad]).ads[0]
@@ -780,6 +782,8 @@ class TestConfirmedCorrections:
         assert out['start'] == 120.0
         assert out['end'] == 140.0
         assert out['dai_core_spans'] == [{'start': 120.0, 'end': 140.0}]
+        assert 'end_extended_by_content' not in out
+        assert 'tail_splice_snap' not in out
 
     def test_plain_confirm_does_not_clamp(self):
         """A confirm without confirmed_span accepts the ad at its own bounds."""

--- a/tests/unit/test_ad_validator.py
+++ b/tests/unit/test_ad_validator.py
@@ -707,6 +707,32 @@ class TestConfirmedCorrections:
         assert 'INFO: Clamped to user-approved span' in (
             out['validation']['flags'])
 
+    def test_newer_exact_correction_wins_over_older_trimmed_confirm(self):
+        validator = AdValidator(
+            episode_duration=600.0,
+            segments=[],
+            confirmed_corrections=[
+                {
+                    'start': 120.0,
+                    'end': 180.0,
+                    'confirmed_span': {'start': 125.0, 'end': 175.0},
+                },
+                {
+                    'start': 100.0,
+                    'end': 200.0,
+                    'confirmed_span': {'start': 120.0, 'end': 180.0},
+                },
+            ],
+        )
+
+        out = validator.validate([
+            {'start': 125.0, 'end': 175.0, 'confidence': 0.4, 'reason': 'ad'}
+        ]).ads[0]
+
+        assert out['start'] == 125.0
+        assert out['end'] == 175.0
+        assert out['validation']['user_confirmed'] is True
+
     def test_confirmed_span_metadata_is_clamped_to_episode_duration(self):
         validator = AdValidator(
             episode_duration=175.0,
@@ -881,13 +907,12 @@ class TestConfirmedCorrections:
         assert 'INFO: User confirmation covers only part of segment' in (
             out['validation']['flags'])
 
-    def test_trimmed_confirm_preferred_over_plain(self):
-        """A trimmed approval is not shadowed by a plain confirm row that
-        covers the same range."""
+    def test_newer_trimmed_confirm_preferred_over_older_plain(self):
+        """The newest correction is authoritative for the same range."""
         confirmed = [
-            {'start': 100.0, 'end': 200.0},  # plain (older row, first)
             {'start': 100.0, 'end': 200.0,
              'confirmed_span': {'start': 130.0, 'end': 200.0}},
+            {'start': 100.0, 'end': 200.0},
         ]
         validator = AdValidator(
             episode_duration=600.0, segments=[],

--- a/tests/unit/test_ad_validator.py
+++ b/tests/unit/test_ad_validator.py
@@ -577,6 +577,7 @@ class TestConfirmedCorrections:
         assert result.accepted == 1
         assert result.ads[0]['validation']['decision'] == Decision.ACCEPT.value
         assert result.ads[0]['validation']['adjusted_confidence'] == 1.0
+        assert result.ads[0]['validation']['user_confirmed'] is True
 
     def test_confirm_match_survives_dai_core_restoration(self):
         validator = AdValidator(

--- a/tests/unit/test_ad_validator.py
+++ b/tests/unit/test_ad_validator.py
@@ -730,6 +730,39 @@ class TestConfirmedCorrections:
         assert 'INFO: Clamped to user-approved span' in (
             out['validation']['flags'])
 
+    def test_confirmed_span_deduplicates_fragmented_redetection(self):
+        validator = AdValidator(
+            episode_duration=600.0,
+            segments=[],
+            confirmed_corrections=[{
+                'start': 100.0,
+                'end': 200.0,
+                'confirmed_span': {'start': 120.0, 'end': 180.0},
+            }],
+        )
+
+        result = validator.validate([
+            {
+                'start': 120.0,
+                'end': 150.0,
+                'confidence': 0.4,
+                'reason': 'First DAI fragment',
+                'detection_stage': 'dai_differential',
+            },
+            {
+                'start': 150.0,
+                'end': 180.0,
+                'confidence': 0.4,
+                'reason': 'Second DAI fragment',
+                'detection_stage': 'dai_differential',
+            },
+        ])
+
+        assert result.accepted == 1
+        assert len(result.ads) == 1
+        assert result.ads[0]['start'] == 120.0
+        assert result.ads[0]['end'] == 180.0
+
     def test_newer_exact_correction_wins_over_older_trimmed_confirm(self):
         validator = AdValidator(
             episode_duration=600.0,

--- a/tests/unit/test_ad_validator.py
+++ b/tests/unit/test_ad_validator.py
@@ -702,8 +702,33 @@ class TestConfirmedCorrections:
         assert out['end'] == 180.0
         assert out['dai_core_spans'] == [{'start': 120.0, 'end': 170.0}]
         assert out['validation']['user_confirmed'] is True
+        assert out['validation']['confirmed_span'] == {
+            'start': 120.0, 'end': 180.0}
         assert 'INFO: Clamped to user-approved span' in (
             out['validation']['flags'])
+
+    def test_confirmed_span_metadata_is_clamped_to_episode_duration(self):
+        validator = AdValidator(
+            episode_duration=175.0,
+            segments=[],
+            confirmed_corrections=[{
+                'start': 100.0,
+                'end': 200.0,
+                'confirmed_span': {'start': 120.0, 'end': 180.0},
+            }],
+        )
+        ad = {
+            'start': 100.0,
+            'end': 175.0,
+            'confidence': 0.95,
+            'reason': 'Re-detected ad from a shorter fetch',
+        }
+
+        out = validator.validate([ad]).ads[0]
+
+        assert out['end'] == 175.0
+        assert out['validation']['confirmed_span'] == {
+            'start': 120.0, 'end': 175.0}
 
     def test_trimmed_confirm_clips_dai_core_to_user_approved_span(self):
         confirmed = [

--- a/tests/unit/test_ad_validator.py
+++ b/tests/unit/test_ad_validator.py
@@ -529,6 +529,31 @@ class TestConfirmedCorrections:
         assert out['end'] == 200.0
         assert 'INFO: Clamped to user-approved span' in out['validation']['flags']
 
+    def test_trimmed_confirm_clips_dai_core_to_user_approved_span(self):
+        confirmed = [
+            {'start': 100.0, 'end': 160.0,
+             'confirmed_span': {'start': 120.0, 'end': 140.0}}
+        ]
+        validator = AdValidator(
+            episode_duration=600.0,
+            segments=[],
+            confirmed_corrections=confirmed,
+        )
+        ad = {
+            'start': 100.0,
+            'end': 160.0,
+            'confidence': 0.95,
+            'reason': 'Dynamically inserted ad',
+            'detection_stage': 'dai_differential',
+            'dai_core_spans': [{'start': 100.0, 'end': 160.0}],
+        }
+
+        out = validator.validate([ad]).ads[0]
+
+        assert out['start'] == 120.0
+        assert out['end'] == 140.0
+        assert out['dai_core_spans'] == [{'start': 120.0, 'end': 140.0}]
+
     def test_plain_confirm_does_not_clamp(self):
         """A confirm without confirmed_span accepts the ad at its own bounds."""
         confirmed = [{'start': 100.0, 'end': 200.0}]

--- a/tests/unit/test_ad_validator.py
+++ b/tests/unit/test_ad_validator.py
@@ -675,6 +675,35 @@ class TestConfirmedCorrections:
         assert out['end'] == 200.0
         assert 'INFO: Clamped to user-approved span' in out['validation']['flags']
 
+    def test_confirmed_span_restores_narrower_redetection(self):
+        confirmed = [{
+            'start': 100.0,
+            'end': 200.0,
+            'confirmed_span': {'start': 120.0, 'end': 180.0},
+        }]
+        validator = AdValidator(
+            episode_duration=600.0,
+            segments=[],
+            confirmed_corrections=confirmed,
+        )
+        ad = {
+            'start': 120.0,
+            'end': 170.0,
+            'confidence': 0.4,
+            'reason': 'Narrower DAI re-detection',
+            'detection_stage': 'dai_differential',
+            'dai_core_spans': [{'start': 120.0, 'end': 170.0}],
+        }
+
+        out = validator.validate([ad]).ads[0]
+
+        assert out['start'] == 120.0
+        assert out['end'] == 180.0
+        assert out['dai_core_spans'] == [{'start': 120.0, 'end': 170.0}]
+        assert out['validation']['user_confirmed'] is True
+        assert 'INFO: Clamped to user-approved span' in (
+            out['validation']['flags'])
+
     def test_trimmed_confirm_clips_dai_core_to_user_approved_span(self):
         confirmed = [
             {'start': 100.0, 'end': 160.0,

--- a/tests/unit/test_ad_validator.py
+++ b/tests/unit/test_ad_validator.py
@@ -578,6 +578,29 @@ class TestConfirmedCorrections:
         assert result.ads[0]['validation']['decision'] == Decision.ACCEPT.value
         assert result.ads[0]['validation']['adjusted_confidence'] == 1.0
 
+    def test_confirm_match_survives_dai_core_restoration(self):
+        validator = AdValidator(
+            episode_duration=300.0,
+            segments=[],
+            confirmed_corrections=[{'start': 120.0, 'end': 140.0}],
+        )
+        narrowed_ad = {
+            'start': 120.0,
+            'end': 140.0,
+            'confidence': 0.4,
+            'reason': 'Automatically narrowed DAI candidate',
+            'detection_stage': 'dai_differential',
+            'dai_core_spans': [{'start': 100.0, 'end': 160.0}],
+        }
+
+        result = validator.validate([narrowed_ad])
+
+        assert result.accepted == 1
+        assert result.ads[0]['start'] == 100.0
+        assert result.ads[0]['end'] == 160.0
+        assert result.ads[0]['validation']['adjusted_confidence'] == 1.0
+        assert '_pre_restore_confirmed_correction' not in result.ads[0]
+
     def test_trimmed_confirm_clamps_wider_redetection(self):
         """A trimmed approval (confirmed_span) clamps a re-detected wider span
         so the trimmed-out content is never cut by a later reprocess."""

--- a/tests/unit/test_ad_validator.py
+++ b/tests/unit/test_ad_validator.py
@@ -763,6 +763,42 @@ class TestConfirmedCorrections:
         assert result.ads[0]['start'] == 120.0
         assert result.ads[0]['end'] == 180.0
 
+    def test_confirmed_span_dedup_ignores_kept_content_fragment(self):
+        validator = AdValidator(
+            episode_duration=600.0,
+            segments=[],
+            confirmed_corrections=[{
+                'start': 100.0,
+                'end': 180.0,
+                'confirmed_span': {'start': 120.0, 'end': 180.0},
+            }],
+        )
+
+        result = validator.validate([
+            {
+                'start': 100.0,
+                'end': 118.0,
+                'confidence': 0.4,
+                'reason': 'Fragment in user-kept content',
+                'detection_stage': 'dai_differential',
+            },
+            {
+                'start': 120.0,
+                'end': 150.0,
+                'confidence': 0.4,
+                'reason': 'Fragment in approved ad',
+                'detection_stage': 'dai_differential',
+            },
+        ])
+
+        assert len(result.ads) == 2
+        assert result.ads[0]['start'] == 100.0
+        assert result.ads[0]['end'] == 118.0
+        assert 'user_confirmed' not in result.ads[0]['validation']
+        assert result.ads[1]['start'] == 120.0
+        assert result.ads[1]['end'] == 180.0
+        assert result.ads[1]['validation']['user_confirmed'] is True
+
     def test_newer_exact_correction_wins_over_older_trimmed_confirm(self):
         validator = AdValidator(
             episode_duration=600.0,

--- a/tests/unit/test_ad_validator.py
+++ b/tests/unit/test_ad_validator.py
@@ -579,7 +579,7 @@ class TestConfirmedCorrections:
         assert result.ads[0]['validation']['adjusted_confidence'] == 1.0
         assert result.ads[0]['validation']['user_confirmed'] is True
 
-    def test_confirm_match_survives_dai_core_restoration(self):
+    def test_plain_confirm_does_not_authorize_restored_dai_edges(self):
         validator = AdValidator(
             episode_duration=300.0,
             segments=[],
@@ -596,10 +596,11 @@ class TestConfirmedCorrections:
 
         result = validator.validate([narrowed_ad])
 
-        assert result.accepted == 1
         assert result.ads[0]['start'] == 100.0
         assert result.ads[0]['end'] == 160.0
-        assert result.ads[0]['validation']['adjusted_confidence'] == 1.0
+        assert 'user_confirmed' not in result.ads[0]['validation']
+        assert 'INFO: User confirmation covers only part of segment' in (
+            result.ads[0]['validation']['flags'])
         assert '_pre_dai_restore_confirmed_correction' not in result.ads[0]
 
     def test_trimmed_confirm_remains_authoritative_after_dai_core_restoration(self):
@@ -791,7 +792,7 @@ class TestConfirmedCorrections:
         assert out['end'] == 240.0
         assert out['validation']['decision'] == Decision.ACCEPT.value
         assert 'user_confirmed' not in out['validation']
-        assert 'INFO: User confirmation covers only part of merged segment' in (
+        assert 'INFO: User confirmation covers only part of segment' in (
             out['validation']['flags'])
 
     def test_partial_confirm_does_not_authorize_adjacent_merged_ad(self):
@@ -814,6 +815,26 @@ class TestConfirmedCorrections:
         assert out['merged_distinct_ads'] is True
         assert out['validation']['decision'] == Decision.ACCEPT.value
         assert 'user_confirmed' not in out['validation']
+
+    def test_partial_confirm_does_not_authorize_wider_unmerged_detection(self):
+        validator = AdValidator(
+            episode_duration=600.0,
+            segments=[],
+            confirmed_corrections=[{'start': 100.0, 'end': 130.0}],
+        )
+        ad = {
+            'start': 100.0,
+            'end': 160.0,
+            'confidence': 0.95,
+            'reason': 'Wider re-detection without merge metadata',
+        }
+
+        out = validator.validate([ad]).ads[0]
+
+        assert out['validation']['decision'] == Decision.ACCEPT.value
+        assert 'user_confirmed' not in out['validation']
+        assert 'INFO: User confirmation covers only part of segment' in (
+            out['validation']['flags'])
 
     def test_trimmed_confirm_preferred_over_plain(self):
         """A trimmed approval is not shadowed by a plain confirm row that

--- a/tests/unit/test_confirm_marks_approved.py
+++ b/tests/unit/test_confirm_marks_approved.py
@@ -127,6 +127,35 @@ def test_confirm_trimmed_moves_marker_bounds_and_approves(temp_db):
     assert corrections[0]['confirmed_span'] == {'start': 130.0, 'end': 200.0}
 
 
+def test_newer_boundary_adjustment_overrides_older_trimmed_confirm(temp_db):
+    episode_id = 'correction-order-test'
+    temp_db.create_pattern_correction(
+        correction_type='confirm', episode_id=episode_id,
+        original_bounds={'start': 100.0, 'end': 200.0},
+        corrected_bounds={'start': 120.0, 'end': 180.0},
+    )
+    temp_db.create_pattern_correction(
+        correction_type='boundary_adjustment', episode_id=episode_id,
+        original_bounds={'start': 120.0, 'end': 180.0},
+        corrected_bounds={'start': 125.0, 'end': 175.0},
+    )
+
+    corrections = temp_db.get_confirmed_corrections(episode_id)
+
+    assert corrections == [
+        {
+            'start': 120.0,
+            'end': 180.0,
+            'confirmed_span': {'start': 125.0, 'end': 175.0},
+        },
+        {
+            'start': 100.0,
+            'end': 200.0,
+            'confirmed_span': {'start': 120.0, 'end': 180.0},
+        },
+    ]
+
+
 def test_confirm_without_trim_keeps_marker_bounds(temp_db):
     markers = [_held(100.0, 200.0)]
     slug, eid = _seed(temp_db, markers)

--- a/tests/unit/test_correction_pattern_scope.py
+++ b/tests/unit/test_correction_pattern_scope.py
@@ -92,6 +92,20 @@ def test_adjust_correction_stores_slug_not_numeric_id(client):
     assert _slug_passed_to_create_ad_pattern(db) == SLUG
 
 
+def test_adjust_correction_supersedes_false_positive(client):
+    db = _mock_db()
+    with patch('api.patterns.get_database', return_value=db):
+        resp = client.post(
+            f'/api/v1/episodes/{SLUG}/{EPISODE_ID}/corrections',
+            data=json.dumps(_correction_payload('adjust', with_adjusted=True)),
+            content_type='application/json',
+        )
+
+    assert resp.status_code == 200, resp.data
+    db.delete_conflicting_corrections.assert_called_once_with(
+        EPISODE_ID, 'boundary_adjustment', 0.0, 60.0)
+
+
 def test_confirm_correction_dedup_lookup_uses_slug(client):
     """The deduplication query (find_pattern_by_text) is also a podcast_id
     consumer; it has to use the slug too or it'll fail to find existing

--- a/tests/unit/test_dai_differential_stage.py
+++ b/tests/unit/test_dai_differential_stage.py
@@ -26,6 +26,7 @@ def test_differential_with_stage_overlap_becomes_cut():
     assert ad.get('held_for_review') is not True
     assert 'differential_uncorroborated' not in ad
     assert 'corroborated by overlapping ad marker' in ad['reason']
+    assert ad['dai_core_spans'] == [{'start': 100.0, 'end': 160.0}]
 
 
 def test_uncorroborated_differential_is_held_not_cut_not_dropped():
@@ -84,6 +85,42 @@ def test_merge_prefers_differential_stage_and_confidence():
     assert merged[0]['detection_stage'] == 'dai_differential'
     assert merged[0]['confidence'] == 0.95
     assert merged[0]['end'] == 160.0
+
+
+def test_merge_preserves_measured_dai_core_inside_coarse_llm_span():
+    detector = AdDetector(api_key='test-key')
+    differential = dai_differential_ads(
+        _DIFF, [], corroborating_spans=[(105.0, 155.0)])[0]
+
+    merged = detector._merge_detection_results([
+        {'start': 80.0, 'end': 180.0, 'confidence': 0.80,
+         'reason': 'Coarse sponsor block', 'detection_stage': 'claude'},
+        differential,
+    ])
+
+    assert len(merged) == 1
+    assert merged[0]['start'] == 80.0
+    assert merged[0]['end'] == 180.0
+    assert merged[0]['dai_core_spans'] == [
+        {'start': 100.0, 'end': 160.0},
+    ]
+
+
+def test_unmerged_adjacent_differential_keeps_core_on_its_own_marker():
+    detector = AdDetector(api_key='test-key')
+    differential = dai_differential_ads(_DIFF, [])[0]
+
+    merged = detector._merge_detection_results([
+        {'start': 80.0, 'end': 99.0, 'confidence': 0.80,
+         'reason': 'Nearby sponsor block', 'detection_stage': 'claude'},
+        differential,
+    ])
+
+    assert len(merged) == 2
+    assert 'dai_core_spans' not in merged[0]
+    assert merged[1]['dai_core_spans'] == [
+        {'start': 100.0, 'end': 160.0},
+    ]
 
 
 def test_merge_clears_held_state_when_claude_verifies_transcribed_span():

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -421,6 +421,21 @@ class TestDeleteConflictingCorrections:
         corrections = temp_db.get_episode_corrections(episode_id)
         assert len(corrections) == 0
 
+    def test_boundary_adjustment_deletes_false_positive(self, temp_db):
+        """A newer boundary edit supersedes an earlier rejection."""
+        episode_id = 'ep-conflict-adjustment'
+        temp_db.create_pattern_correction(
+            correction_type='false_positive',
+            episode_id=episode_id,
+            original_bounds={'start': 100.0, 'end': 200.0},
+        )
+
+        deleted = temp_db.delete_conflicting_corrections(
+            episode_id, 'boundary_adjustment', 100.0, 200.0)
+
+        assert deleted == 1
+        assert temp_db.get_episode_corrections(episode_id) == []
+
     def test_no_conflict_with_non_overlapping_bounds(self, temp_db):
         """Non-overlapping corrections should not be deleted."""
         episode_id = 'ep-conflict-003'

--- a/tests/unit/test_keep_bypass.py
+++ b/tests/unit/test_keep_bypass.py
@@ -275,6 +275,51 @@ class TestKeepMarkersBlockTerminalSnap:
         assert master['start'] == 5393.668
         storage.save_combined_ads.assert_called_once()
 
+    def test_terminal_snap_does_not_cross_rejected_untranscribed_marker(self):
+        rejected = {
+            'start': 5393.5,
+            'end': 5400.0,
+            'confidence': 0.95,
+            'was_cut': False,
+            'reviewer_verdict': 'reject',
+        }
+        terminal = {
+            'start': 5400.0,
+            'end': 5485.17,
+            'confidence': 0.95,
+            'was_cut': True,
+            'reason': 'Norwegian post-roll ad block',
+        }
+        analysis = types.SimpleNamespace(
+            splice_evidence={'events': []},
+            signals=[types.SimpleNamespace(
+                start=5395.0,
+                end=5480.0,
+                signal_type='dai_transition_pair',
+                confidence=0.95,
+            )],
+            silence_spans=[{
+                'start': 5393.312,
+                'end': 5394.024,
+                'duration': 0.712,
+            }],
+            silence_tunables={
+                'max_distance_seconds': 2.0,
+                'min_duration_seconds': 0.3,
+            },
+        )
+
+        with patch.object(processing, 'db') as db, \
+                patch.object(processing, 'storage') as storage:
+            db.get_setting_float.return_value = 30.0
+            out = processing._snap_terminal_starts(
+                'feed', 'episode', [terminal], [rejected, terminal], [],
+                analysis, 5485.17)
+
+        assert out[0]['start'] == 5400.0
+        assert 'terminal_snap' not in terminal
+        storage.save_combined_ads.assert_not_called()
+
     def test_tail_completion_clamp_still_stops_at_kept_marker(self):
         # _complete_cut_tails' next_start clamp treats every marker in
         # all_ads_with_validation as a hard stop, kept or not. Promo-phrase

--- a/tests/unit/test_keep_bypass.py
+++ b/tests/unit/test_keep_bypass.py
@@ -231,6 +231,50 @@ class TestKeepMarkersBlockTerminalSnap:
         assert kept_marker['start'] == 70.0
         assert kept_marker['action_applied'] == 'keep'
 
+    def test_terminal_snap_uses_transition_paired_silence(self):
+        cut = {
+            'start': 5400.0,
+            'end': 5485.17,
+            'confidence': 0.95,
+            'reason': 'Norwegian post-roll ad block',
+        }
+        master = dict(cut)
+        analysis = types.SimpleNamespace(
+            splice_evidence={'events': []},
+            signals=[types.SimpleNamespace(
+                start=5395.0,
+                end=5480.0,
+                signal_type='dai_transition_pair',
+                confidence=0.95,
+            )],
+            silence_spans=[{
+                'start': 5393.312,
+                'end': 5394.024,
+                'duration': 0.712,
+            }],
+            silence_tunables={
+                'max_distance_seconds': 2.0,
+                'min_duration_seconds': 0.3,
+            },
+        )
+        segments = [
+            {'start': 5373.03, 'end': 5388.61,
+             'text': 'thanks for watching and supporting Digital Foundry'},
+            {'start': 5400.88, 'end': 5421.48,
+             'text': 'Norwegian Derby at Ovrevold, tickets available now'},
+        ]
+
+        with patch.object(processing, 'db') as db, \
+                patch.object(processing, 'storage') as storage:
+            db.get_setting_float.return_value = 30.0
+            out = processing._snap_terminal_starts(
+                'feed', 'episode', [cut], [master], segments, analysis,
+                5485.17)
+
+        assert out[0]['start'] == 5393.668
+        assert master['start'] == 5393.668
+        storage.save_combined_ads.assert_called_once()
+
     def test_tail_completion_clamp_still_stops_at_kept_marker(self):
         # _complete_cut_tails' next_start clamp treats every marker in
         # all_ads_with_validation as a hard stop, kept or not. Promo-phrase

--- a/tests/unit/test_keep_bypass.py
+++ b/tests/unit/test_keep_bypass.py
@@ -320,6 +320,49 @@ class TestKeepMarkersBlockTerminalSnap:
         assert 'terminal_snap' not in terminal
         storage.save_combined_ads.assert_not_called()
 
+    def test_terminal_snap_does_not_cross_unclassified_marker(self):
+        unclassified = {
+            'start': 5393.5,
+            'end': 5400.0,
+            'confidence': 0.95,
+        }
+        terminal = {
+            'start': 5400.0,
+            'end': 5485.17,
+            'confidence': 0.95,
+            'was_cut': True,
+            'reason': 'Norwegian DAI ad block',
+        }
+        analysis = types.SimpleNamespace(
+            splice_evidence={'events': []},
+            signals=[types.SimpleNamespace(
+                start=5395.0,
+                end=5480.0,
+                signal_type='dai_transition_pair',
+                confidence=0.95,
+            )],
+            silence_spans=[{
+                'start': 5393.312,
+                'end': 5394.024,
+                'duration': 0.712,
+            }],
+            silence_tunables={
+                'max_distance_seconds': 2.0,
+                'min_duration_seconds': 0.3,
+            },
+        )
+
+        with patch.object(processing, 'db') as db, \
+                patch.object(processing, 'storage') as storage:
+            db.get_setting_float.return_value = 30.0
+            out = processing._snap_terminal_starts(
+                'feed', 'episode', [terminal], [unclassified, terminal], [],
+                analysis, 5485.17)
+
+        assert out[0]['start'] == 5400.0
+        assert 'terminal_snap' not in terminal
+        storage.save_combined_ads.assert_not_called()
+
     def test_tail_completion_clamp_still_stops_at_kept_marker(self):
         # _complete_cut_tails' next_start clamp treats every marker in
         # all_ads_with_validation as a hard stop, kept or not. Promo-phrase

--- a/tests/unit/test_keep_bypass.py
+++ b/tests/unit/test_keep_bypass.py
@@ -23,6 +23,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
 
 from unittest.mock import patch
 
+import pytest
+
 import main_app.processing as processing
 from api.patterns import _matches_held_marker
 from audio_processor import AudioProcessor
@@ -271,8 +273,8 @@ class TestKeepMarkersBlockTerminalSnap:
                 'feed', 'episode', [cut], [master], segments, analysis,
                 5485.17)
 
-        assert out[0]['start'] == 5393.668
-        assert master['start'] == 5393.668
+        assert out[0]['start'] == pytest.approx(5393.668)
+        assert master['start'] == pytest.approx(5393.668)
         storage.save_combined_ads.assert_called_once()
 
     def test_terminal_snap_does_not_cross_rejected_untranscribed_marker(self):

--- a/tests/unit/test_keep_bypass.py
+++ b/tests/unit/test_keep_bypass.py
@@ -23,8 +23,6 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
 
 from unittest.mock import patch
 
-import pytest
-
 import main_app.processing as processing
 from api.patterns import _matches_held_marker
 from audio_processor import AudioProcessor

--- a/tests/unit/test_marker_merge_members.py
+++ b/tests/unit/test_marker_merge_members.py
@@ -144,3 +144,12 @@ def test_non_finite_dai_core_values_are_ignored():
     ]
 
     assert dai_core_bounds(marker) == (120.0, 180.0)
+
+
+def test_non_list_dai_core_value_is_ignored():
+    marker = _ad(100.0, 220.0, 'dai_differential')
+    marker['dai_core_spans'] = 1
+
+    assert dai_core_bounds(marker) == (None, None)
+    clip_dai_core_spans(marker, 100.0, 220.0)
+    assert 'dai_core_spans' not in marker

--- a/tests/unit/test_marker_merge_members.py
+++ b/tests/unit/test_marker_merge_members.py
@@ -146,6 +146,16 @@ def test_non_finite_dai_core_values_are_ignored():
     assert dai_core_bounds(marker) == (120.0, 180.0)
 
 
+def test_oversized_dai_core_values_are_ignored():
+    marker = _ad(100.0, 220.0, 'dai_differential')
+    marker['dai_core_spans'] = [
+        {'start': 10 ** 400, 'end': 10 ** 400 + 1},
+        {'start': 120.0, 'end': 180.0},
+    ]
+
+    assert dai_core_bounds(marker) == (120.0, 180.0)
+
+
 def test_non_list_dai_core_value_is_ignored():
     marker = _ad(100.0, 220.0, 'dai_differential')
     marker['dai_core_spans'] = 1

--- a/tests/unit/test_marker_merge_members.py
+++ b/tests/unit/test_marker_merge_members.py
@@ -7,7 +7,12 @@ os.environ.setdefault('SECRET_KEY', 'test-secret')
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
 
 from ad_detector.boundaries import deduplicate_window_ads
-from utils.markers import clip_dai_core_spans, merge_dai_core_spans, note_merged_members
+from utils.markers import (
+    clip_dai_core_spans,
+    dai_core_bounds,
+    merge_dai_core_spans,
+    note_merged_members,
+)
 
 
 def _ad(start, end, stage):
@@ -127,3 +132,15 @@ def test_dai_cores_merge_and_clip_to_split_piece():
         {'start': 140.0, 'end': 150.0},
         {'start': 150.0, 'end': 180.0},
     ]
+
+
+def test_non_finite_dai_core_values_are_ignored():
+    marker = _ad(100.0, 220.0, 'dai_differential')
+    marker['dai_core_spans'] = [
+        {'start': 100.0, 'end': float('inf')},
+        {'start': float('-inf'), 'end': 150.0},
+        {'start': float('nan'), 'end': 160.0},
+        {'start': 120.0, 'end': 180.0},
+    ]
+
+    assert dai_core_bounds(marker) == (120.0, 180.0)

--- a/tests/unit/test_marker_merge_members.py
+++ b/tests/unit/test_marker_merge_members.py
@@ -7,7 +7,7 @@ os.environ.setdefault('SECRET_KEY', 'test-secret')
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
 
 from ad_detector.boundaries import deduplicate_window_ads
-from utils.markers import note_merged_members
+from utils.markers import clip_dai_core_spans, merge_dai_core_spans, note_merged_members
 
 
 def _ad(start, end, stage):
@@ -102,3 +102,28 @@ def test_overlap_extension_widens_protected_union():
     assert m['merged_distinct_ads'] is True
     assert m['merged_protected_start'] == 100.0
     assert m['merged_protected_end'] == 220.0
+
+
+def test_dai_core_survives_merge_with_coarser_candidate():
+    base = _ad(80.0, 170.0, 'claude')
+    differential = _ad(100.0, 160.0, 'dai_differential')
+    differential['dai_core_spans'] = [{'start': 100.0, 'end': 160.0}]
+
+    merge_dai_core_spans(base, differential)
+
+    assert base['dai_core_spans'] == [{'start': 100.0, 'end': 160.0}]
+
+
+def test_dai_cores_merge_and_clip_to_split_piece():
+    marker = _ad(100.0, 220.0, 'dai_differential')
+    marker['dai_core_spans'] = [
+        {'start': 100.0, 'end': 150.0},
+        {'start': 150.0, 'end': 220.0},
+    ]
+
+    clip_dai_core_spans(marker, 140.0, 180.0)
+
+    assert marker['dai_core_spans'] == [
+        {'start': 140.0, 'end': 150.0},
+        {'start': 150.0, 'end': 180.0},
+    ]

--- a/tests/unit/test_marker_merge_members.py
+++ b/tests/unit/test_marker_merge_members.py
@@ -156,6 +156,16 @@ def test_oversized_dai_core_values_are_ignored():
     assert dai_core_bounds(marker) == (120.0, 180.0)
 
 
+def test_boolean_dai_core_values_are_ignored():
+    marker = _ad(100.0, 220.0, 'dai_differential')
+    marker['dai_core_spans'] = [
+        {'start': False, 'end': True},
+        {'start': 120.0, 'end': 180.0},
+    ]
+
+    assert dai_core_bounds(marker) == (120.0, 180.0)
+
+
 def test_non_list_dai_core_value_is_ignored():
     marker = _ad(100.0, 220.0, 'dai_differential')
     marker['dai_core_spans'] = 1

--- a/tests/unit/test_recut_ad_list.py
+++ b/tests/unit/test_recut_ad_list.py
@@ -185,6 +185,36 @@ def test_final_confirmed_bounds_uses_carried_span_after_large_extension(monkeypa
     assert marker['end'] == 111.0
 
 
+def test_final_confirmed_bounds_does_not_restore_older_trim_after_new_plain_confirm(
+        monkeypatch):
+    marker = {
+        'start': 100.0,
+        'end': 200.0,
+        'validation': {
+            'decision': 'ACCEPT',
+            'user_confirmed': True,
+            'flags': [],
+        },
+    }
+    corrections = [
+        {'start': 100.0, 'end': 200.0},
+        {
+            'start': 100.0,
+            'end': 200.0,
+            'confirmed_span': {'start': 120.0, 'end': 180.0},
+        },
+    ]
+    monkeypatch.setattr(
+        processing.storage, 'save_combined_ads',
+        lambda *args: pytest.fail('newest plain confirm must keep its bounds'))
+
+    processing._finalize_user_confirmed_bounds(
+        'feed', 'episode', [marker], [marker], corrections)
+
+    assert marker['start'] == 100.0
+    assert marker['end'] == 200.0
+
+
 def test_final_confirmed_bounds_clamps_carried_span_to_episode(monkeypatch):
     marker = {
         'start': 101.0,

--- a/tests/unit/test_recut_ad_list.py
+++ b/tests/unit/test_recut_ad_list.py
@@ -48,7 +48,12 @@ def test_best_overlap_ad_excludes_ids():
 
 
 def test_apply_boundary_adjustments_overrides_bounds(monkeypatch):
-    ads = [{'start': 100.0, 'end': 160.0, 'confidence': 0.9}]
+    ads = [{
+        'start': 100.0,
+        'end': 160.0,
+        'confidence': 0.9,
+        'dai_core_spans': [{'start': 100.0, 'end': 160.0}],
+    }]
     corrections = [{
         'correction_type': 'boundary_adjustment',
         'original_bounds': {'start': 100.0, 'end': 160.0},
@@ -58,6 +63,7 @@ def test_apply_boundary_adjustments_overrides_bounds(monkeypatch):
     processing._apply_boundary_adjustments('slug', 'ep', ads)
     assert ads[0]['start'] == 105.0
     assert ads[0]['end'] == 150.0
+    assert ads[0]['dai_core_spans'] == [{'start': 105.0, 'end': 150.0}]
 
 
 def test_apply_boundary_adjustments_skips_unmatched(monkeypatch):

--- a/tests/unit/test_recut_ad_list.py
+++ b/tests/unit/test_recut_ad_list.py
@@ -160,6 +160,51 @@ def test_final_confirmed_bounds_ignores_untrusted_marker(monkeypatch):
     assert marker['end'] == 1406.753
 
 
+def test_final_confirmed_bounds_uses_carried_span_after_large_extension(monkeypatch):
+    marker = {
+        'start': 101.0,
+        'end': 141.0,
+        'validation': {
+            'decision': 'ACCEPT',
+            'user_confirmed': True,
+            'confirmed_span': {'start': 101.0, 'end': 111.0},
+            'flags': [],
+        },
+    }
+    corrections = [{
+        'start': 100.0,
+        'end': 112.0,
+        'confirmed_span': {'start': 101.0, 'end': 111.0},
+    }]
+    monkeypatch.setattr(processing.storage, 'save_combined_ads', lambda *args: None)
+
+    processing._finalize_user_confirmed_bounds(
+        'feed', 'episode', [marker], [marker], corrections)
+
+    assert marker['start'] == 101.0
+    assert marker['end'] == 111.0
+
+
+def test_final_confirmed_bounds_clamps_carried_span_to_episode(monkeypatch):
+    marker = {
+        'start': 101.0,
+        'end': 111.0,
+        'validation': {
+            'decision': 'ACCEPT',
+            'user_confirmed': True,
+            'confirmed_span': {'start': 101.0, 'end': 111.0},
+            'flags': [],
+        },
+    }
+    monkeypatch.setattr(processing.storage, 'save_combined_ads', lambda *args: None)
+
+    processing._finalize_user_confirmed_bounds(
+        'feed', 'episode', [marker], [marker], [], episode_duration=105.0)
+
+    assert marker['start'] == 101.0
+    assert marker['end'] == 105.0
+
+
 def test_build_recut_ad_list_drops_rejected(monkeypatch):
     ads = [
         {'start': 30.0, 'end': 90.0, 'confidence': 0.98, 'sponsor': 'A', 'reason': 'sponsor read for A'},

--- a/tests/unit/test_recut_ad_list.py
+++ b/tests/unit/test_recut_ad_list.py
@@ -235,6 +235,56 @@ def test_final_confirmed_bounds_clamps_carried_span_to_episode(monkeypatch):
     assert marker['end'] == 105.0
 
 
+def test_final_confirmed_bounds_ignores_collapsed_duration_clamp(monkeypatch):
+    marker = {
+        'start': 101.0,
+        'end': 111.0,
+        'validation': {
+            'decision': 'ACCEPT',
+            'user_confirmed': True,
+            'confirmed_span': {'start': 101.0, 'end': 111.0},
+            'flags': [],
+        },
+    }
+    monkeypatch.setattr(
+        processing.storage, 'save_combined_ads',
+        lambda *args: pytest.fail('a collapsed clamp must not be persisted'))
+
+    processing._finalize_user_confirmed_bounds(
+        'feed', 'episode', [marker], [marker], [], episode_duration=100.0)
+
+    assert marker['start'] == 101.0
+    assert marker['end'] == 111.0
+
+
+def test_final_confirmed_bounds_master_fallback_requires_overlap(monkeypatch):
+    approved = {'start': 101.0, 'end': 111.0}
+
+    def marker(start, end):
+        return {
+            'start': start,
+            'end': end,
+            'validation': {
+                'decision': 'ACCEPT',
+                'user_confirmed': True,
+                'confirmed_span': approved,
+                'flags': [],
+            },
+        }
+
+    cut = marker(101.0, 141.0)
+    unrelated = marker(500.0, 510.0)
+    related_master = marker(100.0, 140.0)
+    monkeypatch.setattr(processing.storage, 'save_combined_ads', lambda *args: None)
+
+    processing._finalize_user_confirmed_bounds(
+        'feed', 'episode', [cut], [unrelated, related_master], [])
+
+    assert cut['end'] == 111.0
+    assert (related_master['start'], related_master['end']) == (101.0, 111.0)
+    assert (unrelated['start'], unrelated['end']) == (500.0, 510.0)
+
+
 def test_build_recut_ad_list_drops_rejected(monkeypatch):
     ads = [
         {'start': 30.0, 'end': 90.0, 'confidence': 0.98, 'sponsor': 'A', 'reason': 'sponsor read for A'},

--- a/tests/unit/test_recut_ad_list.py
+++ b/tests/unit/test_recut_ad_list.py
@@ -96,6 +96,70 @@ def test_apply_boundary_adjustments_newest_wins(monkeypatch):
     assert ads[0]['end'] == 150.0
 
 
+def test_final_confirmed_bounds_sync_cut_and_master(monkeypatch):
+    cut = {
+        'start': 1361.5,
+        'end': 1406.753,
+        'confidence': 0.95,
+        'dai_core_spans': [{'start': 1361.5, 'end': 1406.4}],
+        'end_extended_by_content': True,
+        'tail_splice_snap': {'event_time': 1407.5},
+        'validation': {
+            'decision': 'ACCEPT',
+            'user_confirmed': True,
+            'flags': ['INFO: User confirmed as ad'],
+        },
+    }
+    master = dict(cut)
+    master['validation'] = dict(cut['validation'])
+    master['validation']['flags'] = list(cut['validation']['flags'])
+    corrections = [{
+        'start': 1361.654,
+        'end': 1409.104,
+        'confirmed_span': {'start': 1361.5, 'end': 1408.93},
+    }]
+    saves = []
+    monkeypatch.setattr(
+        processing.storage, 'save_combined_ads',
+        lambda *args: saves.append(args))
+
+    result = processing._finalize_user_confirmed_bounds(
+        'feed', 'episode', [cut], [master], corrections)
+
+    assert result[0]['start'] == 1361.5
+    assert result[0]['end'] == 1408.93
+    assert master['start'] == 1361.5
+    assert master['end'] == 1408.93
+    assert result[0]['dai_core_spans'] == [
+        {'start': 1361.5, 'end': 1406.4}]
+    assert 'end_extended_by_content' not in result[0]
+    assert 'tail_splice_snap' not in result[0]
+    assert 'INFO: Finalized to user-approved span' in (
+        master['validation']['flags'])
+    assert len(saves) == 1
+
+
+def test_final_confirmed_bounds_ignores_untrusted_marker(monkeypatch):
+    marker = {
+        'start': 1361.5,
+        'end': 1406.753,
+        'validation': {'decision': 'ACCEPT', 'flags': []},
+    }
+    corrections = [{
+        'start': 1361.654,
+        'end': 1409.104,
+        'confirmed_span': {'start': 1361.5, 'end': 1408.93},
+    }]
+    monkeypatch.setattr(
+        processing.storage, 'save_combined_ads',
+        lambda *args: pytest.fail('unchanged markers must not be persisted'))
+
+    processing._finalize_user_confirmed_bounds(
+        'feed', 'episode', [marker], [marker], corrections)
+
+    assert marker['end'] == 1406.753
+
+
 def test_build_recut_ad_list_drops_rejected(monkeypatch):
     ads = [
         {'start': 30.0, 'end': 90.0, 'confidence': 0.98, 'sponsor': 'A', 'reason': 'sponsor read for A'},

--- a/tests/unit/test_recut_ad_list.py
+++ b/tests/unit/test_recut_ad_list.py
@@ -235,6 +235,34 @@ def test_final_confirmed_bounds_clamps_carried_span_to_episode(monkeypatch):
     assert marker['end'] == 105.0
 
 
+def test_final_confirmed_bounds_persists_metadata_only_cleanup(monkeypatch):
+    marker = {
+        'start': 101.0,
+        'end': 111.0,
+        'end_extended_by_content': True,
+        'tail_splice_snap': {'event_time': 111.0},
+        'dai_core_spans': [{'start': 100.0, 'end': 112.0}],
+        'validation': {
+            'decision': 'ACCEPT',
+            'user_confirmed': True,
+            'confirmed_span': {'start': 101.0, 'end': 111.0},
+            'flags': [],
+        },
+    }
+    saves = []
+    monkeypatch.setattr(
+        processing.storage, 'save_combined_ads',
+        lambda *args: saves.append(args))
+
+    processing._finalize_user_confirmed_bounds(
+        'feed', 'episode', [marker], [marker], [])
+
+    assert 'end_extended_by_content' not in marker
+    assert 'tail_splice_snap' not in marker
+    assert marker['dai_core_spans'] == [{'start': 101.0, 'end': 111.0}]
+    assert len(saves) == 1
+
+
 def test_final_confirmed_bounds_ignores_collapsed_duration_clamp(monkeypatch):
     marker = {
         'start': 101.0,

--- a/tests/unit/test_tail_splice_snap.py
+++ b/tests/unit/test_tail_splice_snap.py
@@ -1,0 +1,104 @@
+"""Post-review tail recovery through untranscribed sonic logos."""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
+
+from ad_detector.boundaries import snap_extended_ad_tails_to_splice
+
+
+def _event(time, depth=-120.0, event_type='digital_silence'):
+    return {
+        'time': time,
+        'end_time': time + 0.6,
+        'type': event_type,
+        'depth_dbfs': depth,
+        'duration_s': 0.6,
+    }
+
+
+def _fixture():
+    marker = {
+        'start': 2360.85,
+        'end': 2410.9,
+        'confidence': 0.97,
+        'reason': "McDonald's dynamically inserted ad",
+        'end_extended_by_content': True,
+    }
+    segments = [
+        {
+            'start': 2400.0,
+            'end': 2410.9,
+            'text': "McDonald's is proud to be run and owned locally.",
+        },
+        {
+            'start': 2423.29,
+            'end': 2450.27,
+            'text': 'Can you give me your quintessential PlayStation 3 experiences?',
+        },
+    ]
+    return marker, segments
+
+
+def test_content_extended_tail_reaches_forward_splice():
+    marker, segments = _fixture()
+
+    result = snap_extended_ad_tails_to_splice(
+        [marker], segments, [_event(2415.85)], window_s=10.0)
+
+    assert result[0]['end'] == 2415.85
+    assert result[0]['tail_splice_snap'] == {
+        'original_end': 2410.9,
+        'event_time': 2415.85,
+        'event_type': 'digital_silence',
+        'depth_dbfs': -120.0,
+    }
+
+
+def test_plain_content_between_tail_and_splice_blocks_extension():
+    marker, segments = _fixture()
+    segments.insert(1, {
+        'start': 2412.0,
+        'end': 2414.0,
+        'text': 'Back to the show and our next question.',
+    })
+
+    result = snap_extended_ad_tails_to_splice(
+        [marker], segments, [_event(2415.85)], window_s=10.0)
+
+    assert result[0]['end'] == 2410.9
+    assert 'tail_splice_snap' not in result[0]
+
+
+def test_marker_without_content_extension_is_not_eligible():
+    marker, segments = _fixture()
+    marker.pop('end_extended_by_content')
+
+    result = snap_extended_ad_tails_to_splice(
+        [marker], segments, [_event(2415.85)], window_s=10.0)
+
+    assert result[0]['end'] == 2410.9
+
+
+def test_tail_snap_does_not_cross_next_marker():
+    marker, segments = _fixture()
+    next_marker = {'start': 2414.0, 'end': 2420.0, 'reason': 'separate marker'}
+
+    result = snap_extended_ad_tails_to_splice(
+        [marker], segments, [_event(2415.85)], window_s=10.0,
+        coverage_ads=[marker, next_marker])
+
+    assert result[0]['end'] == 2410.9
+
+
+def test_non_silence_and_far_events_are_ignored():
+    marker, segments = _fixture()
+    events = [
+        _event(2415.85, event_type='loudness_step'),
+        _event(2421.0),
+    ]
+
+    result = snap_extended_ad_tails_to_splice(
+        [marker], segments, events, window_s=10.0)
+
+    assert result[0]['end'] == 2410.9

--- a/tests/unit/test_tail_splice_snap.py
+++ b/tests/unit/test_tail_splice_snap.py
@@ -3,12 +3,15 @@ import os
 import sys
 from types import SimpleNamespace
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
 
 from ad_detector.boundaries import (
     _merge_ad_pair,
     snap_extended_ad_tails_to_splice,
 )
+from ad_validator import AdValidator, ValidationResult
 from main_app import processing
 
 
@@ -196,6 +199,61 @@ def test_merge_preserves_content_extension_on_later_fragment():
     _merge_ad_pair(merged, ads[1])
 
     assert merged['end_extended_by_content'] is True
+
+
+@pytest.mark.parametrize('gap', [2.0, 8.0])
+def test_validator_merge_clears_stale_earlier_tail_provenance(gap):
+    earlier = {
+        'start': 100.0,
+        'end': 130.0,
+        'confidence': 0.9,
+        'reason': 'Sponsor ad part one',
+        'end_extended_by_content': True,
+        'tail_splice_snap': {'event_time': 130.0},
+    }
+    later = {
+        'start': 130.0 + gap,
+        'end': 160.0,
+        'confidence': 0.9,
+        'reason': 'Sponsor ad part two',
+    }
+    validator = AdValidator(
+        episode_duration=300.0,
+        segments=[{'start': 0.0, 'end': 1.0, 'text': 'intro'}],
+    )
+
+    merged = validator._merge_close_ads(
+        [earlier, later], ValidationResult(ads=[]))[0]
+
+    assert merged['end'] == 160.0
+    assert 'end_extended_by_content' not in merged
+    assert 'tail_splice_snap' not in merged
+
+
+def test_validator_merge_inherits_later_tail_provenance():
+    earlier = {
+        'start': 100.0,
+        'end': 130.0,
+        'confidence': 0.9,
+        'reason': 'Sponsor ad part one',
+    }
+    later_snap = {'event_time': 160.0, 'original_end': 158.0}
+    later = {
+        'start': 132.0,
+        'end': 160.0,
+        'confidence': 0.9,
+        'reason': 'Sponsor ad part two',
+        'end_extended_by_content': True,
+        'tail_splice_snap': later_snap,
+    }
+    validator = AdValidator(episode_duration=300.0, segments=[])
+
+    merged = validator._merge_close_ads(
+        [earlier, later], ValidationResult(ads=[]))[0]
+
+    assert merged['end_extended_by_content'] is True
+    assert merged['tail_splice_snap'] == later_snap
+    assert merged['tail_splice_snap'] is not later_snap
 
 
 def test_processing_skips_destructive_tail_snap_during_cold_start(monkeypatch):

--- a/tests/unit/test_tail_splice_snap.py
+++ b/tests/unit/test_tail_splice_snap.py
@@ -228,7 +228,10 @@ def test_processing_allows_tail_snap_after_calibration(monkeypatch):
     monkeypatch.setattr(
         processing, 'snap_extended_ad_tails_to_splice',
         lambda *args, **kwargs: [snapped])
-    monkeypatch.setattr(processing.storage, 'save_combined_ads', lambda *args: None)
+    saves = []
+    monkeypatch.setattr(
+        processing.storage, 'save_combined_ads',
+        lambda *args: saves.append(args))
     analysis = SimpleNamespace(splice_evidence={
         'events': [_event(2415.85)],
         'calibration': {'status': 'calibrated'},
@@ -239,3 +242,5 @@ def test_processing_allows_tail_snap_after_calibration(monkeypatch):
 
     assert result[0]['end'] == 2415.85
     assert marker['end'] == 2415.85
+    assert marker['tail_splice_snap']['event_time'] == 2415.85
+    assert len(saves) == 1

--- a/tests/unit/test_tail_splice_snap.py
+++ b/tests/unit/test_tail_splice_snap.py
@@ -162,6 +162,7 @@ def test_merge_clears_stale_content_extension_from_earlier_fragment():
             'confidence': 0.9,
             'reason': 'Sponsor ad part one',
             'end_extended_by_content': True,
+            'tail_splice_snap': {'event_time': 130.0},
         },
         {
             'start': 132.0,
@@ -176,9 +177,11 @@ def test_merge_clears_stale_content_extension_from_earlier_fragment():
 
     assert merged['end'] == 160.0
     assert 'end_extended_by_content' not in merged
+    assert 'tail_splice_snap' not in merged
 
 
 def test_merge_preserves_content_extension_on_later_fragment():
+    later_snap = {'event_time': 160.0, 'original_end': 158.0}
     ads = [
         {
             'start': 100.0,
@@ -192,6 +195,7 @@ def test_merge_preserves_content_extension_on_later_fragment():
             'confidence': 0.9,
             'reason': 'Sponsor ad part two',
             'end_extended_by_content': True,
+            'tail_splice_snap': later_snap,
         },
     ]
 
@@ -199,6 +203,8 @@ def test_merge_preserves_content_extension_on_later_fragment():
     _merge_ad_pair(merged, ads[1])
 
     assert merged['end_extended_by_content'] is True
+    assert merged['tail_splice_snap'] == later_snap
+    assert merged['tail_splice_snap'] is not later_snap
 
 
 @pytest.mark.parametrize('gap', [2.0, 8.0])

--- a/tests/unit/test_tail_splice_snap.py
+++ b/tests/unit/test_tail_splice_snap.py
@@ -109,6 +109,33 @@ def test_overlapping_marker_blocks_tail_extension_immediately():
     assert result[0]['end'] == 2410.9
 
 
+def test_later_marker_does_not_hide_content_before_proposed_splice():
+    marker = {
+        'start': 70.0,
+        'end': 100.0,
+        'confidence': 0.97,
+        'reason': 'Sponsor ad',
+        'end_extended_by_content': True,
+    }
+    next_marker = {
+        'start': 110.0,
+        'end': 130.0,
+        'reason': 'Separate ad marker',
+    }
+    segments = [{
+        'start': 105.0,
+        'end': 115.0,
+        'text': 'Now we return to the game analysis.',
+    }]
+
+    result = snap_extended_ad_tails_to_splice(
+        [marker], segments, [_event(108.0)], window_s=10.0,
+        coverage_ads=[marker, next_marker])
+
+    assert result[0]['end'] == 100.0
+    assert 'tail_splice_snap' not in result[0]
+
+
 def test_non_silence_and_far_events_are_ignored():
     marker, segments = _fixture()
     events = [

--- a/tests/unit/test_tail_splice_snap.py
+++ b/tests/unit/test_tail_splice_snap.py
@@ -4,7 +4,10 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
 
-from ad_detector.boundaries import snap_extended_ad_tails_to_splice
+from ad_detector.boundaries import (
+    _merge_ad_pair,
+    snap_extended_ad_tails_to_splice,
+)
 
 
 def _event(time, depth=-120.0, event_type='digital_silence'):
@@ -117,3 +120,50 @@ def test_non_silence_and_far_events_are_ignored():
         [marker], segments, events, window_s=10.0)
 
     assert result[0]['end'] == 2410.9
+
+
+def test_merge_clears_stale_content_extension_from_earlier_fragment():
+    ads = [
+        {
+            'start': 100.0,
+            'end': 130.0,
+            'confidence': 0.9,
+            'reason': 'Sponsor ad part one',
+            'end_extended_by_content': True,
+        },
+        {
+            'start': 132.0,
+            'end': 160.0,
+            'confidence': 0.9,
+            'reason': 'Sponsor ad part two',
+        },
+    ]
+
+    merged = ads[0].copy()
+    _merge_ad_pair(merged, ads[1])
+
+    assert merged['end'] == 160.0
+    assert 'end_extended_by_content' not in merged
+
+
+def test_merge_preserves_content_extension_on_later_fragment():
+    ads = [
+        {
+            'start': 100.0,
+            'end': 130.0,
+            'confidence': 0.9,
+            'reason': 'Sponsor ad part one',
+        },
+        {
+            'start': 132.0,
+            'end': 160.0,
+            'confidence': 0.9,
+            'reason': 'Sponsor ad part two',
+            'end_extended_by_content': True,
+        },
+    ]
+
+    merged = ads[0].copy()
+    _merge_ad_pair(merged, ads[1])
+
+    assert merged['end_extended_by_content'] is True

--- a/tests/unit/test_tail_splice_snap.py
+++ b/tests/unit/test_tail_splice_snap.py
@@ -91,6 +91,21 @@ def test_tail_snap_does_not_cross_next_marker():
     assert result[0]['end'] == 2410.9
 
 
+def test_overlapping_marker_blocks_tail_extension_immediately():
+    marker, segments = _fixture()
+    overlapping_marker = {
+        'start': 2409.0,
+        'end': 2414.0,
+        'reason': 'separate overlapping marker',
+    }
+
+    result = snap_extended_ad_tails_to_splice(
+        [marker], segments, [_event(2412.0)], window_s=10.0,
+        coverage_ads=[marker, overlapping_marker])
+
+    assert result[0]['end'] == 2410.9
+
+
 def test_non_silence_and_far_events_are_ignored():
     marker, segments = _fixture()
     events = [

--- a/tests/unit/test_tail_splice_snap.py
+++ b/tests/unit/test_tail_splice_snap.py
@@ -1,6 +1,7 @@
 """Post-review tail recovery through untranscribed sonic logos."""
 import os
 import sys
+from types import SimpleNamespace
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
 
@@ -8,6 +9,7 @@ from ad_detector.boundaries import (
     _merge_ad_pair,
     snap_extended_ad_tails_to_splice,
 )
+from main_app import processing
 
 
 def _event(time, depth=-120.0, event_type='digital_silence'):
@@ -194,3 +196,46 @@ def test_merge_preserves_content_extension_on_later_fragment():
     _merge_ad_pair(merged, ads[1])
 
     assert merged['end_extended_by_content'] is True
+
+
+def test_processing_skips_destructive_tail_snap_during_cold_start(monkeypatch):
+    marker, segments = _fixture()
+
+    def unexpected_snap(*args, **kwargs):
+        raise AssertionError('cold-start events must not drive a cut extension')
+
+    monkeypatch.setattr(
+        processing, 'snap_extended_ad_tails_to_splice', unexpected_snap)
+    analysis = SimpleNamespace(splice_evidence={
+        'events': [_event(2415.85)],
+        'calibration': {'status': 'cold_start'},
+    })
+
+    result = processing._snap_completed_cut_tails_to_splice(
+        'feed', 'episode', [marker], [marker], segments, analysis)
+
+    assert result == [marker]
+
+
+def test_processing_allows_tail_snap_after_calibration(monkeypatch):
+    marker, segments = _fixture()
+    snapped = dict(marker, end=2415.85, tail_splice_snap={
+        'original_end': 2410.9,
+        'event_time': 2415.85,
+        'event_type': 'digital_silence',
+        'depth_dbfs': -120.0,
+    })
+    monkeypatch.setattr(
+        processing, 'snap_extended_ad_tails_to_splice',
+        lambda *args, **kwargs: [snapped])
+    monkeypatch.setattr(processing.storage, 'save_combined_ads', lambda *args: None)
+    analysis = SimpleNamespace(splice_evidence={
+        'events': [_event(2415.85)],
+        'calibration': {'status': 'calibrated'},
+    })
+
+    result = processing._snap_completed_cut_tails_to_splice(
+        'feed', 'episode', [marker], [marker], segments, analysis)
+
+    assert result[0]['end'] == 2415.85
+    assert marker['end'] == 2415.85

--- a/tests/unit/test_terminal_splice_snap.py
+++ b/tests/unit/test_terminal_splice_snap.py
@@ -8,6 +8,8 @@ the deeper-but-wrong candidate.
 import os
 import sys
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
 
 from ad_detector.boundaries import (
@@ -130,7 +132,7 @@ def test_transition_pair_silence_recovers_untranscribed_ad_intro():
 
     assert len(events) == 1
     assert events[0]['type'] == 'dai_transition_silence'
-    assert events[0]['time'] == 5393.668
+    assert events[0]['time'] == pytest.approx(5393.668)
 
     marker = {
         'start': 5400.0,
@@ -148,7 +150,7 @@ def test_transition_pair_silence_recovers_untranscribed_ad_intro():
     out = snap_terminal_ad_to_splice(
         [marker], segments, events, 5485.17, _WINDOW)
 
-    assert out[0]['start'] == 5393.668
+    assert out[0]['start'] == pytest.approx(5393.668)
     assert out[0]['terminal_snap']['event_type'] == (
         'dai_transition_silence')
 
@@ -191,3 +193,28 @@ def test_transition_pair_silence_measures_null_persisted_duration():
 
     assert len(events) == 1
     assert events[0]['duration_s'] == 5394.024 - 5393.312
+
+
+def test_transition_pair_silence_skips_malformed_analysis_values():
+    signals = [
+        {'start': 5395.0, 'signal_type': 'dai_transition_pair',
+         'confidence': '0.95'},
+        {'start': 5395.0, 'signal_type': 'dai_transition_pair',
+         'confidence': float('inf')},
+        {'start': float('nan'), 'signal_type': 'dai_transition_pair',
+         'confidence': 0.95},
+        {'start': 5395.0, 'signal_type': 'dai_transition_pair',
+         'confidence': 0.95},
+    ]
+    silence = [
+        None,
+        {'start': '5393.312', 'end': 5394.024},
+        {'start': 5393.312, 'end': float('inf')},
+        {'start': 5393.312, 'end': 5394.024, 'duration': float('nan')},
+    ]
+
+    events = transition_pair_silence_events(
+        signals, silence, max_distance_s=2.0, min_silence_s=0.3)
+
+    assert len(events) == 1
+    assert events[0]['time'] == pytest.approx(5393.668)

--- a/tests/unit/test_terminal_splice_snap.py
+++ b/tests/unit/test_terminal_splice_snap.py
@@ -10,7 +10,10 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
 
-from ad_detector.boundaries import snap_terminal_ad_to_splice
+from ad_detector.boundaries import (
+    snap_terminal_ad_to_splice,
+    transition_pair_silence_events,
+)
 
 _EOF = 4200.0
 _WINDOW = 30.0
@@ -109,3 +112,63 @@ def test_only_silence_event_types_considered():
                   'flatness_step': None}]
     out = snap_terminal_ad_to_splice([marker], segments, step_only, _EOF, _WINDOW)
     assert out[0]['start'] == 4172.0
+
+
+def test_transition_pair_silence_recovers_untranscribed_ad_intro():
+    signals = [{
+        'start': 5395.0,
+        'end': 5480.0,
+        'signal_type': 'dai_transition_pair',
+        'confidence': 0.95,
+    }]
+    silence_spans = [
+        {'start': 5391.394, 'end': 5391.869, 'duration': 0.475},
+        {'start': 5393.312, 'end': 5394.024, 'duration': 0.712},
+    ]
+    events = transition_pair_silence_events(
+        signals, silence_spans, max_distance_s=2.0, min_silence_s=0.3)
+
+    assert len(events) == 1
+    assert events[0]['type'] == 'dai_transition_silence'
+    assert events[0]['time'] == 5393.668
+
+    marker = {
+        'start': 5400.0,
+        'end': 5485.17,
+        'confidence': 0.95,
+        'reason': 'Norwegian post-roll ad block',
+    }
+    segments = [
+        {'start': 5373.03, 'end': 5388.61,
+         'text': 'thanks for watching and supporting Digital Foundry'},
+        {'start': 5400.88, 'end': 5421.48,
+         'text': 'Norwegian Derby at Ovrevold, tickets available now'},
+    ]
+
+    out = snap_terminal_ad_to_splice(
+        [marker], segments, events, 5485.17, _WINDOW)
+
+    assert out[0]['start'] == 5393.668
+    assert out[0]['terminal_snap']['event_type'] == (
+        'dai_transition_silence')
+
+
+def test_transition_pair_silence_requires_strong_nearby_pair():
+    silence = [{'start': 5393.312, 'end': 5394.024, 'duration': 0.712}]
+    weak = [{
+        'start': 5395.0,
+        'end': 5480.0,
+        'signal_type': 'dai_transition_pair',
+        'confidence': 0.8,
+    }]
+    far = [{
+        'start': 5400.0,
+        'end': 5480.0,
+        'signal_type': 'dai_transition_pair',
+        'confidence': 0.95,
+    }]
+
+    assert transition_pair_silence_events(
+        weak, silence, max_distance_s=2.0, min_silence_s=0.3) == []
+    assert transition_pair_silence_events(
+        far, silence, max_distance_s=2.0, min_silence_s=0.3) == []

--- a/tests/unit/test_terminal_splice_snap.py
+++ b/tests/unit/test_terminal_splice_snap.py
@@ -172,3 +172,22 @@ def test_transition_pair_silence_requires_strong_nearby_pair():
         weak, silence, max_distance_s=2.0, min_silence_s=0.3) == []
     assert transition_pair_silence_events(
         far, silence, max_distance_s=2.0, min_silence_s=0.3) == []
+
+
+def test_transition_pair_silence_measures_null_persisted_duration():
+    signals = [{
+        'start': 5395.0,
+        'signal_type': 'dai_transition_pair',
+        'confidence': 0.95,
+    }]
+    silence = [{
+        'start': 5393.312,
+        'end': 5394.024,
+        'duration': None,
+    }]
+
+    events = transition_pair_silence_events(
+        signals, silence, max_distance_s=2.0, min_silence_s=0.3)
+
+    assert len(events) == 1
+    assert events[0]['duration_s'] == 5394.024 - 5393.312


### PR DESCRIPTION
Ports kristofferR/MinusPod agent/dai-review-safeguards (34 commits, original authorship preserved) plus the three unique commits from agent/dai-core-coverage (correction precedence, expanded manual bounds, terminal splice validation), rebased onto main after #679.

## Theme
Human review decisions (confirmed spans, trims, false-positive rejections) must survive automatic boundary mutation, and measured cross-fetch DAI evidence must survive marker merges and splits.

## What it does
- dai_core_spans provenance on dai_differential detections, with new utils/markers.py helpers: merge_dai_core_spans, clip_dai_core_spans, dai_core_bounds, invalidate_tail_provenance. Evidence is merged on marker merges, clipped on splits/clamps, and validated defensively (bool/NaN/shape guards).
- Exact confirmed-span clamping replaces the inward-only trim; _matching_confirmed returns the newest overlapping correction; user_confirmed/confirmed_span live in the validator-owned validation dict so detectors cannot forge them.
- Fragment dedup for one approved span re-detected as multiple DAI fragments: earliest eligible fragment claims the correction, later ones are rejected with an INFO audit flag rather than silently dropped.
- Tail handling: snap_extended_ad_tails_to_splice removes untranscribed DAI sonic logos after recovered spoken CTAs; transition_pair_silence_events derives precise terminal-boundary evidence from coarse DAI pairs; terminal snaps are blocked across rejected audio and other markers; tail provenance is invalidated whenever a stage picks a new end.
- Reviewer contradiction safeguards (ad_reviewer.py): plural/elliptical negation scoping, expand-only protection centralized, reviewed marker boundaries protected through merges.
- _finalize_user_confirmed_bounds re-asserts the approved span as the last authority before audio cutting.
- Correction precedence in api/db: newest correction wins over an older trimmed confirm (src/api/patterns.py, src/database/patterns.py).

## Port notes
- Rebased over the pass-2 actions port (#679); the boundary-split paths now both mark trusted fragments (pass-2) and clip DAI evidence (this port); the validator merge combines the either-side-held rule from #677 with this campaign's FP-correction and pre-restore-confirmation merge blocks; _adopt_later_marker_end carries tail provenance inside the pass-2-aware merge bookkeeping.
- The campaign's two dedup designs (drop-based from review-safeguards, reject-with-audit-flag from the later coverage commit) were reconciled: the final reject-based design is kept, with the drop loop's eligibility rules (confirmed-span overlap; restored bounds clear of false positives) folded into candidate selection. One drop-semantics test updated to the reject-and-keep behavior.
- _apply_pass2_heuristic_rolls, _covered_by_cuts, and _drop_uncovered_pass2_ads duplications were resolved to main's 2.89.4 verification_reconciliation module locations.
- Legacy typing modernized throughout.

## Test plan
- tests/unit: 5245 passed locally (includes ~1000 new test lines: test_tail_splice_snap.py, test_ad_reviewer_contradiction.py, expanded test_ad_validator.py / test_terminal_splice_snap.py / test_ad_reviewer.py)
- ruff clean