### PR TITLE
Unwrap changelog hard-wrapping in release note output

### DIFF
--- a/scripts/changelog_section.py
+++ b/scripts/changelog_section.py
@@ -15,6 +15,36 @@ def _version_key(version: str) -> tuple:
     return tuple(int(part) for part in version.split("."))
 
 
+def unwrap_lines(text: str) -> str:
+    """Join hard-wrapped continuation lines for GitHub release bodies.
+
+    Release bodies render every single newline as a hard line break, so
+    the changelog's 72-column wrapping displays as ragged short lines.
+    Two-space continuation lines are folded into the line above; headers,
+    blank lines, list items, and fenced code blocks are left alone.
+    """
+    out: list[str] = []
+    fence = False
+    for line in text.splitlines():
+        if line.lstrip().startswith("```"):
+            fence = not fence
+            out.append(line)
+            continue
+        is_cont = (
+            not fence
+            and re.match(r"^  \S", line)
+            and not re.match(r"^\s*[-*] ", line)
+            and out and out[-1].strip()
+            and not out[-1].lstrip().startswith("#")
+            and not out[-1].lstrip().startswith("```")
+        )
+        if is_cont:
+            out[-1] += " " + line.strip()
+        else:
+            out.append(line)
+    return "\n".join(out) + "\n"
+
+
 def extract_section(text: str, version: str) -> str:
     pattern = re.compile(
         r"^## \[" + re.escape(version) + r"\][^\n]*\n(.*?)(?=^## \[|\Z)",
@@ -59,6 +89,7 @@ def main() -> int:
             section = extract_rollup(text, args.version, args.rollup_since)
         else:
             section = extract_section(text, args.version)
+        section = unwrap_lines(section)
     except KeyError:
         print(f"version {args.version} not found in {args.changelog}",
               file=sys.stderr)

--- a/tests/unit/test_changelog_section.py
+++ b/tests/unit/test_changelog_section.py
@@ -81,3 +81,43 @@ def test_rollup_target_missing_raises_keyerror():
     from changelog_section import extract_rollup
     with pytest.raises(KeyError):
         extract_rollup(ROLLUP_SAMPLE, "9.9.9", "2.75.0")
+
+
+class TestUnwrapLines:
+    """Release bodies render single newlines as hard breaks, so the
+    changelog's 72-column wrapping must be unwrapped on output."""
+
+    def test_joins_continuation_lines_into_the_bullet(self):
+        from changelog_section import unwrap_lines
+        wrapped = (
+            "### Fixed\n\n"
+            "- A long entry that the changelog wraps onto\n"
+            "  a second line and then onto\n"
+            "  a third line.\n"
+        )
+        assert unwrap_lines(wrapped) == (
+            "### Fixed\n\n"
+            "- A long entry that the changelog wraps onto"
+            " a second line and then onto a third line.\n"
+        )
+
+    def test_headers_blanks_and_new_bullets_stay_separate(self):
+        from changelog_section import unwrap_lines
+        text = "### Added\n\n- First entry.\n- Second entry.\n"
+        assert unwrap_lines(text) == text
+
+    def test_fenced_code_blocks_are_untouched(self):
+        from changelog_section import unwrap_lines
+        text = (
+            "- Entry with a snippet:\n"
+            "```\n"
+            "  indented code line\n"
+            "  another code line\n"
+            "```\n"
+        )
+        assert unwrap_lines(text) == text
+
+    def test_indented_sub_bullets_keep_their_own_lines(self):
+        from changelog_section import unwrap_lines
+        text = "- Parent entry.\n  - Sub item one.\n  - Sub item two.\n"
+        assert unwrap_lines(text) == text


### PR DESCRIPTION
GitHub release bodies render every single newline as a hard line break, unlike file markdown, so the changelog's 72-column wrapping displayed as ragged left-aligned short lines in every auto-published pre-release. All existing release bodies have been fixed in place; this makes the fix permanent for future releases.

changelog_section.py, which publish_release.sh pipes into the pre-release body, now joins two-space continuation lines on output. Headers, blank lines, list items, sub-bullets, and fenced code blocks keep their own lines. The library functions are unchanged; only the CLI output path unwraps, so tests that assert on extracted sections are unaffected.

## Test plan
- [x] test_changelog_section.py: 10 passed (4 new unwrap cases: joining, structure preservation, code fences, sub-bullets)
- [x] ruff clean
- [x] Verified against the live CHANGELOG: output renders as one flowing line per bullet