### PR TITLE
Seed-sponsor toggles, text recurrence hints, segment-ID addressing (experimental)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,6 +29,18 @@ Customize ad detection in Settings:
 
 Each customizable prompt (first pass system, verification, chapter, and the Ad Reviewer's review and resurrect prompts under Experiments) has its own **Reset** button next to its label, in addition to the section-wide "Reset Prompts to Default" / "Reset Reviewer Prompts to Default" buttons. The per-prompt button is a two-click confirm; it stays visible but disabled (with a tooltip) while that prompt is already at its default, so a customized prompt is easy to spot and revert without resetting every prompt at once.
 
+### Seed sponsors
+
+Four toggles decide which LLM passes are handed the running list of known sponsors: Detection, Verification, Reviewer, and Resurrect. Turning one off does not turn off that pass; it just stops seeding its prompt with prior sponsors, so the pass judges each candidate on its own. Turning off Reviewer, for example, makes that pass an independent second opinion rather than a check that already expects the sponsor it is reviewing.
+
+All four default on to match prior behavior. API: `PUT /api/v1/settings/ad-detection` with `seedSponsorsDetection`, `seedSponsorsVerification`, `seedSponsorsReviewer`, `seedSponsorsResurrect` (booleans).
+
+### Text recurrence hints
+
+Settings > AI & Processing has a Text recurrence hints toggle. When on, MinusPod compares the current transcript against a show's last two or more processed episodes and flags spans of wording that repeat near-verbatim, such as intros, credits, and other boilerplate. Those spans go to pass 1 detection as a hint; nothing is ever cut on text recurrence alone.
+
+Off by default. API: `PUT /api/v1/settings/ad-detection` with `textRecurrenceHints` (boolean).
+
 ### Detection Tuning
 
 Settings > Ad Detection has two grouped subsections for tuning how aggressively the verification pass and the cross-fetch differential stage act on what they find. All six controls are database settings; API: `PUT /api/v1/settings/ad-detection` (see `openapi.yaml`).
@@ -201,6 +213,12 @@ API: `jitBlockedUserAgents` (array of strings) on `PUT /api/v1/settings/ad-detec
 ## Experiments
 
 The Experiments section in Settings holds opt-in features that are still being evaluated. Everything here is disabled by default. Turning a feature on does not change behavior on existing processed episodes; it applies only to subsequent processing runs.
+
+### Ad Addressing Mode
+
+Settings > Experiments has an Ad addressing mode select, marked experimental. Timestamps, the default, asks the model for a start and end time for each ad. Segment IDs asks the model to name numbered transcript lines instead; MinusPod then maps those line numbers back to the exact Whisper times, so the model never has to guess a timestamp. Segment IDs is still being benchmarked against Timestamps, and the results decide whether the default ever changes.
+
+Default `timestamps`. API: `PUT /api/v1/settings/ad-detection` with `adAddressingMode` (`timestamps` or `segment_ids`).
 
 ### Ad Reviewer
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -8,6 +8,8 @@ Every term the app uses, in plain words, with a link to the part of the docs tha
 
 **Ad Reviewer** - An optional second LLM that double-checks each planned cut before it happens and can confirm, adjust, reject, or resurrect a detection. Off by default. [Configuration > Ad Reviewer](configuration.md#ad-reviewer)
 
+**Addressing mode** - An experimental detector setting. In Segment IDs mode, the LLM names numbered transcript lines instead of inventing start and end timestamps, and MinusPod maps those line numbers back to exact Whisper times. Timestamps stays the default while benchmark results decide whether that changes. [Configuration > Ad Addressing Mode](configuration.md#ad-addressing-mode)
+
 **Audio analysis** - A pre-detection pass over the audio itself (volume shifts, transitions, silence) whose signals feed the detector and validator. [How It Works > Audio Analysis](how-it-works.md#audio-analysis)
 
 **Audio cue** - A short, repeated sound a show plays around its ad breaks (a sting, a jingle). MinusPod can learn one as a template and use matches as hard evidence for ad boundaries. [Audio Cue Detection](audio-cues.md)
@@ -110,6 +112,8 @@ Every term the app uses, in plain words, with a link to the part of the docs tha
 
 **Second scan** - See Verification pass.
 
+**Seed sponsors** - Four toggles, one per LLM pass (detection, verification, reviewer, resurrect), that control whether that pass is handed the known-sponsor list. All on by default; turning one off lets that pass judge each candidate without a prior nudge from sponsors seen before. [Configuration > Seed sponsors](configuration.md#seed-sponsors)
+
 **Segment category** - What kind of content a detected marker spans: sponsor, cross-promo, self-promo, interaction, intro, outro, or recap. Each category resolves to an action (remove, beep, or keep), set per feed or globally on the **Segment actions** card and defaulting to remove until changed. Intro, outro, and recap are only detected on feeds where show-segments detection resolves to on (a per-feed Inherit/On/Off choice, falling back to the global default); the other four categories are always detected. A defined pattern's match always cuts regardless of the resolved action. [How It Works > Segment Categories](how-it-works.md#segment-categories)
   - Sponsor - Paid ads, including dynamically inserted ones
   - Cross-promo - Promos for other shows and the network
@@ -128,6 +132,8 @@ Every term the app uses, in plain words, with a link to the part of the docs tha
 ## T
 
 **Text pattern** - A learned chunk of ad transcript matched against new episodes by similarity. Deterministic: if the same ad copy appears, it hits. [How It Works > Pattern Learning](how-it-works.md#pattern-learning)
+
+**Text recurrence hint** - An optional signal that flags transcript spans repeating near-verbatim across a show's last two or more episodes (intros, credits, boilerplate) and passes them to pass 1 detection as a hint. Off by default, and never enough by itself to cut anything. [Configuration > Text recurrence hints](configuration.md#text-recurrence-hints)
 
 **Title blacklist** - A per-feed list of case-insensitive glob patterns (e.g. `Bonus Episode *`) that skip processing for matching episode titles. A per-feed choice serves a skipped episode unmodified or hides it from the feed. Manual reprocess overrides it. [Configuration > Title blacklist](configuration.md#title-blacklist)
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -8,7 +8,7 @@ Every term the app uses, in plain words, with a link to the part of the docs tha
 
 **Ad Reviewer** - An optional second LLM that double-checks each planned cut before it happens and can confirm, adjust, reject, or resurrect a detection. Off by default. [Configuration > Ad Reviewer](configuration.md#ad-reviewer)
 
-**Addressing mode** - An experimental detector setting. In Segment IDs mode, the LLM names numbered transcript lines instead of inventing start and end timestamps, and MinusPod maps those line numbers back to exact Whisper times. Timestamps stays the default while benchmark results decide whether that changes. [Configuration > Ad Addressing Mode](configuration.md#ad-addressing-mode)
+**Addressing mode** - An experimental detector setting where the LLM names numbered transcript lines instead of inventing start and end timestamps, and MinusPod maps those line numbers back to exact Whisper times. Timestamps stays the default while benchmark results decide whether that changes. [Configuration > Ad Addressing Mode](configuration.md#ad-addressing-mode)
 
 **Audio analysis** - A pre-detection pass over the audio itself (volume shifts, transitions, silence) whose signals feed the detector and validator. [How It Works > Audio Analysis](how-it-works.md#audio-analysis)
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -451,6 +451,7 @@ export interface Settings {
   segmentCategoryActions: { value: Record<SegmentCategory, SegmentAction>; isDefault: boolean };
   onlyExposeProcessedDefault: SettingValueBoolean;
   detectShowSegments: SettingValueBoolean;
+  textRecurrenceHints: SettingValueBoolean;
   processNewEpisodesFirst: SettingValueBoolean;
   seedSponsorsDetection: SettingValueBoolean;
   seedSponsorsVerification: SettingValueBoolean;
@@ -551,6 +552,7 @@ export interface Settings {
     segmentCategoryActions: Record<SegmentCategory, SegmentAction>;
     onlyExposeProcessedDefault: boolean;
     detectShowSegments: boolean;
+    textRecurrenceHints: boolean;
     processNewEpisodesFirst: boolean;
     seedSponsorsDetection: boolean;
     seedSponsorsVerification: boolean;
@@ -649,6 +651,7 @@ export interface UpdateSettingsPayload {
   segmentCategoryActions?: Partial<Record<SegmentCategory, SegmentAction>>;
   onlyExposeProcessedDefault?: boolean;
   detectShowSegments?: boolean;
+  textRecurrenceHints?: boolean;
   processNewEpisodesFirst?: boolean;
   seedSponsorsDetection?: boolean;
   seedSponsorsVerification?: boolean;

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -452,6 +452,10 @@ export interface Settings {
   onlyExposeProcessedDefault: SettingValueBoolean;
   detectShowSegments: SettingValueBoolean;
   processNewEpisodesFirst: SettingValueBoolean;
+  seedSponsorsDetection: SettingValueBoolean;
+  seedSponsorsVerification: SettingValueBoolean;
+  seedSponsorsReviewer: SettingValueBoolean;
+  seedSponsorsResurrect: SettingValueBoolean;
   artworkWatermarkEnabled: SettingValueBoolean;
   artworkBadgePosition: SettingValue;
   lowAdYieldAction: SettingValue;
@@ -548,6 +552,10 @@ export interface Settings {
     onlyExposeProcessedDefault: boolean;
     detectShowSegments: boolean;
     processNewEpisodesFirst: boolean;
+    seedSponsorsDetection: boolean;
+    seedSponsorsVerification: boolean;
+    seedSponsorsReviewer: boolean;
+    seedSponsorsResurrect: boolean;
     artworkWatermarkEnabled: boolean;
     artworkBadgePosition: string;
     lowAdYieldAction: string;
@@ -642,6 +650,10 @@ export interface UpdateSettingsPayload {
   onlyExposeProcessedDefault?: boolean;
   detectShowSegments?: boolean;
   processNewEpisodesFirst?: boolean;
+  seedSponsorsDetection?: boolean;
+  seedSponsorsVerification?: boolean;
+  seedSponsorsReviewer?: boolean;
+  seedSponsorsResurrect?: boolean;
   artworkWatermarkEnabled?: boolean;
   artworkBadgePosition?: string;
   lowAdYieldAction?: LowAdYieldAction;

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -452,6 +452,7 @@ export interface Settings {
   onlyExposeProcessedDefault: SettingValueBoolean;
   detectShowSegments: SettingValueBoolean;
   textRecurrenceHints: SettingValueBoolean;
+  adAddressingMode: SettingValue;
   processNewEpisodesFirst: SettingValueBoolean;
   seedSponsorsDetection: SettingValueBoolean;
   seedSponsorsVerification: SettingValueBoolean;
@@ -553,6 +554,7 @@ export interface Settings {
     onlyExposeProcessedDefault: boolean;
     detectShowSegments: boolean;
     textRecurrenceHints: boolean;
+    adAddressingMode: string;
     processNewEpisodesFirst: boolean;
     seedSponsorsDetection: boolean;
     seedSponsorsVerification: boolean;
@@ -652,6 +654,7 @@ export interface UpdateSettingsPayload {
   onlyExposeProcessedDefault?: boolean;
   detectShowSegments?: boolean;
   textRecurrenceHints?: boolean;
+  adAddressingMode?: string;
   processNewEpisodesFirst?: boolean;
   seedSponsorsDetection?: boolean;
   seedSponsorsVerification?: boolean;

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1077,6 +1077,8 @@ function Settings() {
         resurrectPromptIsDefault={settings?.resurrectPrompt.isDefault}
         onResetReviewPrompt={() => resetPromptMutation.mutate('review')}
         onResetResurrectPrompt={() => resetPromptMutation.mutate('resurrect')}
+        addressingMode={settings?.adAddressingMode?.value ?? settings?.defaults?.adAddressingMode ?? 'timestamps'}
+        onAddressingModeChange={(v) => tunableMutation.mutate({ adAddressingMode: v })}
       />
 
       <AudioCueDetectionSection audioCue={audioCue} onChange={setAudioCue} />

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -39,6 +39,7 @@ import AudioSection from './settings/AudioSection';
 import CoverArtSection from './settings/CoverArtSection';
 import { refreshAllArtwork } from '../api/feeds';
 import AdDetectionSection from './settings/AdDetectionSection';
+import SeedSponsorsSection from './settings/SeedSponsorsSection';
 import GlobalDefaultsSection from './settings/GlobalDefaultsSection';
 import SegmentActionsSection from './settings/SegmentActionsSection';
 import Podcasting20Section from './settings/Podcasting20Section';
@@ -1027,6 +1028,14 @@ function Settings() {
         onDifferentialMeasuredCorrMaxChange={setDifferentialMeasuredCorrMax}
         differentialHoldMinSeconds={differentialHoldMinSeconds}
         onDifferentialHoldMinSecondsChange={setDifferentialHoldMinSeconds}
+      />
+
+      <SeedSponsorsSection
+        detection={settings?.seedSponsorsDetection?.value ?? settings?.defaults?.seedSponsorsDetection ?? true}
+        verification={settings?.seedSponsorsVerification?.value ?? settings?.defaults?.seedSponsorsVerification ?? true}
+        reviewer={settings?.seedSponsorsReviewer?.value ?? settings?.defaults?.seedSponsorsReviewer ?? true}
+        resurrect={settings?.seedSponsorsResurrect?.value ?? settings?.defaults?.seedSponsorsResurrect ?? true}
+        onChange={(key, v) => tunableMutation.mutate({ [key]: v })}
       />
 
       <PromptsSection

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -904,6 +904,8 @@ function Settings() {
         onEpisodeLogRetentionDaysChange={setEpisodeLogRetentionDays}
         episodeLogLevel={episodeLogLevel}
         onEpisodeLogLevelChange={setEpisodeLogLevel}
+        textRecurrenceHints={settings?.textRecurrenceHints?.value ?? settings?.defaults?.textRecurrenceHints ?? false}
+        onTextRecurrenceHintsChange={(v) => tunableMutation.mutate({ textRecurrenceHints: v })}
       />
 
       <SegmentActionsSection

--- a/frontend/src/pages/settings/ExperimentsSection.test.tsx
+++ b/frontend/src/pages/settings/ExperimentsSection.test.tsx
@@ -35,6 +35,8 @@ describe('ExperimentsSection: per-prompt reset', () => {
         resurrectPromptIsDefault
         onResetReviewPrompt={vi.fn()}
         onResetResurrectPrompt={vi.fn()}
+        addressingMode="timestamps"
+        onAddressingModeChange={vi.fn()}
       />,
     );
     const resetButtons = screen.getAllByRole('button', { name: 'Reset' });
@@ -57,6 +59,8 @@ describe('ExperimentsSection: per-prompt reset', () => {
         resurrectPromptIsDefault
         onResetReviewPrompt={onResetReviewPrompt}
         onResetResurrectPrompt={onResetResurrectPrompt}
+        addressingMode="timestamps"
+        onAddressingModeChange={vi.fn()}
       />,
     );
     const [resetBtn] = screen.getAllByRole('button', { name: 'Reset' });
@@ -80,6 +84,8 @@ describe('ExperimentsSection: per-prompt reset', () => {
         resurrectPromptIsDefault={false}
         onResetReviewPrompt={onResetReviewPrompt}
         onResetResurrectPrompt={onResetResurrectPrompt}
+        addressingMode="timestamps"
+        onAddressingModeChange={vi.fn()}
       />,
     );
     const resetBtn = screen.getAllByRole('button', { name: 'Reset' })[1];
@@ -87,5 +93,42 @@ describe('ExperimentsSection: per-prompt reset', () => {
     await user.click(screen.getByRole('button', { name: 'Click again to confirm' }));
     expect(onResetResurrectPrompt).toHaveBeenCalledTimes(1);
     expect(onResetReviewPrompt).not.toHaveBeenCalled();
+  });
+});
+
+describe('ExperimentsSection: addressing mode', () => {
+  it('renders the addressing mode select with the current value', () => {
+    render(
+      <ExperimentsSection
+        reviewer={baseReviewer()}
+        onChange={vi.fn()}
+        onResetPrompts={vi.fn()}
+        resetIsPending={false}
+        addressingMode="segment_ids"
+        onAddressingModeChange={vi.fn()}
+      />,
+    );
+    const select = screen.getByLabelText('Ad addressing mode') as HTMLSelectElement;
+    expect(select.value).toBe('segment_ids');
+    expect(screen.getByRole('option', { name: 'Timestamps (default)' })).toBeDefined();
+    expect(screen.getByRole('option', { name: 'Segment IDs' })).toBeDefined();
+  });
+
+  it('fires onAddressingModeChange when the select changes', async () => {
+    const onAddressingModeChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ExperimentsSection
+        reviewer={baseReviewer()}
+        onChange={vi.fn()}
+        onResetPrompts={vi.fn()}
+        resetIsPending={false}
+        addressingMode="timestamps"
+        onAddressingModeChange={onAddressingModeChange}
+      />,
+    );
+    const select = screen.getByLabelText('Ad addressing mode');
+    await user.selectOptions(select, 'segment_ids');
+    expect(onAddressingModeChange).toHaveBeenCalledWith('segment_ids');
   });
 });

--- a/frontend/src/pages/settings/ExperimentsSection.tsx
+++ b/frontend/src/pages/settings/ExperimentsSection.tsx
@@ -4,6 +4,7 @@ import ToggleSwitch from '../../components/ToggleSwitch';
 import PromptField from './PromptField';
 import NumberInput from '../../components/NumberInput';
 import { selectBase } from '../../components/fieldStyles';
+import ExperimentalBadge from '../../components/ExperimentalBadge';
 
 export interface ReviewerState {
   enabled: boolean;
@@ -30,6 +31,8 @@ interface ExperimentsSectionProps {
   resurrectPromptIsDefault?: boolean;
   onResetReviewPrompt?: () => void;
   onResetResurrectPrompt?: () => void;
+  addressingMode: string;
+  onAddressingModeChange: (v: string) => void;
 }
 
 function ExperimentsSection({
@@ -42,6 +45,8 @@ function ExperimentsSection({
   resurrectPromptIsDefault,
   onResetReviewPrompt,
   onResetResurrectPrompt,
+  addressingMode,
+  onAddressingModeChange,
 }: ExperimentsSectionProps) {
   const update = <K extends keyof ReviewerState>(key: K, value: ReviewerState[K]) =>
     onChange({ ...reviewer, [key]: value });
@@ -50,10 +55,37 @@ function ExperimentsSection({
   // Save (the backend rejects them). maxShift stays out: it has weaker semantics
   // and leans on the native min/max only.
   return (
-    <CollapsibleSection
-      title="Ad Reviewer"
-      subtitle="Reviews each detected ad and decides confirm, adjust, or reject before the cut. Off by default."
-    >
+    <>
+      <CollapsibleSection
+        title="Ad Addressing Mode"
+        subtitle="Experimental: how the detector points at ads in the transcript."
+      >
+        <div>
+          <div className="flex items-center gap-3 mb-2">
+            <label htmlFor="adAddressingMode" className="text-sm font-medium text-foreground">
+              Ad addressing mode
+            </label>
+            <ExperimentalBadge title="Experimental: segment IDs are still being benchmarked against timestamps" />
+          </div>
+          <select
+            id="adAddressingMode"
+            value={addressingMode}
+            onChange={(e) => onAddressingModeChange(e.target.value)}
+            className={`w-full ${selectBase}`}
+          >
+            <option value="timestamps">Timestamps (default)</option>
+            <option value="segment_ids">Segment IDs</option>
+          </select>
+          <p className="mt-2 text-sm text-muted-foreground">
+            How the detector points at ads in the transcript. Timestamps asks the model for start and end times; segment IDs asks it to name numbered transcript lines instead, which removes made-up timestamps but is still being evaluated. Benchmark results decide the future default.
+          </p>
+        </div>
+      </CollapsibleSection>
+
+      <CollapsibleSection
+        title="Ad Reviewer"
+        subtitle="Reviews each detected ad and decides confirm, adjust, or reject before the cut. Off by default."
+      >
       <div className="space-y-6">
         {/* Reviewer behavior */}
         <div className="space-y-6">
@@ -241,7 +273,8 @@ function ExperimentsSection({
           />
         </div>
       </div>
-    </CollapsibleSection>
+      </CollapsibleSection>
+    </>
   );
 }
 

--- a/frontend/src/pages/settings/GlobalDefaultsSection.test.tsx
+++ b/frontend/src/pages/settings/GlobalDefaultsSection.test.tsx
@@ -36,6 +36,8 @@ function Harness({ onCommit }: { onCommit: (minutes: number) => void }) {
         onEpisodeLogRetentionDaysChange={() => {}}
         episodeLogLevel="debug"
         onEpisodeLogLevelChange={() => {}}
+        textRecurrenceHints={false}
+        onTextRecurrenceHintsChange={() => {}}
       />
       <button onClick={() => onCommit(minutes)}>Commit</button>
     </>
@@ -69,6 +71,8 @@ function PodpingHarness({ onCommit }: { onCommit: (payload: PodpingState) => voi
         onEpisodeLogRetentionDaysChange={() => {}}
         episodeLogLevel="debug"
         onEpisodeLogLevelChange={() => {}}
+        textRecurrenceHints={false}
+        onTextRecurrenceHintsChange={() => {}}
       />
       <button onClick={() => onCommit({ podpingEnabled })}>Commit</button>
     </>
@@ -102,6 +106,8 @@ function ProcessNewFirstHarness({ onCommit }: { onCommit: (payload: ProcessNewFi
         onEpisodeLogRetentionDaysChange={() => {}}
         episodeLogLevel="debug"
         onEpisodeLogLevelChange={() => {}}
+        textRecurrenceHints={false}
+        onTextRecurrenceHintsChange={() => {}}
       />
       <button onClick={() => onCommit({ processNewEpisodesFirst })}>Commit</button>
     </>
@@ -250,6 +256,8 @@ function LowAdYieldHarness({ onCommit }: { onCommit: (payload: LowAdYieldState) 
         onEpisodeLogRetentionDaysChange={() => {}}
         episodeLogLevel="debug"
         onEpisodeLogLevelChange={() => {}}
+        textRecurrenceHints={false}
+        onTextRecurrenceHintsChange={() => {}}
       />
       <button onClick={() => onCommit({ lowAdYieldAction })}>Commit</button>
     </>
@@ -311,6 +319,8 @@ function EpisodeLogHarness({ onCommit }: { onCommit: (payload: EpisodeLogState) 
         onEpisodeLogRetentionDaysChange={setRetentionDays}
         episodeLogLevel={level}
         onEpisodeLogLevelChange={setLevel}
+        textRecurrenceHints={false}
+        onTextRecurrenceHintsChange={() => {}}
       />
       <button onClick={() => onCommit({ retentionDays, level })}>Commit</button>
     </>
@@ -345,5 +355,59 @@ describe('GlobalDefaultsSection: episode run logs', () => {
     await user.selectOptions(screen.getByLabelText('Detail kept in a run log'), 'info');
     await user.click(screen.getByRole('button', { name: 'Commit' }));
     expect(committed!.level).toBe('info');
+  });
+});
+
+interface TextRecurrenceHintsState {
+  textRecurrenceHints: boolean;
+}
+
+function TextRecurrenceHintsHarness({ onCommit }: { onCommit: (payload: TextRecurrenceHintsState) => void }) {
+  const [textRecurrenceHints, setTextRecurrenceHints] = useState(false);
+  return (
+    <>
+      <GlobalDefaultsSection
+        autoProcessEnabled={false}
+        onAutoProcessEnabledChange={() => {}}
+        rssRefreshIntervalMinutes={15}
+        onRssRefreshIntervalMinutesChange={() => {}}
+        podpingEnabled={false}
+        onPodpingEnabledChange={() => {}}
+        maxFeedEpisodes={10}
+        onMaxFeedEpisodesChange={() => {}}
+        onlyExposeProcessedDefault={false}
+        onOnlyExposeProcessedDefaultChange={() => {}}
+        processNewEpisodesFirst
+        onProcessNewEpisodesFirstChange={() => {}}
+        lowAdYieldAction="nothing"
+        onLowAdYieldActionChange={() => {}}
+        episodeLogRetentionDays={30}
+        onEpisodeLogRetentionDaysChange={() => {}}
+        episodeLogLevel="debug"
+        onEpisodeLogLevelChange={() => {}}
+        textRecurrenceHints={textRecurrenceHints}
+        onTextRecurrenceHintsChange={setTextRecurrenceHints}
+      />
+      <button onClick={() => onCommit({ textRecurrenceHints })}>Commit</button>
+    </>
+  );
+}
+
+describe('GlobalDefaultsSection: Text recurrence hints toggle', () => {
+  it('renders off by default', () => {
+    render(<TextRecurrenceHintsHarness onCommit={() => {}} />);
+    const toggle = screen.getByRole('switch', { name: 'Text recurrence hints' });
+    expect(toggle.getAttribute('aria-checked')).toBe('false');
+  });
+
+  it('commits { textRecurrenceHints: true } after switching on', async () => {
+    let committed: TextRecurrenceHintsState | null = null;
+    render(<TextRecurrenceHintsHarness onCommit={(payload) => { committed = payload; }} />);
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole('switch', { name: 'Text recurrence hints' }));
+    await user.click(screen.getByRole('button', { name: 'Commit' }));
+
+    expect(committed).toEqual({ textRecurrenceHints: true });
   });
 });

--- a/frontend/src/pages/settings/GlobalDefaultsSection.tsx
+++ b/frontend/src/pages/settings/GlobalDefaultsSection.tsx
@@ -24,6 +24,8 @@ interface GlobalDefaultsSectionProps {
   onEpisodeLogRetentionDaysChange: (days: number) => void;
   episodeLogLevel: EpisodeLogLevel;
   onEpisodeLogLevelChange: (level: EpisodeLogLevel) => void;
+  textRecurrenceHints: boolean;
+  onTextRecurrenceHintsChange: (enabled: boolean) => void;
 }
 
 function GlobalDefaultsSection({
@@ -45,6 +47,8 @@ function GlobalDefaultsSection({
   onEpisodeLogRetentionDaysChange,
   episodeLogLevel,
   onEpisodeLogLevelChange,
+  textRecurrenceHints,
+  onTextRecurrenceHintsChange,
 }: GlobalDefaultsSectionProps) {
   return (
     <CollapsibleSection
@@ -229,6 +233,23 @@ function GlobalDefaultsSection({
           </label>
           <p className="mt-2 text-sm text-muted-foreground">
             Hides upstream episodes that haven't finished processing from served RSS feeds, so podcast apps don't auto-download an episode that would 503. Per-feed override is available on each feed's settings.
+          </p>
+        </div>
+
+        {/* Text recurrence hints */}
+        <div className="pt-4 border-t border-border">
+          <label className="flex items-center gap-3 cursor-pointer">
+            <ToggleSwitch
+              checked={textRecurrenceHints}
+              onChange={onTextRecurrenceHintsChange}
+              ariaLabel="Text recurrence hints"
+            />
+            <span className="text-sm font-medium text-foreground">
+              Text recurrence hints
+            </span>
+          </label>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Looks for wording that repeats across a show's recent episodes and treats it as a hint for intros, credits, and other boilerplate. Experimental; off by default.
           </p>
         </div>
       </div>

--- a/frontend/src/pages/settings/SeedSponsorsSection.test.tsx
+++ b/frontend/src/pages/settings/SeedSponsorsSection.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * Tests for the Seed sponsors settings section: four independent toggles
+ * controlling whether the known-sponsor list is included in each ad-review
+ * prompt (detection, verification, reviewer, resurrect).
+ */
+import { useState } from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SeedSponsorsSection from './SeedSponsorsSection';
+
+type SeedSponsorsKey =
+  | 'seedSponsorsDetection'
+  | 'seedSponsorsVerification'
+  | 'seedSponsorsReviewer'
+  | 'seedSponsorsResurrect';
+
+function Harness({
+  onChange,
+}: {
+  onChange: (key: SeedSponsorsKey, value: boolean) => void;
+}) {
+  const [detection, setDetection] = useState(true);
+  const [verification, setVerification] = useState(true);
+  const [reviewer, setReviewer] = useState(true);
+  const [resurrect, setResurrect] = useState(true);
+
+  const handleChange = (key: SeedSponsorsKey, value: boolean) => {
+    if (key === 'seedSponsorsDetection') setDetection(value);
+    if (key === 'seedSponsorsVerification') setVerification(value);
+    if (key === 'seedSponsorsReviewer') setReviewer(value);
+    if (key === 'seedSponsorsResurrect') setResurrect(value);
+    onChange(key, value);
+  };
+
+  return (
+    <SeedSponsorsSection
+      detection={detection}
+      verification={verification}
+      reviewer={reviewer}
+      resurrect={resurrect}
+      onChange={handleChange}
+    />
+  );
+}
+
+describe('SeedSponsorsSection: rendering', () => {
+  it('renders four labeled switches, all on by default', () => {
+    render(<Harness onChange={() => {}} />);
+    const detection = screen.getByRole('switch', { name: 'Detection' });
+    const verification = screen.getByRole('switch', { name: 'Verification' });
+    const reviewer = screen.getByRole('switch', { name: 'Reviewer' });
+    const resurrect = screen.getByRole('switch', { name: 'Resurrect' });
+
+    expect(detection.getAttribute('aria-checked')).toBe('true');
+    expect(verification.getAttribute('aria-checked')).toBe('true');
+    expect(reviewer.getAttribute('aria-checked')).toBe('true');
+    expect(resurrect.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('shows the section title', () => {
+    render(<Harness onChange={() => {}} />);
+    expect(screen.getByText('Seed sponsors')).toBeTruthy();
+  });
+
+  it('shows the section subtitle once expanded', async () => {
+    render(<Harness onChange={() => {}} />);
+    const user = userEvent.setup();
+    await user.click(screen.getByText('Seed sponsors'));
+    expect(
+      screen.getByText('Choose which prompts see the known-sponsor list. All on by default.'),
+    ).toBeTruthy();
+  });
+});
+
+describe('SeedSponsorsSection: reviewer toggle', () => {
+  it('calls onChange with seedSponsorsReviewer and nothing else when clicked', async () => {
+    const calls: Array<[SeedSponsorsKey, boolean]> = [];
+    render(<Harness onChange={(key, value) => calls.push([key, value])} />);
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole('switch', { name: 'Reviewer' }));
+
+    expect(calls).toEqual([['seedSponsorsReviewer', false]]);
+  });
+
+  it('does not change the other three switches', async () => {
+    render(<Harness onChange={() => {}} />);
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole('switch', { name: 'Reviewer' }));
+
+    expect(screen.getByRole('switch', { name: 'Detection' }).getAttribute('aria-checked')).toBe('true');
+    expect(screen.getByRole('switch', { name: 'Verification' }).getAttribute('aria-checked')).toBe('true');
+    expect(screen.getByRole('switch', { name: 'Resurrect' }).getAttribute('aria-checked')).toBe('true');
+    expect(screen.getByRole('switch', { name: 'Reviewer' }).getAttribute('aria-checked')).toBe('false');
+  });
+});
+
+describe('SeedSponsorsSection: other toggles', () => {
+  it('calls onChange with seedSponsorsDetection when the detection switch is clicked', async () => {
+    const calls: Array<[SeedSponsorsKey, boolean]> = [];
+    render(<Harness onChange={(key, value) => calls.push([key, value])} />);
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole('switch', { name: 'Detection' }));
+
+    expect(calls).toEqual([['seedSponsorsDetection', false]]);
+  });
+
+  it('calls onChange with seedSponsorsVerification when the verification switch is clicked', async () => {
+    const calls: Array<[SeedSponsorsKey, boolean]> = [];
+    render(<Harness onChange={(key, value) => calls.push([key, value])} />);
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole('switch', { name: 'Verification' }));
+
+    expect(calls).toEqual([['seedSponsorsVerification', false]]);
+  });
+
+  it('calls onChange with seedSponsorsResurrect when the resurrect switch is clicked', async () => {
+    const calls: Array<[SeedSponsorsKey, boolean]> = [];
+    render(<Harness onChange={(key, value) => calls.push([key, value])} />);
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole('switch', { name: 'Resurrect' }));
+
+    expect(calls).toEqual([['seedSponsorsResurrect', false]]);
+  });
+});

--- a/frontend/src/pages/settings/SeedSponsorsSection.tsx
+++ b/frontend/src/pages/settings/SeedSponsorsSection.tsx
@@ -1,0 +1,91 @@
+import CollapsibleSection from '../../components/CollapsibleSection';
+import ToggleSwitch from '../../components/ToggleSwitch';
+
+type SeedSponsorsKey =
+  | 'seedSponsorsDetection'
+  | 'seedSponsorsVerification'
+  | 'seedSponsorsReviewer'
+  | 'seedSponsorsResurrect';
+
+interface SeedSponsorsSectionProps {
+  detection: boolean;
+  verification: boolean;
+  reviewer: boolean;
+  resurrect: boolean;
+  onChange: (key: SeedSponsorsKey, value: boolean) => void;
+}
+
+function SeedSponsorsSection({
+  detection,
+  verification,
+  reviewer,
+  resurrect,
+  onChange,
+}: SeedSponsorsSectionProps) {
+  return (
+    <CollapsibleSection
+      title="Seed sponsors"
+      subtitle="Choose which prompts see the known-sponsor list. All on by default."
+    >
+      <div className="space-y-6">
+        <div>
+          <label className="flex items-center gap-3 cursor-pointer">
+            <ToggleSwitch
+              checked={detection}
+              onChange={(v) => onChange('seedSponsorsDetection', v)}
+              ariaLabel="Detection"
+            />
+            <span className="text-sm font-medium text-foreground">Detection</span>
+          </label>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Include the known-sponsor list in the pass 1 detection prompt.
+          </p>
+        </div>
+
+        <div className="pt-4 border-t border-border">
+          <label className="flex items-center gap-3 cursor-pointer">
+            <ToggleSwitch
+              checked={verification}
+              onChange={(v) => onChange('seedSponsorsVerification', v)}
+              ariaLabel="Verification"
+            />
+            <span className="text-sm font-medium text-foreground">Verification</span>
+          </label>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Include the known-sponsor list in the pass 2 verification prompt.
+          </p>
+        </div>
+
+        <div className="pt-4 border-t border-border">
+          <label className="flex items-center gap-3 cursor-pointer">
+            <ToggleSwitch
+              checked={reviewer}
+              onChange={(v) => onChange('seedSponsorsReviewer', v)}
+              ariaLabel="Reviewer"
+            />
+            <span className="text-sm font-medium text-foreground">Reviewer</span>
+          </label>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Include the known-sponsor list when the reviewer checks each detection. Turning this off makes the reviewer an independent second opinion.
+          </p>
+        </div>
+
+        <div className="pt-4 border-t border-border">
+          <label className="flex items-center gap-3 cursor-pointer">
+            <ToggleSwitch
+              checked={resurrect}
+              onChange={(v) => onChange('seedSponsorsResurrect', v)}
+              ariaLabel="Resurrect"
+            />
+            <span className="text-sm font-medium text-foreground">Resurrect</span>
+          </label>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Include the known-sponsor list when the reviewer reconsiders rejected detections.
+          </p>
+        </div>
+      </div>
+    </CollapsibleSection>
+  );
+}
+
+export default SeedSponsorsSection;

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3918,6 +3918,25 @@ paths:
                 detectShowSegments:
                   type: boolean
                   description: Global default for detecting intro, outro, and recap/housekeeping segments in addition to the always-detected ad-side categories. Overridden by per-feed detectShowSegments when set.
+                seedSponsorsDetection:
+                  type: boolean
+                  description: Whether the detection pass prompt is rendered with the seed sponsor list. Off renders that prompt with an empty sponsor block. Default true.
+                seedSponsorsVerification:
+                  type: boolean
+                  description: Whether the verification pass prompt is rendered with the seed sponsor list. Off renders that prompt with an empty sponsor block. Default true.
+                seedSponsorsReviewer:
+                  type: boolean
+                  description: Whether the reviewer pass prompt is rendered with the seed sponsor list. Off renders that prompt with an empty sponsor block. Default true.
+                seedSponsorsResurrect:
+                  type: boolean
+                  description: Whether the resurrect pass prompt is rendered with the seed sponsor list. Off renders that prompt with an empty sponsor block. Default true.
+                textRecurrenceHints:
+                  type: boolean
+                  description: Hints the detection prompt with transcript spans whose wording recurs near-verbatim across prior episodes of the same show (intros, disclaimers, credits). Off by default.
+                adAddressingMode:
+                  type: string
+                  enum: [timestamps, segment_ids]
+                  description: How the LLM addresses detected segments. 'timestamps' (default) reports absolute start/end seconds. 'segment_ids' reports transcript line ids instead, which the server maps to exact segment times.
                 processNewEpisodesFirst:
                   type: boolean
                   description: Whether episodes published within the last 48 hours get an automatic queue-priority boost ahead of the rest of the auto-process backlog. On by default.
@@ -9310,6 +9329,55 @@ components:
               description: Global default for detecting intro, outro, and recap/housekeeping segments (per-feed detectShowSegments overrides when set)
             isDefault:
               type: boolean
+        seedSponsorsDetection:
+          type: object
+          properties:
+            value:
+              type: boolean
+              description: Whether the detection pass prompt is rendered with the seed sponsor list. Default true.
+            isDefault:
+              type: boolean
+        seedSponsorsVerification:
+          type: object
+          properties:
+            value:
+              type: boolean
+              description: Whether the verification pass prompt is rendered with the seed sponsor list. Default true.
+            isDefault:
+              type: boolean
+        seedSponsorsReviewer:
+          type: object
+          properties:
+            value:
+              type: boolean
+              description: Whether the reviewer pass prompt is rendered with the seed sponsor list. Default true.
+            isDefault:
+              type: boolean
+        seedSponsorsResurrect:
+          type: object
+          properties:
+            value:
+              type: boolean
+              description: Whether the resurrect pass prompt is rendered with the seed sponsor list. Default true.
+            isDefault:
+              type: boolean
+        textRecurrenceHints:
+          type: object
+          properties:
+            value:
+              type: boolean
+              description: Hints the detection prompt with transcript spans whose wording recurs near-verbatim across prior episodes of the same show. Off by default.
+            isDefault:
+              type: boolean
+        adAddressingMode:
+          type: object
+          properties:
+            value:
+              type: string
+              enum: [timestamps, segment_ids]
+              description: How the LLM addresses detected segments. 'timestamps' (default) or 'segment_ids'.
+            isDefault:
+              type: boolean
         processNewEpisodesFirst:
           type: object
           properties:
@@ -9601,6 +9669,19 @@ components:
               type: boolean
             detectShowSegments:
               type: boolean
+            seedSponsorsDetection:
+              type: boolean
+            seedSponsorsVerification:
+              type: boolean
+            seedSponsorsReviewer:
+              type: boolean
+            seedSponsorsResurrect:
+              type: boolean
+            textRecurrenceHints:
+              type: boolean
+            adAddressingMode:
+              type: string
+              enum: [timestamps, segment_ids]
             processNewEpisodesFirst:
               type: boolean
             rssRefreshIntervalMinutes:

--- a/src/ad_detector/__init__.py
+++ b/src/ad_detector/__init__.py
@@ -119,6 +119,8 @@ from .prompts import (
     format_window_prompt,
     get_static_system_prompt,
     parse_ads_from_response,
+    parse_id_ads_from_response,
+    resolve_segment_id_ads,
     extract_json_ads_array,
     CATEGORY_REPAIR_SYSTEM_PROMPT,
     CATEGORY_REPAIR_JSON_SCHEMA,
@@ -997,14 +999,31 @@ class AdDetector:
             f"[{slug}:{episode_id}] {window_label} LLM response ({len(response_text)} chars): {preview}"
         )
 
-        window_ads = parse_ads_from_response(
-            response_text, slug, episode_id, sponsor_service=self.sponsor_service
-        )
-
-        if validate_timestamps:
-            window_ads = validate_ad_timestamps(
-                window_ads, window_segments, window_start, window_end
-            )
+        if addressing_mode == 'segment_ids':
+            id_ads, used_ids = parse_id_ads_from_response(
+                response_text, slug, episode_id,
+                sponsor_service=self.sponsor_service)
+            if used_ids:
+                window_ads = resolve_segment_id_ads(
+                    id_ads, window_segments, slug, episode_id,
+                    sponsor_service=self.sponsor_service)
+            else:
+                logger.warning(
+                    f"[{slug}:{episode_id}] {window_label}: model ignored "
+                    f"segment-id contract, falling back to timestamp parsing")
+                window_ads = parse_ads_from_response(
+                    response_text, slug, episode_id,
+                    sponsor_service=self.sponsor_service)
+                if validate_timestamps:
+                    window_ads = validate_ad_timestamps(
+                        window_ads, window_segments, window_start, window_end)
+        else:
+            window_ads = parse_ads_from_response(
+                response_text, slug, episode_id,
+                sponsor_service=self.sponsor_service)
+            if validate_timestamps:
+                window_ads = validate_ad_timestamps(
+                    window_ads, window_segments, window_start, window_end)
 
         valid_window_ads = []
         for ad in window_ads:

--- a/src/ad_detector/__init__.py
+++ b/src/ad_detector/__init__.py
@@ -126,7 +126,6 @@ from .prompts import (
     format_category_repair_prompt,
     parse_category_repair_response,
     SEGMENT_ID_SYSTEM_SECTION,
-    SEGMENT_ID_WINDOW_RULES,
 )
 # Source the JSON-array scanner directly from utils.llm_response instead of
 # laundering it through prompts.py; re-exported below for backward-compat
@@ -930,8 +929,9 @@ class AdDetector:
 
         ``addressing_mode``: 'timestamps' (default, unchanged rendering) or
         'segment_ids' (issue: hushpod adoption) -- switches the transcript
-        line format and appends SEGMENT_ID_WINDOW_RULES via
-        ``format_window_prompt``'s ``extra_rules``.
+        line format and passes ``addressing_mode`` through to
+        ``format_window_prompt``, which swaps the window-context rules
+        instead of appending a second, conflicting set.
         """
         window_segments = window['segments']
         window_start = window['start']
@@ -943,10 +943,6 @@ class AdDetector:
         ) if audio_enforcer else ""
         recurrence_context = format_recurrence_hint(
             recurrence_spans or [], window_start, window_end)
-        extra_rules = (
-            SEGMENT_ID_WINDOW_RULES(window_end)
-            if addressing_mode == 'segment_ids' else ""
-        )
 
         prompt = format_window_prompt(
             podcast_name=podcast_name,
@@ -958,7 +954,7 @@ class AdDetector:
             window_start=window_start,
             window_end=window_end,
             audio_context=audio_context + recurrence_context,
-            extra_rules=extra_rules,
+            addressing_mode=addressing_mode,
         )
 
         window_label = f"{window_label_prefix} {window_idx + 1}"

--- a/src/ad_detector/__init__.py
+++ b/src/ad_detector/__init__.py
@@ -125,6 +125,8 @@ from .prompts import (
     CATEGORY_REPAIR_MAX_TOKENS,
     format_category_repair_prompt,
     parse_category_repair_response,
+    SEGMENT_ID_SYSTEM_SECTION,
+    SEGMENT_ID_WINDOW_RULES,
 )
 # Source the JSON-array scanner directly from utils.llm_response instead of
 # laundering it through prompts.py; re-exported below for backward-compat
@@ -801,16 +803,37 @@ class AdDetector:
             logger.warning(f"Could not resolve segment actions for {slug}: {e}")
             return None
 
-    def _build_detection_system_prompt(self, slug: str) -> str:
+    def _resolve_addressing_mode(self) -> str:
+        """'segment_ids' or 'timestamps'. Unknown values coerce to
+        'timestamps' (validated at point of use; env/DB can bypass the API)."""
+        try:
+            value = (self.db.get_setting('ad_addressing_mode') or '')
+        except Exception:
+            value = ''
+        return 'segment_ids' if value.strip().lower() == 'segment_ids' else 'timestamps'
+
+    @staticmethod
+    def _format_transcript_lines(window_segments, addressing_mode):
+        if addressing_mode == 'segment_ids':
+            return [f"[{seg['sid']}] {seg['text']}" for seg in window_segments]
+        return [f"[{seg['start']:.1f}s - {seg['end']:.1f}s] {seg['text']}"
+                for seg in window_segments]
+
+    def _build_detection_system_prompt(self, slug: str, addressing_mode: str = 'timestamps') -> str:
         """Compose the system prompt for detection window calls.
 
         Appends SHOW_SEGMENTS_PROMPT_SECTION to get_system_prompt() when the
         podcast opted in, after override resolution, so a customized
-        system_prompt still gets the show-segments instructions.
+        system_prompt still gets the show-segments instructions. Appends
+        SEGMENT_ID_SYSTEM_SECTION when ``addressing_mode`` is 'segment_ids'
+        (issue: hushpod adoption), after the show-segments section so both
+        can layer independently.
         """
         prompt = self.get_system_prompt()
         if self._podcast_wants_show_segments(slug):
             prompt = f"{prompt}\n\n{SHOW_SEGMENTS_PROMPT_SECTION}"
+        if addressing_mode == 'segment_ids':
+            prompt = f"{prompt}{SEGMENT_ID_SYSTEM_SECTION}"
         return prompt
 
     _HINT_TIER1_CAP = 12
@@ -892,7 +915,8 @@ class AdDetector:
                                 llm_timeout, max_retries,
                                 slug, episode_id, pass_name,
                                 window_label_prefix, validate_timestamps,
-                                recurrence_spans=None):
+                                recurrence_spans=None,
+                                addressing_mode='timestamps'):
         """Run one window through prompt-build + LLM call + parse + filter.
 
         Returns a ``WindowResult``. Thread-safe: writes nothing to shared
@@ -903,20 +927,26 @@ class AdDetector:
         ``recurrence_spans``: optional pass-1-only text-recurrence spans
         (issue: hushpod adoption); rendered into a hint appended after
         ``audio_context`` when it overlaps this window.
+
+        ``addressing_mode``: 'timestamps' (default, unchanged rendering) or
+        'segment_ids' (issue: hushpod adoption) -- switches the transcript
+        line format and appends SEGMENT_ID_WINDOW_RULES via
+        ``format_window_prompt``'s ``extra_rules``.
         """
         window_segments = window['segments']
         window_start = window['start']
         window_end = window['end']
 
-        transcript_lines = [
-            f"[{seg['start']:.1f}s - {seg['end']:.1f}s] {seg['text']}"
-            for seg in window_segments
-        ]
+        transcript_lines = self._format_transcript_lines(window_segments, addressing_mode)
         audio_context = audio_enforcer.format_for_window(
             audio_analysis, window_start, window_end
         ) if audio_enforcer else ""
         recurrence_context = format_recurrence_hint(
             recurrence_spans or [], window_start, window_end)
+        extra_rules = (
+            SEGMENT_ID_WINDOW_RULES(window_end)
+            if addressing_mode == 'segment_ids' else ""
+        )
 
         prompt = format_window_prompt(
             podcast_name=podcast_name,
@@ -928,6 +958,7 @@ class AdDetector:
             window_start=window_start,
             window_end=window_end,
             audio_context=audio_context + recurrence_context,
+            extra_rules=extra_rules,
         )
 
         window_label = f"{window_label_prefix} {window_idx + 1}"
@@ -1100,7 +1131,7 @@ class AdDetector:
                             progress_base, progress_range, slug, episode_id,
                             pass_name, window_label_prefix, validate_timestamps,
                             action_map=None, category_repair_enabled=False,
-                            recurrence_spans=None):
+                            recurrence_spans=None, addressing_mode='timestamps'):
         """Shared window orchestration for the detection and verification passes.
 
         Runs every window through ``_run_windows``, merges results in window
@@ -1124,6 +1155,10 @@ class AdDetector:
         ``recurrence_spans``: optional pass-1-only text-recurrence spans,
         forwarded to ``_process_single_window``. Callers other than pass 1
         (e.g. verification) leave this None.
+
+        ``addressing_mode``: forwarded to ``_process_single_window`` (issue:
+        hushpod adoption). Defaults to 'timestamps', which reproduces
+        pre-change rendering byte-for-byte.
 
         Returns ``(final_ads, all_raw_responses, failed_windows,
         failure_response, category_missing, category_total,
@@ -1175,6 +1210,7 @@ class AdDetector:
             window_label_prefix=window_label_prefix,
             validate_timestamps=validate_timestamps,
             recurrence_spans=recurrence_spans,
+            addressing_mode=addressing_mode,
         )
 
         category_repaired = 0
@@ -1335,6 +1371,14 @@ class AdDetector:
                 logger.info(f"[{slug}:{episode_id}] Auto-detected {len(foreign_language_ads)} "
                            f"non-English segments as ads")
 
+            # Resolved once per run, before windowing: 'segment_ids' stamps a
+            # global index onto every segment so create_windows' per-window
+            # references keep it (issue: hushpod adoption).
+            addressing_mode = self._resolve_addressing_mode()
+            if addressing_mode == 'segment_ids':
+                for sid, seg in enumerate(segments):
+                    seg['sid'] = sid
+
             # Create overlapping windows from transcript
             windows = create_windows(segments)
             total_duration = segments[-1]['end']
@@ -1346,7 +1390,7 @@ class AdDetector:
                        f"for {total_duration/60:.1f}min episode")
 
             # Get prompts and model
-            system_prompt = self._build_detection_system_prompt(slug)
+            system_prompt = self._build_detection_system_prompt(slug, addressing_mode)
             model = self.get_model()
 
             logger.info(f"[{slug}:{episode_id}] Using model: {model}")
@@ -1412,6 +1456,7 @@ class AdDetector:
                 action_map=action_map,
                 category_repair_enabled=segment_categories_configured,
                 recurrence_spans=recurrence_spans,
+                addressing_mode=addressing_mode,
             )
             if failure is not None:
                 return failure
@@ -2717,6 +2762,14 @@ class AdDetector:
         try:
             self.initialize_client()
 
+            # Verification re-transcribes processed audio into a fresh
+            # segment list, so ids are stamped independently of pass 1's
+            # (issue: hushpod adoption); kept consistent with detect_ads.
+            addressing_mode = self._resolve_addressing_mode()
+            if addressing_mode == 'segment_ids':
+                for sid, seg in enumerate(segments):
+                    seg['sid'] = sid
+
             windows = create_windows(segments)
             total_duration = segments[-1]['end'] if segments else 0
 
@@ -2724,6 +2777,8 @@ class AdDetector:
                        f"for {total_duration/60:.1f}min processed audio")
 
             system_prompt = self.get_verification_prompt()
+            if addressing_mode == 'segment_ids':
+                system_prompt = f"{system_prompt}{SEGMENT_ID_SYSTEM_SECTION}"
             model = self.get_verification_model()
 
             logger.info(f"[{slug}:{episode_id}] Verification using model: {model}")
@@ -2776,6 +2831,7 @@ class AdDetector:
                 validate_timestamps=False,
                 action_map=action_map,
                 category_repair_enabled=segment_categories_configured,
+                addressing_mode=addressing_mode,
             )
             if failure is not None:
                 return failure

--- a/src/ad_detector/__init__.py
+++ b/src/ad_detector/__init__.py
@@ -74,6 +74,7 @@ from ad_detector.keep_content import CONTENT_SYSTEM_PROMPT, invert_content_to_ad
 from llm_capabilities import PASS_AD_DETECTION_1, PASS_AD_DETECTION_2, supports_json_schema
 from sponsor_service import SponsorService
 from text_pattern_matcher import is_defined_pattern
+from text_recurrence import format_recurrence_hint
 from utils.constants import (
     INVALID_SPONSOR_VALUES,
     KNOWN_SHORT_BRANDS, canonical_sponsor,
@@ -890,13 +891,18 @@ class AdDetector:
                                 audio_enforcer, audio_analysis,
                                 llm_timeout, max_retries,
                                 slug, episode_id, pass_name,
-                                window_label_prefix, validate_timestamps):
+                                window_label_prefix, validate_timestamps,
+                                recurrence_spans=None):
         """Run one window through prompt-build + LLM call + parse + filter.
 
         Returns a ``WindowResult``. Thread-safe: writes nothing to shared
         instance state. The DB / token-accumulator side effects happen
         through ``_call_llm_for_window`` which uses lock-protected helpers
         downstream.
+
+        ``recurrence_spans``: optional pass-1-only text-recurrence spans
+        (issue: hushpod adoption); rendered into a hint appended after
+        ``audio_context`` when it overlaps this window.
         """
         window_segments = window['segments']
         window_start = window['start']
@@ -909,6 +915,8 @@ class AdDetector:
         audio_context = audio_enforcer.format_for_window(
             audio_analysis, window_start, window_end
         ) if audio_enforcer else ""
+        recurrence_context = format_recurrence_hint(
+            recurrence_spans or [], window_start, window_end)
 
         prompt = format_window_prompt(
             podcast_name=podcast_name,
@@ -919,7 +927,7 @@ class AdDetector:
             total_windows=total_windows,
             window_start=window_start,
             window_end=window_end,
-            audio_context=audio_context,
+            audio_context=audio_context + recurrence_context,
         )
 
         window_label = f"{window_label_prefix} {window_idx + 1}"
@@ -1091,7 +1099,8 @@ class AdDetector:
                             audio_analysis, progress_callback,
                             progress_base, progress_range, slug, episode_id,
                             pass_name, window_label_prefix, validate_timestamps,
-                            action_map=None, category_repair_enabled=False):
+                            action_map=None, category_repair_enabled=False,
+                            recurrence_spans=None):
         """Shared window orchestration for the detection and verification passes.
 
         Runs every window through ``_run_windows``, merges results in window
@@ -1111,6 +1120,10 @@ class AdDetector:
         "category" gets one follow-up LLM call for just those categories (see
         ``_repair_window_categories``). False skips repair and makes no extra
         calls.
+
+        ``recurrence_spans``: optional pass-1-only text-recurrence spans,
+        forwarded to ``_process_single_window``. Callers other than pass 1
+        (e.g. verification) leave this None.
 
         Returns ``(final_ads, all_raw_responses, failed_windows,
         failure_response, category_missing, category_total,
@@ -1161,6 +1174,7 @@ class AdDetector:
             pass_name=pass_name,
             window_label_prefix=window_label_prefix,
             validate_timestamps=validate_timestamps,
+            recurrence_spans=recurrence_spans,
         )
 
         category_repaired = 0
@@ -1289,7 +1303,8 @@ class AdDetector:
                    podcast_description: str = None,
                    progress_callback=None,
                    audio_analysis=None,
-                   positional_prior_hint: str = "") -> dict | None:
+                   positional_prior_hint: str = "",
+                   recurrence_spans: list | None = None) -> dict | None:
         """Detect ad segments using Claude API with sliding window approach.
 
         Processes transcript in overlapping windows to ensure ads at chunk
@@ -1300,6 +1315,8 @@ class AdDetector:
             progress_callback: Optional callback(stage, percent) to report progress
             positional_prior_hint: Pre-rendered learned ad-position scrutiny
                                    hint for the per-window prompt (issue #360)
+            recurrence_spans: Optional cross-episode text-recurrence spans
+                                   (hushpod adoption); rendered per-window.
         """
         if not self.api_key:
             logger.warning("Skipping ad detection - no API key")
@@ -1394,6 +1411,7 @@ class AdDetector:
                 validate_timestamps=True,
                 action_map=action_map,
                 category_repair_enabled=segment_categories_configured,
+                recurrence_spans=recurrence_spans,
             )
             if failure is not None:
                 return failure
@@ -1598,6 +1616,7 @@ class AdDetector:
                           *,
                           ctx=None,
                           positional_prior_hint: str = "",
+                          recurrence_spans: list | None = None,
                           keep_content: bool | None = None,
                           skip_llm: bool = False) -> dict:
         """Process transcript for ad detection using three-stage pipeline.
@@ -1629,6 +1648,9 @@ class AdDetector:
                  callers that do not run inside the pipeline.
             skip_llm: cue_only preset. When True, stage 3 never runs (no
                  keep-content, no blacklist Claude call).
+            recurrence_spans: Optional cross-episode text-recurrence spans
+                 (hushpod adoption), forwarded to the blacklist detect_ads()
+                 call only; keep-content mode does not receive it.
 
         Returns:
             Dict with ads, status, and detection metadata
@@ -1856,7 +1878,8 @@ class AdDetector:
                     podcast_description=podcast_description,
                     progress_callback=progress_callback,
                     audio_analysis=audio_analysis,
-                    positional_prior_hint=positional_prior_hint
+                    positional_prior_hint=positional_prior_hint,
+                    recurrence_spans=recurrence_spans,
                 )
 
         if result is None:

--- a/src/ad_detector/__init__.py
+++ b/src/ad_detector/__init__.py
@@ -66,6 +66,7 @@ from config import (
     KEEP_CONTENT_MIN_AD_SECONDS,
     KEEP_CONTENT_MAX_SINGLE_AD_FRACTION,
     KEEP_CONTENT_MAX_SINGLE_AD_SECONDS,
+    coerce_bool_setting,
 )
 from ad_detector.cue_boundary_snap import _cue_role
 from ad_detector.cue_pair_ads import synthesize_ads_from_cue_pairs
@@ -716,7 +717,7 @@ class AdDetector:
             from utils.constants import DEFAULT_SYSTEM_PROMPT
             prompt = DEFAULT_SYSTEM_PROMPT
         return self._apply_pass_override(
-            self._render_with_sponsors(prompt), 'system_prompt_override')
+            self._render_with_sponsors(prompt, 'seed_sponsors_detection'), 'system_prompt_override')
 
     def get_verification_prompt(self) -> str:
         """Get verification prompt from database or default, with dynamic sponsors substituted."""
@@ -730,7 +731,7 @@ class AdDetector:
             from database import DEFAULT_VERIFICATION_PROMPT
             prompt = DEFAULT_VERIFICATION_PROMPT
         return self._apply_pass_override(
-            self._render_with_sponsors(prompt), 'verification_prompt_override')
+            self._render_with_sponsors(prompt, 'seed_sponsors_verification'), 'verification_prompt_override')
 
     def _get_sponsor_list_safely(self) -> str:
         """Pull the dynamic sponsor list, returning empty string on any error."""
@@ -742,13 +743,30 @@ class AdDetector:
             logger.warning(f"Could not load dynamic sponsor list: {e}")
             return ""
 
-    def _render_with_sponsors(self, prompt: str) -> str:
-        """Substitute ``{sponsor_database}`` in a prompt with the dynamic sponsor block.
+    def _seed_sponsors_enabled(self, toggle_key: str) -> bool:
+        """Whether the given seed-sponsors toggle is on. Fails open (True):
+        a missing or unreadable setting must not silently strip the block."""
+        try:
+            value = self.db.get_setting(toggle_key)
+        except Exception as e:
+            logger.warning(f"Could not read {toggle_key}: {e}")
+            return True
+        if value is None:
+            return True
+        return coerce_bool_setting(value)
+
+    def _render_with_sponsors(self, prompt: str, toggle_key: str) -> str:
+        """Substitute ``{sponsor_database}`` in a prompt with the dynamic
+        sponsor block, or with an empty string when the pass's seed-sponsors
+        toggle is off.
 
         Prompts without the placeholder get no sponsor content (the user
         opted out by editing the placeholder away).
         """
-        sponsor_block = format_sponsor_block(self._get_sponsor_list_safely())
+        if self._seed_sponsors_enabled(toggle_key):
+            sponsor_block = format_sponsor_block(self._get_sponsor_list_safely())
+        else:
+            sponsor_block = ""
         return render_prompt(prompt, sponsor_database=sponsor_block)
 
     def _podcast_wants_show_segments(self, slug: str) -> bool:

--- a/src/ad_detector/prompts.py
+++ b/src/ad_detector/prompts.py
@@ -132,12 +132,18 @@ def format_window_prompt(
     window_start: float,
     window_end: float,
     audio_context: str = "",
+    extra_rules: str = "",
 ) -> str:
     """Build the user prompt for a single ad-detection window.
 
     `description_section` and `audio_context` are pre-built strings so the
     benchmark can call this without DB or audio-analysis state. Production
     callers assemble both then pass them in.
+
+    `extra_rules` is appended last (after the window context); it carries
+    mode-specific window rules (e.g. segment-id addressing, issue: hushpod
+    adoption) without disturbing the benchmark's existing calls, which never
+    pass it and get "".
     """
     transcript = "\n".join(transcript_lines)
     window_context = f"""
@@ -152,7 +158,29 @@ def format_window_prompt(
         episode_title=episode_title,
         description_section=description_section,
         transcript=transcript,
-    ) + audio_context + window_context
+    ) + audio_context + window_context + extra_rules
+
+
+SEGMENT_ID_SYSTEM_SECTION = """
+
+ADDRESSING MODE: SEGMENT IDS
+The transcript is a numbered list; each line starts with its [id]. For every
+detection you report, replace the "start" and "end" timestamp fields with
+integer "start_id" and "end_id" fields: the ids of the FIRST and LAST
+transcript lines of the ad, inclusive. Refer to lines ONLY by the ids shown.
+Never output timestamps and never invent ids that do not appear in the
+transcript. All other rules (categories, confidence, reason) are unchanged."""
+
+
+def SEGMENT_ID_WINDOW_RULES(window_end: float) -> str:
+    return (
+        "\n- Report start_id/end_id integers from the [id] brackets, "
+        "never timestamps"
+        "\n- If an ad starts before this window, use this window's first id "
+        "with note \"continues from previous\""
+        "\n- If an ad extends past this window, use this window's last id "
+        "with note \"continues in next\"\n"
+    )
 
 
 def get_static_system_prompt() -> str:

--- a/src/ad_detector/prompts.py
+++ b/src/ad_detector/prompts.py
@@ -155,7 +155,7 @@ def format_window_prompt(
         f"{window_start/60:.1f}-{window_end/60:.1f} minutes ==="
     )
     if addressing_mode == "segment_ids":
-        rules = SEGMENT_ID_WINDOW_RULES(window_end)
+        rules = SEGMENT_ID_WINDOW_RULES
     else:
         rules = (
             "\n- Use absolute timestamps from transcript (as shown in brackets)"
@@ -179,18 +179,23 @@ detection you report, replace the "start" and "end" timestamp fields with
 integer "start_id" and "end_id" fields: the ids of the FIRST and LAST
 transcript lines of the ad, inclusive. Refer to lines ONLY by the ids shown.
 Never output timestamps and never invent ids that do not appear in the
-transcript. All other rules (categories, confidence, reason) are unchanged."""
+transcript. All other rules (categories, confidence, reason) are unchanged.
+
+Ignore any earlier instruction to read [Xs] timestamp markers or to output
+numeric "start"/"end" seconds: in this mode the transcript lines carry [id]
+numbers only, and the JSON fields "start"/"end" are replaced by integer
+"start_id"/"end_id". All other rules (categories, confidence, reason) still
+apply."""
 
 
-def SEGMENT_ID_WINDOW_RULES(window_end: float) -> str:
-    return (
-        "\n- Report start_id/end_id integers from the [id] brackets, "
-        "never timestamps"
-        "\n- If an ad starts before this window, use this window's first id "
-        "with note \"continues from previous\""
-        "\n- If an ad extends past this window, use this window's last id "
-        "with note \"continues in next\"\n"
-    )
+SEGMENT_ID_WINDOW_RULES = (
+    "\n- Report start_id/end_id integers from the [id] brackets, "
+    "never timestamps"
+    "\n- If an ad starts before this window, use this window's first id "
+    "with note \"continues from previous\""
+    "\n- If an ad extends past this window, use this window's last id "
+    "with note \"continues in next\"\n"
+)
 
 
 def get_static_system_prompt() -> str:
@@ -596,7 +601,8 @@ def parse_id_ads_from_response(response_text: str, slug: str = None,
     """
     try:
         raw, _extraction_method = extract_json_ads_array(response_text, slug, episode_id)
-    except Exception:
+    except Exception as e:
+        logger.warning(f"[{slug}:{episode_id}] Failed to extract ID-mode ads: {e}")
         return [], False
     if raw is None or not isinstance(raw, list):
         return [], False
@@ -606,12 +612,14 @@ def parse_id_ads_from_response(response_text: str, slug: str = None,
 
     ads = []
     any_ids = False
+    skipped_no_id = 0
     for obj in raw:
         if not isinstance(obj, dict):
             continue
         sid_lo = _int_field(obj, ('start_id', 'startid', 'start_segment_id'))
         sid_hi = _int_field(obj, ('end_id', 'endid', 'end_segment_id'))
         if sid_lo is None or sid_hi is None:
+            skipped_no_id += 1
             continue
         any_ids = True
         ad = dict(obj)
@@ -622,6 +630,14 @@ def parse_id_ads_from_response(response_text: str, slug: str = None,
         ad.pop('start', None)
         ad.pop('end', None)
         ads.append(ad)
+    if any_ids and skipped_no_id:
+        # Mixed response: some objects used the id contract, others didn't
+        # (likely timestamp-mode ads in the same response). The id-less
+        # objects are silently dropped below -- surface the count so a lost
+        # detection is diagnosable instead of invisible.
+        logger.warning(
+            f"[{slug}:{episode_id}] ID-mode response mixed formats: "
+            f"skipped {skipped_no_id} object(s) without id fields")
     return (ads, True) if any_ids else ([], False)
 
 
@@ -651,7 +667,13 @@ def resolve_segment_id_ads(ads: list[dict], window_segments: list[dict],
         raw = {k: v for k, v in ad.items() if k not in ('start_id', 'end_id')}
         start = seg_lo['start']
         end = seg_hi['end']
-        ad_entry = _normalize_ad(raw, start, end, slug, episode_id, sponsor_service)
+        try:
+            ad_entry = _normalize_ad(raw, start, end, slug, episode_id, sponsor_service)
+        except (ValueError, TypeError) as e:
+            logger.warning(
+                f"[{slug}:{episode_id}] Skipping ad with invalid field "
+                f"(ids {lo}-{hi}): {e}")
+            continue
         if ad_entry is not None:
             resolved.append(ad_entry)
     return resolved

--- a/src/ad_detector/prompts.py
+++ b/src/ad_detector/prompts.py
@@ -264,6 +264,237 @@ def _as_text(value) -> str:
     return _strip_continuation_prefix(_flatten(value))
 
 
+def _get_valid_sponsor_value(value):
+    if not value:
+        return None
+    str_value = _flatten(value)
+    # A continuation note is window bookkeeping, not a sponsor; trimming
+    # the prefix and keeping the remainder minted labels like 'window'.
+    if _CONTINUATION_PREFIX_RE.match(str_value):
+        return None
+    if len(str_value) < 2:
+        return None
+    if str_value.lower() in INVALID_SPONSOR_VALUES:
+        return None
+    if len(str_value) > SPONSOR_MAX_NAME_CHARS:
+        return None
+    if is_sponsor_reasoning_rationale(str_value):
+        return None
+    return str_value
+
+
+def _text_is_duplicate(a: str, b: str) -> bool:
+    """Check if two strings are essentially the same text.
+
+    Length has to be comparable first. A bare sponsor name is both a
+    prefix of its own description and a full word subset of it, so
+    without this "Box" swallowed the note explaining the read and left
+    the marker saying only "Box".
+    """
+    a_lower = a.lower().strip()
+    b_lower = b.lower().strip()
+    shorter, longer = sorted((a_lower, b_lower), key=len)
+    if not shorter or len(shorter) < len(longer) * DUPLICATE_MIN_LENGTH_RATIO:
+        return False
+    if longer.startswith(shorter):
+        return True
+    a_words = set(a_lower.split())
+    b_words = set(b_lower.split())
+    if not a_words or not b_words:
+        return False
+    overlap = len(a_words & b_words)
+    smaller = min(len(a_words), len(b_words))
+    return overlap / smaller > 0.8 if smaller > 0 else False
+
+
+def _extract_sponsor_name(ad: dict) -> str:
+    """Extract sponsor/advertiser name using priority fields, keywords, and dynamic scanning."""
+    # Local alias for the SponsorService method - keeps call sites below short.
+    extract_sponsor_from_text = SponsorService.extract_sponsor_from_reason
+
+    for field in SPONSOR_PRIORITY_FIELDS:
+        value = _get_valid_sponsor_value(ad.get(field))
+        if value:
+            return value
+
+    for key in ad.keys():
+        key_lower = key.lower()
+        for keyword in SPONSOR_PATTERN_KEYWORDS:
+            if keyword in key_lower:
+                value = _get_valid_sponsor_value(ad.get(key))
+                if value:
+                    return value
+
+    priority_lower = {f.lower() for f in SPONSOR_PRIORITY_FIELDS}
+    for key, val in ad.items():
+        key_lower = key.lower()
+        if key_lower in STRUCTURAL_FIELDS or key_lower in priority_lower:
+            continue
+        if isinstance(val, str) and len(val) < 80:
+            value = _get_valid_sponsor_value(val)
+            if value:
+                return value
+
+    for key, val in ad.items():
+        if key.lower() in STRUCTURAL_FIELDS:
+            continue
+        if isinstance(val, str) and len(val) > 10:
+            sponsor = extract_sponsor_from_text(val)
+            if sponsor:
+                return sponsor
+
+    return 'Advertisement detected'
+
+
+def _normalize_ad(ad: dict, start: float, end: float, slug: str = None,
+                   episode_id: str = None, sponsor_service=None) -> dict | None:
+    """Post-parse normalization shared by the timestamp-mode and segment-id-mode
+    parsers: degenerate-range rejection, is_ad/classification filters, sponsor
+    name + reason/description extraction, confidence normalization, the
+    duration/evidence gate, and category resolution. ``ad`` still carries all
+    raw LLM fields; ``start``/``end`` are already-resolved seconds (parsed
+    from timestamp fields, or mapped from segment ids). Returns the final ad
+    dict, or None if the candidate is rejected.
+    """
+    if end <= start:
+        logger.warning(
+            f"[{slug}:{episode_id}] Discarding ad candidate: "
+            f"invalid range (start={start:.1f}s >= end={end:.1f}s) - "
+            f"reason={str(ad.get('reason', ad.get('sponsor', '')))[:80]}"
+        )
+        return None
+
+    # Filter out explicitly marked non-ads
+    is_ad_val = ad.get('is_ad')
+    if is_ad_val is not None:
+        if str(is_ad_val).lower() in ('false', 'no', '0', 'none'):
+            logger.info(f"[{slug}:{episode_id}] Skipping non-ad: "
+                        f"{start:.1f}s-{end:.1f}s (is_ad={is_ad_val})")
+            return None
+
+    # Filter by classification/type field
+    classification = str(ad.get('classification') or ad.get('type') or '').lower()
+    if classification in NOT_AD_CLASSIFICATIONS:
+        logger.info(f"[{slug}:{episode_id}] Skipping non-ad: "
+                    f"{start:.1f}s-{end:.1f}s (classification={classification})")
+        return None
+
+    # Extract sponsor/advertiser name using priority fields + pattern matching
+    # Try extract_sponsor_name first for a real sponsor name.
+    # If it returns the default, fall back to Claude's raw reason.
+    sponsor_name = _extract_sponsor_name(ad)
+    reason = sponsor_name
+    existing_reason = ad.get('reason')
+    if reason == 'Advertisement detected':
+        if existing_reason and isinstance(existing_reason, str) and len(existing_reason) > 3:
+            reason = existing_reason
+    elif existing_reason and isinstance(existing_reason, str) and len(existing_reason) > len(reason) + 5:
+        # Claude's reason is substantially more descriptive than the bare sponsor name
+        reason = existing_reason
+
+    # Extract description from Claude's response to enrich the reason
+    # Dynamic scan: check ALL non-structural string fields > 10 chars
+    # Skip 'reason' (already used above); duplication with sponsor handled at combine time
+    description = None
+    for key, val in ad.items():
+        if key.lower() in STRUCTURAL_FIELDS:
+            continue
+        if key == 'reason':
+            continue
+        if isinstance(val, str) and len(val) > 10:
+            # Prefer longer descriptive text over short values
+            if description is None or len(val) > len(description):
+                description = val
+    # Kept whole (#591); the old 300/150 caps put a literal
+    # "..." in the UI with no fuller text to expand to.
+    description = truncate(
+        _strip_continuation_prefix(description),
+        REASON_DESCRIPTION_MAX)
+
+    # Combine sponsor + description in reason field
+    if description:
+        if reason and reason != 'Advertisement detected':
+            # Avoid duplication: check if description is essentially the same text
+            if not _text_is_duplicate(reason, description):
+                description = _drop_leading(description, reason)
+                reason = f"{reason}: {description}" if description else reason
+        elif not reason or reason == 'Advertisement detected':
+            reason = description
+
+    # Normalize confidence to 0-1 range
+    raw_conf = ad.get('confidence', 0.8)
+    if isinstance(raw_conf, str):
+        mapped = CONFIDENCE_STRING_MAP.get(raw_conf.lower().strip())
+        if mapped is not None:
+            logger.debug(f"[{slug}:{episode_id}] Mapped string confidence '{raw_conf}' -> {mapped}")
+            raw_conf = mapped
+        else:
+            raw_conf = raw_conf.rstrip('%')
+    raw_conf = float(raw_conf)
+    norm_conf = raw_conf / 100.0 if raw_conf > 1.0 else raw_conf
+    norm_conf = min(1.0, max(0.0, norm_conf))
+
+    # Dynamic validation: require positive evidence this is an ad
+    # instead of blocklisting content indicators (which keeps growing)
+    duration = end - start
+    has_sponsor_field = any(
+        _singular(key) in _SPONSOR_FIELD_STEMS
+        and _get_valid_sponsor_value(val)
+        for key, val in ad.items()
+    )
+    has_known_sponsor = (
+        sponsor_service and
+        sponsor_service.find_sponsor_in_text(reason)
+    ) if reason else False
+    has_ad_language = mentions_advertising(reason)
+
+    if not has_sponsor_field and not has_known_sponsor and not has_ad_language:
+        # Low confidence + no evidence = reject regardless of duration
+        if norm_conf < LOW_CONFIDENCE:
+            logger.info(
+                f"[{slug}:{episode_id}] Rejecting low-confidence non-sponsor: "
+                f"{start:.1f}s-{end:.1f}s ({duration:.0f}s, conf={norm_conf:.0%}) - "
+                f"reason: {reason[:100] if reason else 'None'}"
+            )
+            return None
+        # No positive ad evidence -- apply duration gate
+        # Short segments (<CONTENT_DURATION_THRESHOLD) get benefit of doubt
+        # Long segments are almost certainly content descriptions
+        if duration >= CONTENT_DURATION_THRESHOLD:
+            logger.info(
+                f"[{slug}:{episode_id}] Rejecting suspected content: "
+                f"{start:.1f}s-{end:.1f}s ({duration:.0f}s) - "
+                f"no sponsor identified in reason: {reason[:100] if reason else 'None'}"
+            )
+            return None
+        # For shorter segments without evidence, log warning but allow through
+        if duration >= LOW_EVIDENCE_WARN_THRESHOLD:
+            logger.warning(
+                f"[{slug}:{episode_id}] Low-confidence ad (no sponsor found): "
+                f"{start:.1f}s-{end:.1f}s ({duration:.0f}s) - "
+                f"reason: {reason[:100] if reason else 'None'}"
+            )
+
+    logger.info(f"[{slug}:{episode_id}] Extracted ad: {start:.1f}s-{end:.1f}s, reason='{reason}', fields={list(ad.keys())}")
+    ad_entry = {
+        'start': start,
+        'end': end,
+        'confidence': norm_conf,
+        'reason': reason,
+        'end_text': _as_text(ad.get('end_text'))
+    }
+    # Store sponsor name separately for UI display
+    # (reuses sponsor_name captured above; ad is unmutated between)
+    if sponsor_name and sponsor_name != 'Advertisement detected':
+        ad_entry['sponsor'] = sponsor_name
+    # Pass the LLM's raw category through unvalidated; the
+    # merge seam normalizes it against SEGMENT_CATEGORIES.
+    resolved_category = resolve_ad_category(ad)
+    if resolved_category:
+        ad_entry['category'] = resolved_category
+    return ad_entry
+
+
 def parse_ads_from_response(response_text: str, slug: str = None,
                               episode_id: str = None,
                               sponsor_service=None) -> list[dict]:
@@ -272,86 +503,6 @@ def parse_ads_from_response(response_text: str, slug: str = None,
     Returns:
         List of validated ad dicts with start, end, confidence, reason, end_text
     """
-    def get_valid_value(value):
-        if not value:
-            return None
-        str_value = _flatten(value)
-        # A continuation note is window bookkeeping, not a sponsor; trimming
-        # the prefix and keeping the remainder minted labels like 'window'.
-        if _CONTINUATION_PREFIX_RE.match(str_value):
-            return None
-        if len(str_value) < 2:
-            return None
-        if str_value.lower() in INVALID_SPONSOR_VALUES:
-            return None
-        if len(str_value) > SPONSOR_MAX_NAME_CHARS:
-            return None
-        if is_sponsor_reasoning_rationale(str_value):
-            return None
-        return str_value
-
-    def _text_is_duplicate(a: str, b: str) -> bool:
-        """Check if two strings are essentially the same text.
-
-        Length has to be comparable first. A bare sponsor name is both a
-        prefix of its own description and a full word subset of it, so
-        without this "Box" swallowed the note explaining the read and left
-        the marker saying only "Box".
-        """
-        a_lower = a.lower().strip()
-        b_lower = b.lower().strip()
-        shorter, longer = sorted((a_lower, b_lower), key=len)
-        if not shorter or len(shorter) < len(longer) * DUPLICATE_MIN_LENGTH_RATIO:
-            return False
-        if longer.startswith(shorter):
-            return True
-        a_words = set(a_lower.split())
-        b_words = set(b_lower.split())
-        if not a_words or not b_words:
-            return False
-        overlap = len(a_words & b_words)
-        smaller = min(len(a_words), len(b_words))
-        return overlap / smaller > 0.8 if smaller > 0 else False
-
-    # Local alias for the SponsorService method - keeps call sites below short
-    # and avoids re-importing inside the closure.
-    extract_sponsor_from_text = SponsorService.extract_sponsor_from_reason
-
-    def extract_sponsor_name(ad: dict) -> str:
-        """Extract sponsor/advertiser name using priority fields, keywords, and dynamic scanning."""
-        for field in SPONSOR_PRIORITY_FIELDS:
-            value = get_valid_value(ad.get(field))
-            if value:
-                return value
-
-        for key in ad.keys():
-            key_lower = key.lower()
-            for keyword in SPONSOR_PATTERN_KEYWORDS:
-                if keyword in key_lower:
-                    value = get_valid_value(ad.get(key))
-                    if value:
-                        return value
-
-        priority_lower = {f.lower() for f in SPONSOR_PRIORITY_FIELDS}
-        for key, val in ad.items():
-            key_lower = key.lower()
-            if key_lower in STRUCTURAL_FIELDS or key_lower in priority_lower:
-                continue
-            if isinstance(val, str) and len(val) < 80:
-                value = get_valid_value(val)
-                if value:
-                    return value
-
-        for key, val in ad.items():
-            if key.lower() in STRUCTURAL_FIELDS:
-                continue
-            if isinstance(val, str) and len(val) > 10:
-                sponsor = extract_sponsor_from_text(val)
-                if sponsor:
-                    return sponsor
-
-        return 'Advertisement detected'
-
     try:
         ads, extraction_method = extract_json_ads_array(response_text, slug, episode_id)
 
@@ -400,142 +551,10 @@ def parse_ads_from_response(response_text: str, slug: str = None,
                 try:
                     start = parse_timestamp(start_val)
                     end = parse_timestamp(end_val)
-                    if end <= start:
-                        logger.warning(
-                            f"[{slug}:{episode_id}] Discarding ad candidate: "
-                            f"invalid range (start={start:.1f}s >= end={end:.1f}s) - "
-                            f"reason={str(ad.get('reason', ad.get('sponsor', '')))[:80]}"
-                        )
-                        continue
-                    # Filter out explicitly marked non-ads
-                    is_ad_val = ad.get('is_ad')
-                    if is_ad_val is not None:
-                        if str(is_ad_val).lower() in ('false', 'no', '0', 'none'):
-                            logger.info(f"[{slug}:{episode_id}] Skipping non-ad: "
-                                        f"{start:.1f}s-{end:.1f}s (is_ad={is_ad_val})")
-                            continue
-
-                    # Filter by classification/type field
-                    classification = str(ad.get('classification') or ad.get('type') or '').lower()
-                    if classification in NOT_AD_CLASSIFICATIONS:
-                        logger.info(f"[{slug}:{episode_id}] Skipping non-ad: "
-                                    f"{start:.1f}s-{end:.1f}s (classification={classification})")
-                        continue
-
-                    # Extract sponsor/advertiser name using priority fields + pattern matching
-                    # Try extract_sponsor_name first for a real sponsor name.
-                    # If it returns the default, fall back to Claude's raw reason.
-                    sponsor_name = extract_sponsor_name(ad)
-                    reason = sponsor_name
-                    existing_reason = ad.get('reason')
-                    if reason == 'Advertisement detected':
-                        if existing_reason and isinstance(existing_reason, str) and len(existing_reason) > 3:
-                            reason = existing_reason
-                    elif existing_reason and isinstance(existing_reason, str) and len(existing_reason) > len(reason) + 5:
-                        # Claude's reason is substantially more descriptive than the bare sponsor name
-                        reason = existing_reason
-
-                    # Extract description from Claude's response to enrich the reason
-                    # Dynamic scan: check ALL non-structural string fields > 10 chars
-                    # Skip 'reason' (already used above); duplication with sponsor handled at combine time
-                    description = None
-                    for key, val in ad.items():
-                        if key.lower() in STRUCTURAL_FIELDS:
-                            continue
-                        if key == 'reason':
-                            continue
-                        if isinstance(val, str) and len(val) > 10:
-                            # Prefer longer descriptive text over short values
-                            if description is None or len(val) > len(description):
-                                description = val
-                    # Kept whole (#591); the old 300/150 caps put a literal
-                    # "..." in the UI with no fuller text to expand to.
-                    description = truncate(
-                        _strip_continuation_prefix(description),
-                        REASON_DESCRIPTION_MAX)
-
-                    # Combine sponsor + description in reason field
-                    if description:
-                        if reason and reason != 'Advertisement detected':
-                            # Avoid duplication: check if description is essentially the same text
-                            if not _text_is_duplicate(reason, description):
-                                description = _drop_leading(description, reason)
-                                reason = f"{reason}: {description}" if description else reason
-                        elif not reason or reason == 'Advertisement detected':
-                            reason = description
-
-                    # Normalize confidence to 0-1 range
-                    raw_conf = ad.get('confidence', 0.8)
-                    if isinstance(raw_conf, str):
-                        mapped = CONFIDENCE_STRING_MAP.get(raw_conf.lower().strip())
-                        if mapped is not None:
-                            logger.debug(f"[{slug}:{episode_id}] Mapped string confidence '{raw_conf}' -> {mapped}")
-                            raw_conf = mapped
-                        else:
-                            raw_conf = raw_conf.rstrip('%')
-                    raw_conf = float(raw_conf)
-                    norm_conf = raw_conf / 100.0 if raw_conf > 1.0 else raw_conf
-                    norm_conf = min(1.0, max(0.0, norm_conf))
-
-                    # Dynamic validation: require positive evidence this is an ad
-                    # instead of blocklisting content indicators (which keeps growing)
-                    duration = end - start
-                    has_sponsor_field = any(
-                        _singular(key) in _SPONSOR_FIELD_STEMS
-                        and get_valid_value(val)
-                        for key, val in ad.items()
-                    )
-                    has_known_sponsor = (
-                        sponsor_service and
-                        sponsor_service.find_sponsor_in_text(reason)
-                    ) if reason else False
-                    has_ad_language = mentions_advertising(reason)
-
-                    if not has_sponsor_field and not has_known_sponsor and not has_ad_language:
-                        # Low confidence + no evidence = reject regardless of duration
-                        if norm_conf < LOW_CONFIDENCE:
-                            logger.info(
-                                f"[{slug}:{episode_id}] Rejecting low-confidence non-sponsor: "
-                                f"{start:.1f}s-{end:.1f}s ({duration:.0f}s, conf={norm_conf:.0%}) - "
-                                f"reason: {reason[:100] if reason else 'None'}"
-                            )
-                            continue
-                        # No positive ad evidence -- apply duration gate
-                        # Short segments (<CONTENT_DURATION_THRESHOLD) get benefit of doubt
-                        # Long segments are almost certainly content descriptions
-                        if duration >= CONTENT_DURATION_THRESHOLD:
-                            logger.info(
-                                f"[{slug}:{episode_id}] Rejecting suspected content: "
-                                f"{start:.1f}s-{end:.1f}s ({duration:.0f}s) - "
-                                f"no sponsor identified in reason: {reason[:100] if reason else 'None'}"
-                            )
-                            continue
-                        # For shorter segments without evidence, log warning but allow through
-                        if duration >= LOW_EVIDENCE_WARN_THRESHOLD:
-                            logger.warning(
-                                f"[{slug}:{episode_id}] Low-confidence ad (no sponsor found): "
-                                f"{start:.1f}s-{end:.1f}s ({duration:.0f}s) - "
-                                f"reason: {reason[:100] if reason else 'None'}"
-                            )
-
-                    logger.info(f"[{slug}:{episode_id}] Extracted ad: {start:.1f}s-{end:.1f}s, reason='{reason}', fields={list(ad.keys())}")
-                    ad_entry = {
-                        'start': start,
-                        'end': end,
-                        'confidence': norm_conf,
-                        'reason': reason,
-                        'end_text': _as_text(ad.get('end_text'))
-                    }
-                    # Store sponsor name separately for UI display
-                    # (reuses sponsor_name captured above; ad is unmutated between)
-                    if sponsor_name and sponsor_name != 'Advertisement detected':
-                        ad_entry['sponsor'] = sponsor_name
-                    # Pass the LLM's raw category through unvalidated; the
-                    # merge seam normalizes it against SEGMENT_CATEGORIES.
-                    resolved_category = resolve_ad_category(ad)
-                    if resolved_category:
-                        ad_entry['category'] = resolved_category
-                    valid_ads.append(ad_entry)
+                    ad_entry = _normalize_ad(
+                        ad, start, end, slug, episode_id, sponsor_service)
+                    if ad_entry is not None:
+                        valid_ads.append(ad_entry)
                 except ValueError as e:
                     logger.warning(f"[{slug}:{episode_id}] Skipping ad with invalid timestamp: {e}")
                     continue
@@ -545,6 +564,97 @@ def parse_ads_from_response(response_text: str, slug: str = None,
     except json.JSONDecodeError as e:
         logger.error(f"[{slug}:{episode_id}] Failed to parse JSON: {e}")
         return []
+
+
+def _int_field(obj: dict, keys: tuple[str, ...]):
+    """The first of ``keys`` present in ``obj``, coerced to int, or None if
+    absent or non-numeric. Exact key match only -- unlike the fuzzy
+    'start'/'end' substring matcher in ``parse_ads_from_response``, id fields
+    must never be guessed at, or ``start_id`` could be misread by a substring
+    match on 'start' as a timestamp."""
+    for key in keys:
+        if key in obj:
+            try:
+                return int(obj[key])
+            except (TypeError, ValueError):
+                return None
+    return None
+
+
+def parse_id_ads_from_response(response_text: str, slug: str = None,
+                                episode_id: str = None,
+                                sponsor_service=None) -> tuple[list[dict], bool]:
+    """Parse an ID-mode LLM response (issue: hushpod adoption).
+
+    Returns (ads, used_ids). used_ids is True when at least one object in
+    the response carries integer id fields; ads then hold 'start_id'/'end_id'
+    plus the usual fields (confidence, category, reason -- normalized later
+    by ``resolve_segment_id_ads``). used_ids False means the model ignored
+    the ID contract (some models do): the caller re-parses with
+    ``parse_ads_from_response`` so the window is not lost, at the cost of
+    approximate timestamps for that window.
+    """
+    try:
+        raw, _extraction_method = extract_json_ads_array(response_text, slug, episode_id)
+    except Exception:
+        return [], False
+    if raw is None or not isinstance(raw, list):
+        return [], False
+    raw = _flatten_ad_envelopes(raw)
+    if not raw:
+        return [], True  # explicit empty "no ads" answer is a valid ID answer
+
+    ads = []
+    any_ids = False
+    for obj in raw:
+        if not isinstance(obj, dict):
+            continue
+        sid_lo = _int_field(obj, ('start_id', 'startid', 'start_segment_id'))
+        sid_hi = _int_field(obj, ('end_id', 'endid', 'end_segment_id'))
+        if sid_lo is None or sid_hi is None:
+            continue
+        any_ids = True
+        ad = dict(obj)
+        ad['start_id'], ad['end_id'] = sid_lo, sid_hi
+        # An id-mode object should never carry timestamp fields, but strip
+        # them defensively so a stray 'start'/'end' can't leak through
+        # resolve_segment_id_ads and be mistaken for the resolved value.
+        ad.pop('start', None)
+        ad.pop('end', None)
+        ads.append(ad)
+    return (ads, True) if any_ids else ([], False)
+
+
+def resolve_segment_id_ads(ads: list[dict], window_segments: list[dict],
+                            slug: str = None, episode_id: str = None,
+                            sponsor_service=None) -> list[dict]:
+    """Map start_id/end_id to exact segment start/end seconds, then run the
+    resolved ads through the same post-parse normalization
+    ``parse_ads_from_response`` applies (confidence normalization, sponsor
+    extraction, degenerate-range rejection, evidence gate, category
+    resolution) via ``_normalize_ad``.
+
+    Unknown ids drop the detection (an invented id is detectable; an
+    invented timestamp is not -- that asymmetry is the point of this mode).
+    """
+    by_sid = {seg['sid']: seg for seg in window_segments if 'sid' in seg}
+    resolved = []
+    for ad in ads:
+        lo = min(ad['start_id'], ad['end_id'])
+        hi = max(ad['start_id'], ad['end_id'])
+        seg_lo, seg_hi = by_sid.get(lo), by_sid.get(hi)
+        if seg_lo is None or seg_hi is None:
+            logger.warning(
+                f"[{slug}:{episode_id}] Dropping detection with out-of-window "
+                f"segment ids {lo}-{hi}")
+            continue
+        raw = {k: v for k, v in ad.items() if k not in ('start_id', 'end_id')}
+        start = seg_lo['start']
+        end = seg_hi['end']
+        ad_entry = _normalize_ad(raw, start, end, slug, episode_id, sponsor_service)
+        if ad_entry is not None:
+            resolved.append(ad_entry)
+    return resolved
 
 
 # =============================================================================

--- a/src/ad_detector/prompts.py
+++ b/src/ad_detector/prompts.py
@@ -132,7 +132,7 @@ def format_window_prompt(
     window_start: float,
     window_end: float,
     audio_context: str = "",
-    extra_rules: str = "",
+    addressing_mode: str = "timestamps",
 ) -> str:
     """Build the user prompt for a single ad-detection window.
 
@@ -140,25 +140,35 @@ def format_window_prompt(
     benchmark can call this without DB or audio-analysis state. Production
     callers assemble both then pass them in.
 
-    `extra_rules` is appended last (after the window context); it carries
-    mode-specific window rules (e.g. segment-id addressing, issue: hushpod
-    adoption) without disturbing the benchmark's existing calls, which never
-    pass it and get "".
+    `addressing_mode` selects the window-context rules appended after the
+    header: 'timestamps' (default) emits the original three bullets telling
+    the model to use absolute timestamps, byte-identical to before this
+    parameter existed; 'segment_ids' (issue: hushpod adoption) emits
+    SEGMENT_ID_WINDOW_RULES instead of those bullets -- never both, so the
+    prompt never tells the model to use and never use timestamps in the same
+    message. Callers that never pass it (benchmark, keep-content windows)
+    get 'timestamps' behavior unchanged.
     """
     transcript = "\n".join(transcript_lines)
-    window_context = f"""
-
-=== WINDOW {window_index + 1}/{total_windows}: {window_start/60:.1f}-{window_end/60:.1f} minutes ===
-- Use absolute timestamps from transcript (as shown in brackets)
-- If an ad starts before this window, use the first timestamp with note "continues from previous"
-- If an ad extends past this window, use {window_end:.1f} with note "continues in next"
-"""
+    header = (
+        f"\n\n=== WINDOW {window_index + 1}/{total_windows}: "
+        f"{window_start/60:.1f}-{window_end/60:.1f} minutes ==="
+    )
+    if addressing_mode == "segment_ids":
+        rules = SEGMENT_ID_WINDOW_RULES(window_end)
+    else:
+        rules = (
+            "\n- Use absolute timestamps from transcript (as shown in brackets)"
+            "\n- If an ad starts before this window, use the first timestamp with note \"continues from previous\""
+            f"\n- If an ad extends past this window, use {window_end:.1f} with note \"continues in next\"\n"
+        )
+    window_context = header + rules
     return USER_PROMPT_TEMPLATE.format(
         podcast_name=podcast_name,
         episode_title=episode_title,
         description_section=description_section,
         transcript=transcript,
-    ) + audio_context + window_context + extra_rules
+    ) + audio_context + window_context
 
 
 SEGMENT_ID_SYSTEM_SECTION = """

--- a/src/ad_reviewer.py
+++ b/src/ad_reviewer.py
@@ -20,6 +20,7 @@ from config import (
     AUDIO_CUE_TYPE_CONTENT_TRANSITION,
     is_template_cue,
     MIN_AD_DURATION_FOR_REMOVAL,
+    coerce_bool_setting,
 )
 from audio_enforcer import content_anchors
 from database import DEFAULT_REVIEW_PROMPT, DEFAULT_RESURRECT_PROMPT
@@ -738,9 +739,10 @@ class AdReviewer:
 
         max_shift = self._read_max_boundary_shift()
         model = self._resolve_model(pass_model)
-        sponsor_block = format_sponsor_block(self._sponsor_list_or_empty())
-        review_prompt = self._render_review_prompt(max_shift, sponsor_block)
-        resurrect_prompt = self._render_resurrect_prompt(sponsor_block)
+        review_prompt = self._render_review_prompt(
+            max_shift, self._sponsor_block_for('seed_sponsors_reviewer'))
+        resurrect_prompt = self._render_resurrect_prompt(
+            self._sponsor_block_for('seed_sponsors_resurrect'))
 
         result = ReviewResult(verdicts=[])
 
@@ -1497,6 +1499,24 @@ class AdReviewer:
         except Exception as e:
             logger.warning(f"reviewer sponsor list lookup failed: {e}")
             return ""
+
+    def _seed_sponsors_enabled(self, toggle_key: str) -> bool:
+        """Fails open (True): a missing or unreadable setting must not
+        silently strip the sponsor block."""
+        try:
+            value = self.db.get_setting(toggle_key)
+        except Exception as e:
+            logger.warning(f"Could not read {toggle_key}: {e}")
+            return True
+        if value is None:
+            return True
+        return coerce_bool_setting(value)
+
+    def _sponsor_block_for(self, toggle_key: str) -> str:
+        """Sponsor block for one reviewer prompt, honoring its toggle."""
+        if not self._seed_sponsors_enabled(toggle_key):
+            return ""
+        return format_sponsor_block(self._sponsor_list_or_empty())
 
     def _read_setting(self, key: str) -> str | None:
         try:

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -209,6 +209,8 @@ def get_settings():
         settings, 'detect_show_segments', registry_default('detect_show_segments')))
     text_recurrence_hints = coerce_bool_setting(_setting_value(
         settings, 'text_recurrence_hints', registry_default('text_recurrence_hints')))
+    ad_addressing_mode = _setting_value(
+        settings, 'ad_addressing_mode', registry_default('ad_addressing_mode'))
     seed_sponsors = {
         key: coerce_bool_setting(_setting_value(
             settings, key, registry_default(key)))
@@ -539,6 +541,8 @@ def get_settings():
             'detect_show_segments', detect_show_segments_default),
         'textRecurrenceHints': _sv(
             'text_recurrence_hints', text_recurrence_hints),
+        'adAddressingMode': _sv(
+            'ad_addressing_mode', ad_addressing_mode),
         'seedSponsorsDetection': _sv(
             'seed_sponsors_detection', seed_sponsors['seed_sponsors_detection']),
         'seedSponsorsVerification': _sv(
@@ -669,6 +673,14 @@ def update_ad_detection_settings():
         return error_response('Request body required', 400)
 
     db = get_database()
+
+    if 'adAddressingMode' in data:
+        value = str(data['adAddressingMode'] or '').strip().lower()
+        if value not in ('timestamps', 'segment_ids'):
+            return error_response(
+                'adAddressingMode must be "timestamps" or "segment_ids"', 400)
+        db.set_setting('ad_addressing_mode', value, is_default=False)
+        logger.info(f"Updated ad_addressing_mode to: {value}")
 
     phases = (
         _apply_prompt_fields,

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -207,6 +207,12 @@ def get_settings():
         only_expose_processed_value.lower() in ('true', '1', 'yes'))
     detect_show_segments_default = coerce_bool_setting(_setting_value(
         settings, 'detect_show_segments', registry_default('detect_show_segments')))
+    seed_sponsors = {
+        key: coerce_bool_setting(_setting_value(
+            settings, key, registry_default(key)))
+        for key in ('seed_sponsors_detection', 'seed_sponsors_verification',
+                    'seed_sponsors_reviewer', 'seed_sponsors_resurrect')
+    }
     process_new_episodes_first = coerce_bool_setting(_setting_value(
         settings, 'process_new_episodes_first',
         registry_default('process_new_episodes_first')))
@@ -529,6 +535,14 @@ def get_settings():
             'only_expose_processed_default', only_expose_processed_default),
         'detectShowSegments': _sv(
             'detect_show_segments', detect_show_segments_default),
+        'seedSponsorsDetection': _sv(
+            'seed_sponsors_detection', seed_sponsors['seed_sponsors_detection']),
+        'seedSponsorsVerification': _sv(
+            'seed_sponsors_verification', seed_sponsors['seed_sponsors_verification']),
+        'seedSponsorsReviewer': _sv(
+            'seed_sponsors_reviewer', seed_sponsors['seed_sponsors_reviewer']),
+        'seedSponsorsResurrect': _sv(
+            'seed_sponsors_resurrect', seed_sponsors['seed_sponsors_resurrect']),
         'processNewEpisodesFirst': _sv(
             'process_new_episodes_first', process_new_episodes_first),
         'artworkWatermarkEnabled': _sv(
@@ -831,6 +845,17 @@ def _apply_processing_flags(db, data):
         value = 'true' if data['detectShowSegments'] else 'false'
         db.set_setting('detect_show_segments', value, is_default=False)
         logger.info(f"Updated detect-show-segments default to: {value}")
+
+    for payload_key, db_key in (
+        ('seedSponsorsDetection', 'seed_sponsors_detection'),
+        ('seedSponsorsVerification', 'seed_sponsors_verification'),
+        ('seedSponsorsReviewer', 'seed_sponsors_reviewer'),
+        ('seedSponsorsResurrect', 'seed_sponsors_resurrect'),
+    ):
+        if payload_key in data:
+            value = 'true' if data[payload_key] else 'false'
+            db.set_setting(db_key, value, is_default=False)
+            logger.info(f"Updated {db_key} to: {value}")
 
     if 'processNewEpisodesFirst' in data:
         value = 'true' if data['processNewEpisodesFirst'] else 'false'

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -207,6 +207,8 @@ def get_settings():
         only_expose_processed_value.lower() in ('true', '1', 'yes'))
     detect_show_segments_default = coerce_bool_setting(_setting_value(
         settings, 'detect_show_segments', registry_default('detect_show_segments')))
+    text_recurrence_hints = coerce_bool_setting(_setting_value(
+        settings, 'text_recurrence_hints', registry_default('text_recurrence_hints')))
     seed_sponsors = {
         key: coerce_bool_setting(_setting_value(
             settings, key, registry_default(key)))
@@ -535,6 +537,8 @@ def get_settings():
             'only_expose_processed_default', only_expose_processed_default),
         'detectShowSegments': _sv(
             'detect_show_segments', detect_show_segments_default),
+        'textRecurrenceHints': _sv(
+            'text_recurrence_hints', text_recurrence_hints),
         'seedSponsorsDetection': _sv(
             'seed_sponsors_detection', seed_sponsors['seed_sponsors_detection']),
         'seedSponsorsVerification': _sv(
@@ -845,6 +849,11 @@ def _apply_processing_flags(db, data):
         value = 'true' if data['detectShowSegments'] else 'false'
         db.set_setting('detect_show_segments', value, is_default=False)
         logger.info(f"Updated detect-show-segments default to: {value}")
+
+    if 'textRecurrenceHints' in data:
+        value = 'true' if data['textRecurrenceHints'] else 'false'
+        db.set_setting('text_recurrence_hints', value, is_default=False)
+        logger.info(f"Updated text-recurrence-hints to: {value}")
 
     for payload_key, db_key in (
         ('seedSponsorsDetection', 'seed_sponsors_detection'),

--- a/src/database/episodes.py
+++ b/src/database/episodes.py
@@ -823,7 +823,8 @@ class EpisodeMixin:
         )
         return [dict(row) for row in cursor.fetchall()]
 
-    _EPISODE_JSON_COLS = frozenset({'ad_markers_json', 'audio_analysis_json'})
+    _EPISODE_JSON_COLS = frozenset({'ad_markers_json', 'audio_analysis_json',
+                                    'original_segments_json'})
 
     def _get_recent_episode_json_col(self, slug: str, col: str,
                                      exclude_episode_id: str | None = None,
@@ -872,6 +873,15 @@ class EpisodeMixin:
         """
         return self._get_recent_episode_json_col(
             slug, 'audio_analysis_json', exclude_episode_id, limit, min_duration)
+
+    def get_recent_original_segments(self, slug: str,
+                                     exclude_episode_id: str | None = None,
+                                     limit: int = 5) -> list[list[dict]]:
+        """Original (pre-cut) Whisper segments of the feed's most recent
+        processed episodes, newest first, for text recurrence."""
+        rows = self._get_recent_episode_json_col(
+            slug, 'original_segments_json', exclude_episode_id, limit)
+        return [json.loads(r['original_segments_json']) for r in rows]
 
     def get_episodes_by_ids(self, slug: str, episode_ids: list[str]) -> list[dict]:
         """Get multiple episodes by slug and episode_ids in a single query."""

--- a/src/database/settings.py
+++ b/src/database/settings.py
@@ -306,6 +306,12 @@ SETTINGS_REGISTRY: dict[str, SettingSpec] = {
     'text_recurrence_hints': SettingSpec(
         default='false', seeded=True, resettable=False,
         payload_key='textRecurrenceHints', payload_kind='bool'),
+    # Experimental: LLM addresses ads by transcript segment id instead of
+    # absolute timestamps. Default preserves current behavior; the benchmark
+    # A/B (F0.5) decides whether the default ever flips.
+    'ad_addressing_mode': SettingSpec(
+        default='timestamps', seeded=True, resettable=False,
+        payload_key='adAddressingMode'),
     # Whether the RSS-refresh enqueue path boosts episodes published within
     # FRESH_WINDOW_HOURS ahead of the rest of the auto-process queue.
     'process_new_episodes_first': SettingSpec(

--- a/src/database/settings.py
+++ b/src/database/settings.py
@@ -301,6 +301,11 @@ SETTINGS_REGISTRY: dict[str, SettingSpec] = {
     'seed_sponsors_resurrect': SettingSpec(
         default='true', seeded=True, resettable=False,
         payload_key='seedSponsorsResurrect', payload_kind='bool'),
+    # Cross-episode text recurrence hint (off until benchmarked; see
+    # docs/superpowers/specs/2026-08-25-hushpod-adoption-design.md).
+    'text_recurrence_hints': SettingSpec(
+        default='false', seeded=True, resettable=False,
+        payload_key='textRecurrenceHints', payload_kind='bool'),
     # Whether the RSS-refresh enqueue path boosts episodes published within
     # FRESH_WINDOW_HOURS ahead of the rest of the auto-process queue.
     'process_new_episodes_first': SettingSpec(

--- a/src/database/settings.py
+++ b/src/database/settings.py
@@ -286,6 +286,21 @@ SETTINGS_REGISTRY: dict[str, SettingSpec] = {
     'detect_show_segments': SettingSpec(
         default='0', seeded=True, resettable=False,
         payload_key='detectShowSegments', payload_kind='bool'),
+    # Seed-sponsors toggles (issue: hushpod adoption). One per prompt that
+    # takes the dynamic sponsor block; off renders that prompt with an empty
+    # {sponsor_database}. All default on to preserve current behavior.
+    'seed_sponsors_detection': SettingSpec(
+        default='true', seeded=True, resettable=False,
+        payload_key='seedSponsorsDetection', payload_kind='bool'),
+    'seed_sponsors_verification': SettingSpec(
+        default='true', seeded=True, resettable=False,
+        payload_key='seedSponsorsVerification', payload_kind='bool'),
+    'seed_sponsors_reviewer': SettingSpec(
+        default='true', seeded=True, resettable=False,
+        payload_key='seedSponsorsReviewer', payload_kind='bool'),
+    'seed_sponsors_resurrect': SettingSpec(
+        default='true', seeded=True, resettable=False,
+        payload_key='seedSponsorsResurrect', payload_kind='bool'),
     # Whether the RSS-refresh enqueue path boosts episodes published within
     # FRESH_WINDOW_HOURS ahead of the rest of the auto-process queue.
     'process_new_episodes_first': SettingSpec(

--- a/src/main_app/processing.py
+++ b/src/main_app/processing.py
@@ -84,6 +84,7 @@ from config import (
     TERMINAL_SNAP_WINDOW_SECONDS,
     VETO_MIN_CUT_SECONDS,
     ModelNotConfiguredError,
+    coerce_bool_setting,
 )
 from database.settings import registry_get_default
 from embedded_chapters import embed_chapters, probe_chapters, MIN_CHAPTER_SECONDS
@@ -101,6 +102,7 @@ from llm_client import (
 from offline_queue import is_offline_queue_enabled
 from utils.circuit_breaker import CircuitBreakerOpen
 from positional_prior import format_prior_hint, load_positional_prior
+from text_recurrence import find_recurring_spans
 import run_log
 from reprocess_modes import (
     REPROCESS_MODE_NEEDS_TRANSCRIPT, clear_episode_for_mode,
@@ -725,7 +727,7 @@ def _detect_ads_first_pass(ctx, segments, audio_path,
                             keep_content=None, skip_llm=False,
                             force_create_from_pairs=False,
                             strict_pair_roles=False, episode_duration=0.0,
-                            run_stats=None):
+                            run_stats=None, recurrence_spans=None):
     """Pipeline stage: Run first-pass Claude ad detection.
 
     ``keep_content``: None lets the detector resolve the per-feed mode from
@@ -737,6 +739,8 @@ def _detect_ads_first_pass(ctx, segments, audio_path,
     guard when transcription (and its segment list) is skipped.
     ``run_stats``: caller's run_stats dict; stamped with detection_degraded
     when pass 1 fails but publishes on pattern/cross-fetch markers alone.
+    ``recurrence_spans``: optional cross-episode text-recurrence spans
+    (hushpod adoption); rendered per-window, pass-1 only.
 
     Returns (first_pass_ads, first_pass_count, ad_result).
     """
@@ -755,6 +759,7 @@ def _detect_ads_first_pass(ctx, segments, audio_path,
         cancel_event=cancel_event,
         ctx=ctx,
         positional_prior_hint=positional_prior_hint,
+        recurrence_spans=recurrence_spans,
         keep_content=keep_content,
         skip_llm=skip_llm,
     )
@@ -4320,6 +4325,24 @@ def process_episode(slug: str, episode_id: str, episode_url: str,
                 positional_prior = load_positional_prior(db, slug, episode_id,
                                                          episode_duration)
 
+                # Cross-episode text recurrence hint (off until benchmarked;
+                # see docs/superpowers/specs/2026-08-25-hushpod-adoption-design.md).
+                recurrence_spans = None
+                if coerce_bool_setting(db.get_setting('text_recurrence_hints') or 'false'):
+                    try:
+                        priors = db.get_recent_original_segments(
+                            slug, exclude_episode_id=episode_id, limit=5)
+                        recurrence_spans = find_recurring_spans(segments, priors)
+                        if recurrence_spans:
+                            audio_logger.info(
+                                f"[{slug}:{episode_id}] Text recurrence: "
+                                f"{len(recurrence_spans)} recurring span(s) "
+                                f"from {len(priors)} prior episode(s)")
+                    except Exception as e:
+                        audio_logger.warning(
+                            f"[{slug}:{episode_id}] Text recurrence failed, "
+                            f"continuing without hint: {e}")
+
                 # Stage 3: First-pass detection
                 first_pass_ads, first_pass_count, ad_result = _detect_ads_first_pass(
                     ctx, segments, audio_path,
@@ -4328,6 +4351,7 @@ def process_episode(slug: str, episode_id: str, episode_url: str,
                     cancel_event=cancel_event,
                     positional_prior_hint=format_prior_hint(positional_prior,
                                                             episode_duration),
+                    recurrence_spans=recurrence_spans,
                     dai_differential=dai_differential,
                     # None = resolve fresh from the DB at detection time, so a
                     # detection_mode toggle during download/transcription is honored.

--- a/src/text_recurrence.py
+++ b/src/text_recurrence.py
@@ -55,24 +55,32 @@ def find_recurring_spans(segments, prior_segment_lists):
     words = [w for w, _ in tokens]
     recurring = [False] * len(tokens)
     for i in range(len(tokens) - SHINGLE_SIZE + 1):
-        # Only mark shingles entirely within a single segment as recurring
-        seg_indices = [seg_idx for _, seg_idx in tokens[i:i + SHINGLE_SIZE]]
-        if len(set(seg_indices)) == 1:  # All words from the same segment
-            shingle = ' '.join(words[i:i + SHINGLE_SIZE])
-            hits = sum(1 for ps in prior_shingles if shingle in ps)
-            if hits >= MIN_PRIOR_EPISODES:
-                for j in range(i, i + SHINGLE_SIZE):
-                    recurring[j] = True
+        shingle = ' '.join(words[i:i + SHINGLE_SIZE])
+        hits = sum(1 for ps in prior_shingles if shingle in ps)
+        if hits >= MIN_PRIOR_EPISODES:
+            for j in range(i, i + SHINGLE_SIZE):
+                recurring[j] = True
 
     # Roll token marks up to segments by word coverage.
+    # Short segments (< SHINGLE_SIZE words) require 100% coverage to avoid
+    # false positives from connector-phrase bleed across segment boundaries.
+    # Longer segments use standard SEGMENT_COVERAGE threshold.
     total = [0] * len(segments)
     hit = [0] * len(segments)
     for (_, seg_idx), is_rec in zip(tokens, recurring, strict=True):
         total[seg_idx] += 1
         if is_rec:
             hit[seg_idx] += 1
-    seg_recurring = [t > 0 and h / t >= SEGMENT_COVERAGE
-                     for t, h in zip(total, hit, strict=True)]
+    seg_recurring = []
+    for seg_idx, (t, h) in enumerate(zip(total, hit, strict=True)):
+        if t == 0:
+            seg_recurring.append(False)
+        elif t < SHINGLE_SIZE:
+            # Short segment: must be 100% covered
+            seg_recurring.append(h == t)
+        else:
+            # Long segment: standard coverage threshold
+            seg_recurring.append(h / t >= SEGMENT_COVERAGE)
 
     # Merge adjacent recurring segments, bridging small gaps.
     spans = []

--- a/src/text_recurrence.py
+++ b/src/text_recurrence.py
@@ -1,0 +1,120 @@
+"""Cross-episode text recurrence (hushpod adoption, spec 2026-08-25).
+
+Formulaic shows repeat spoken boilerplate near-verbatim every episode
+(intro spiels, disclaimers, credits) in wording even when the audio is
+re-recorded, so audio fingerprints miss it. This module finds spans of the
+current transcript whose 8-word shingles appear in at least 2 prior
+episodes. Output feeds the pass-1 prompt as a hint only; nothing is ever
+cut on text recurrence alone.
+
+Pure functions, no Flask or DB imports (unit tests import directly, same
+convention as split_planning.py).
+"""
+import re
+
+SHINGLE_SIZE = 8
+MIN_PRIOR_EPISODES = 2
+SEGMENT_COVERAGE = 0.5
+MAX_GAP_SEGMENTS = 1
+MIN_SPAN_SECONDS = 5.0
+MAX_HINT_SPANS = 12
+SNIPPET_CHARS = 160
+
+_WORD_RE = re.compile(r'[a-z0-9]+')
+
+
+def _tokenize(segments):
+    """Lowercased words tagged with the index of the segment they came from."""
+    tokens = []
+    for idx, seg in enumerate(segments):
+        for word in _WORD_RE.findall(seg.get('text', '').lower()):
+            tokens.append((word, idx))
+    return tokens
+
+
+def _shingle_set(segments):
+    """Distinct SHINGLE_SIZE-word shingles in one episode (set-deduped, so
+    repetition inside a single episode cannot satisfy the cross-episode
+    threshold)."""
+    words = [w for w, _ in _tokenize(segments)]
+    return {' '.join(words[i:i + SHINGLE_SIZE])
+            for i in range(len(words) - SHINGLE_SIZE + 1)}
+
+
+def find_recurring_spans(segments, prior_segment_lists):
+    """Spans of `segments` whose wording recurs in >= MIN_PRIOR_EPISODES of
+    `prior_segment_lists`. Fewer than MIN_PRIOR_EPISODES priors: no spans
+    (the threshold is never relaxed)."""
+    if len(prior_segment_lists) < MIN_PRIOR_EPISODES or not segments:
+        return []
+    prior_shingles = [_shingle_set(p) for p in prior_segment_lists]
+
+    tokens = _tokenize(segments)
+    if len(tokens) < SHINGLE_SIZE:
+        return []
+    words = [w for w, _ in tokens]
+    recurring = [False] * len(tokens)
+    for i in range(len(tokens) - SHINGLE_SIZE + 1):
+        # Only mark shingles entirely within a single segment as recurring
+        seg_indices = [seg_idx for _, seg_idx in tokens[i:i + SHINGLE_SIZE]]
+        if len(set(seg_indices)) == 1:  # All words from the same segment
+            shingle = ' '.join(words[i:i + SHINGLE_SIZE])
+            hits = sum(1 for ps in prior_shingles if shingle in ps)
+            if hits >= MIN_PRIOR_EPISODES:
+                for j in range(i, i + SHINGLE_SIZE):
+                    recurring[j] = True
+
+    # Roll token marks up to segments by word coverage.
+    total = [0] * len(segments)
+    hit = [0] * len(segments)
+    for (_, seg_idx), is_rec in zip(tokens, recurring, strict=True):
+        total[seg_idx] += 1
+        if is_rec:
+            hit[seg_idx] += 1
+    seg_recurring = [t > 0 and h / t >= SEGMENT_COVERAGE
+                     for t, h in zip(total, hit, strict=True)]
+
+    # Merge adjacent recurring segments, bridging small gaps.
+    spans = []
+    run_start = None
+    gap = 0
+    for idx, flag in enumerate(seg_recurring + [False]):
+        if flag:
+            if run_start is None:
+                run_start = idx
+            gap = 0
+        elif run_start is not None:
+            gap += 1
+            if gap > MAX_GAP_SEGMENTS or idx >= len(seg_recurring):
+                run_end = min(idx - gap, len(seg_recurring) - 1)
+                spans.append((run_start, run_end))
+                run_start = None
+                gap = 0
+    result = []
+    for lo, hi in spans:
+        start = segments[lo]['start']
+        end = segments[hi]['end']
+        if end - start < MIN_SPAN_SECONDS:
+            continue
+        text = ' '.join(s.get('text', '') for s in segments[lo:hi + 1]).strip()
+        result.append({'start': start, 'end': end, 'text': text})
+    return result
+
+
+def format_recurrence_hint(spans, window_start, window_end):
+    """Prompt block listing recurring spans that overlap this window, or ""."""
+    in_window = [s for s in spans
+                 if s['end'] > window_start and s['start'] < window_end]
+    if not in_window:
+        return ""
+    lines = [
+        f"- {s['start']:.1f}s to {s['end']:.1f}s: \"{s['text'][:SNIPPET_CHARS]}\""
+        for s in in_window[:MAX_HINT_SPANS]
+    ]
+    return (
+        "\n\nRECURRING BOILERPLATE (wording repeats near-verbatim in previous "
+        "episodes of this show, so these spans are almost certainly recurring "
+        "intro/outro/credits/housekeeping rather than unique content; if part "
+        "of a span is a sponsor read or promotional plug, report that part as "
+        "an ad):\n" + "\n".join(lines) + "\n"
+    )

--- a/src/text_recurrence.py
+++ b/src/text_recurrence.py
@@ -72,7 +72,7 @@ def find_recurring_spans(segments, prior_segment_lists):
         if is_rec:
             hit[seg_idx] += 1
     seg_recurring = []
-    for seg_idx, (t, h) in enumerate(zip(total, hit, strict=True)):
+    for t, h in zip(total, hit, strict=True):
         if t == 0:
             seg_recurring.append(False)
         elif t < SHINGLE_SIZE:

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -109,7 +109,7 @@ def is_sponsor_reasoning_rationale(text) -> bool:
     that should hold a brand name or ad description.
 
     Single source of truth for the 2.5.11 sponsor-field guard
-    (ad_detector/prompts.py:get_valid_value), the 2.5.13 verification-miss
+    (ad_detector/prompts.py:_get_valid_sponsor_value), the 2.5.13 verification-miss
     `reason` filter (pattern_service.record_verification_misses), and the
     `_cleanup_low_mention_patterns` migration.
     """

--- a/tests/integration/test_seed_sponsors_settings_api.py
+++ b/tests/integration/test_seed_sponsors_settings_api.py
@@ -39,3 +39,19 @@ def test_seed_sponsors_roundtrip(app_client):
     data = app_client.get('/api/v1/settings').get_json()
     assert data['seedSponsorsReviewer']['value'] is False
     assert data['seedSponsorsDetection']['value'] is True
+
+
+def test_text_recurrence_hints_default_false(app_client):
+    _authed(app_client)
+    data = app_client.get('/api/v1/settings').get_json()
+    assert data['textRecurrenceHints']['value'] is False
+
+
+def test_text_recurrence_hints_roundtrip(app_client):
+    _authed(app_client)
+    resp = app_client.put('/api/v1/settings/ad-detection',
+                          json={'textRecurrenceHints': True},
+                          headers=_csrf_headers(app_client))
+    assert resp.status_code == 200
+    data = app_client.get('/api/v1/settings').get_json()
+    assert data['textRecurrenceHints']['value'] is True

--- a/tests/integration/test_seed_sponsors_settings_api.py
+++ b/tests/integration/test_seed_sponsors_settings_api.py
@@ -55,3 +55,30 @@ def test_text_recurrence_hints_roundtrip(app_client):
     assert resp.status_code == 200
     data = app_client.get('/api/v1/settings').get_json()
     assert data['textRecurrenceHints']['value'] is True
+
+
+def test_ad_addressing_mode_default_timestamps(app_client):
+    _authed(app_client)
+    data = app_client.get('/api/v1/settings').get_json()
+    assert data['adAddressingMode']['value'] == 'timestamps'
+
+
+def test_ad_addressing_mode_roundtrip(app_client):
+    _authed(app_client)
+    resp = app_client.put('/api/v1/settings/ad-detection',
+                          json={'adAddressingMode': 'segment_ids'},
+                          headers=_csrf_headers(app_client))
+    assert resp.status_code == 200
+    data = app_client.get('/api/v1/settings').get_json()
+    assert data['adAddressingMode']['value'] == 'segment_ids'
+
+
+def test_ad_addressing_mode_rejects_bogus_value(app_client):
+    _authed(app_client)
+    before = app_client.get('/api/v1/settings').get_json()['adAddressingMode']['value']
+    resp = app_client.put('/api/v1/settings/ad-detection',
+                          json={'adAddressingMode': 'bogus'},
+                          headers=_csrf_headers(app_client))
+    assert resp.status_code == 400
+    data = app_client.get('/api/v1/settings').get_json()
+    assert data['adAddressingMode']['value'] == before

--- a/tests/integration/test_seed_sponsors_settings_api.py
+++ b/tests/integration/test_seed_sponsors_settings_api.py
@@ -1,0 +1,41 @@
+"""Integration tests for the seed-sponsors toggle settings API exposure
+and PUT persistence (hushpod adoption)."""
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
+os.environ.setdefault('MINUSPOD_DATA_DIR', tempfile.mkdtemp(prefix='ss-api-test-'))
+
+
+def _authed(client):
+    with client.session_transaction() as sess:
+        sess['authenticated'] = True
+    client.get('/api/v1/auth/status')
+
+
+def _csrf_headers(client):
+    csrf = None
+    for cookie in client._cookies.values():
+        if cookie.key == 'minuspod_csrf':
+            csrf = cookie.value
+    return {'X-CSRF-Token': csrf} if csrf else {}
+
+
+def test_seed_sponsors_defaults_true(app_client):
+    _authed(app_client)
+    data = app_client.get('/api/v1/settings').get_json()
+    for key in ('seedSponsorsDetection', 'seedSponsorsVerification',
+                'seedSponsorsReviewer', 'seedSponsorsResurrect'):
+        assert data[key]['value'] is True
+
+
+def test_seed_sponsors_roundtrip(app_client):
+    _authed(app_client)
+    resp = app_client.put('/api/v1/settings/ad-detection',
+                          json={'seedSponsorsReviewer': False},
+                          headers=_csrf_headers(app_client))
+    assert resp.status_code == 200
+    data = app_client.get('/api/v1/settings').get_json()
+    assert data['seedSponsorsReviewer']['value'] is False
+    assert data['seedSponsorsDetection']['value'] is True

--- a/tests/unit/test_prompt_render.py
+++ b/tests/unit/test_prompt_render.py
@@ -78,18 +78,24 @@ def test_get_static_system_prompt_substitutes_seed_sponsors():
 def test_render_with_sponsors_empty_list_drops_block():
     """When the dynamic sponsor list is empty, no header should appear."""
     from ad_detector import AdDetector
+    from unittest.mock import MagicMock
     detector = AdDetector.__new__(AdDetector)
     # Bypass the sponsor_service property by stubbing the helper directly
     detector._get_sponsor_list_safely = lambda: ''
-    out = detector._render_with_sponsors('Body{sponsor_database}END')
+    detector.db = MagicMock()
+    detector.db.get_setting.return_value = 'true'
+    out = detector._render_with_sponsors('Body{sponsor_database}END', 'seed_sponsors_detection')
     assert out == 'BodyEND'
 
 
 def test_render_with_sponsors_non_empty_list_inserts_block():
     from ad_detector import AdDetector
+    from unittest.mock import MagicMock
     detector = AdDetector.__new__(AdDetector)
     detector._get_sponsor_list_safely = lambda: 'AG1, Squarespace'
-    out = detector._render_with_sponsors('Body{sponsor_database}END')
+    detector.db = MagicMock()
+    detector.db.get_setting.return_value = 'true'
+    out = detector._render_with_sponsors('Body{sponsor_database}END', 'seed_sponsors_detection')
     assert 'DYNAMIC SPONSOR DATABASE' in out
     assert 'AG1, Squarespace' in out
     assert 'Body' in out and 'END' in out

--- a/tests/unit/test_seed_sponsors_toggles.py
+++ b/tests/unit/test_seed_sponsors_toggles.py
@@ -1,0 +1,56 @@
+"""Seed-sponsors toggles: each prompt's {sponsor_database} injection is
+independently gated by its setting; missing/unreadable settings fail open."""
+from unittest.mock import MagicMock
+
+from ad_detector import AdDetector
+
+
+def _detector(settings: dict) -> AdDetector:
+    d = AdDetector.__new__(AdDetector)
+    d.db = MagicMock()
+    d.db.get_setting.side_effect = lambda key: settings.get(key)
+    d.sponsor_service = MagicMock()
+    d.sponsor_service.get_claude_sponsor_list.return_value = "Acme, BetterHelp"
+    return d
+
+
+def test_detection_toggle_on_injects_block():
+    d = _detector({'seed_sponsors_detection': 'true'})
+    out = d._render_with_sponsors("X {sponsor_database} Y", 'seed_sponsors_detection')
+    assert "Acme, BetterHelp" in out
+
+
+def test_detection_toggle_off_empties_block():
+    d = _detector({'seed_sponsors_detection': 'false'})
+    out = d._render_with_sponsors("X {sponsor_database} Y", 'seed_sponsors_detection')
+    assert "Acme" not in out
+    assert "DYNAMIC SPONSOR DATABASE" not in out
+    assert out == "X  Y"
+
+
+def test_verification_toggle_independent_of_detection():
+    d = _detector({'seed_sponsors_detection': 'false',
+                   'seed_sponsors_verification': 'true'})
+    assert "Acme" in d._render_with_sponsors(
+        "{sponsor_database}", 'seed_sponsors_verification')
+    assert "Acme" not in d._render_with_sponsors(
+        "{sponsor_database}", 'seed_sponsors_detection')
+
+
+def test_missing_setting_fails_open():
+    d = _detector({})
+    assert "Acme" in d._render_with_sponsors(
+        "{sponsor_database}", 'seed_sponsors_detection')
+
+
+def test_db_error_fails_open():
+    d = _detector({})
+    d.db.get_setting.side_effect = RuntimeError("db down")
+    assert "Acme" in d._render_with_sponsors(
+        "{sponsor_database}", 'seed_sponsors_detection')
+
+
+def test_removed_placeholder_still_yields_no_block():
+    d = _detector({'seed_sponsors_detection': 'true'})
+    out = d._render_with_sponsors("no placeholder here", 'seed_sponsors_detection')
+    assert "Acme" not in out

--- a/tests/unit/test_seed_sponsors_toggles.py
+++ b/tests/unit/test_seed_sponsors_toggles.py
@@ -54,3 +54,36 @@ def test_removed_placeholder_still_yields_no_block():
     d = _detector({'seed_sponsors_detection': 'true'})
     out = d._render_with_sponsors("no placeholder here", 'seed_sponsors_detection')
     assert "Acme" not in out
+
+
+# Reviewer tests
+
+from ad_reviewer import AdReviewer
+
+
+def _reviewer(settings: dict) -> AdReviewer:
+    r = AdReviewer.__new__(AdReviewer)
+    r.db = MagicMock()
+    r.db.get_setting.side_effect = lambda key: settings.get(key)
+    r.sponsor_service = MagicMock()
+    r.sponsor_service.get_claude_sponsor_list.return_value = "Acme, BetterHelp"
+    return r
+
+
+def test_reviewer_block_empty_when_toggle_off():
+    r = _reviewer({'seed_sponsors_reviewer': 'false',
+                   'seed_sponsors_resurrect': 'true'})
+    assert r._sponsor_block_for('seed_sponsors_reviewer') == ""
+    assert "Acme" in r._sponsor_block_for('seed_sponsors_resurrect')
+
+
+def test_resurrect_block_empty_when_toggle_off():
+    r = _reviewer({'seed_sponsors_reviewer': 'true',
+                   'seed_sponsors_resurrect': 'false'})
+    assert "Acme" in r._sponsor_block_for('seed_sponsors_reviewer')
+    assert r._sponsor_block_for('seed_sponsors_resurrect') == ""
+
+
+def test_reviewer_toggles_fail_open():
+    r = _reviewer({})
+    assert "Acme" in r._sponsor_block_for('seed_sponsors_reviewer')

--- a/tests/unit/test_segment_id_addressing.py
+++ b/tests/unit/test_segment_id_addressing.py
@@ -2,7 +2,10 @@
 from unittest.mock import MagicMock
 
 from ad_detector import AdDetector
-from ad_detector.prompts import SEGMENT_ID_SYSTEM_SECTION, format_window_prompt
+from ad_detector.prompts import (
+    SEGMENT_ID_SYSTEM_SECTION, format_window_prompt,
+    parse_id_ads_from_response, resolve_segment_id_ads,
+)
 
 
 def _detector(mode):
@@ -52,3 +55,52 @@ def test_window_prompt_rules_are_mode_exclusive():
     ts_out = format_window_prompt(**_window_kwargs(), addressing_mode='timestamps')
     assert 'Use absolute timestamps' in ts_out
     assert 'start_id' not in ts_out
+
+
+SEGS = [{'sid': i, 'start': i * 10.0, 'end': i * 10.0 + 10.0,
+         'text': f'seg {i}'} for i in range(10)]
+
+
+def test_ids_resolve_to_exact_segment_times():
+    ads, used = parse_id_ads_from_response(
+        '[{"start_id": 2, "end_id": 4, "confidence": 0.9, '
+        '"category": "sponsor", "reason": "promo code read"}]')
+    assert used is True
+    resolved = resolve_segment_id_ads(ads, SEGS)
+    assert resolved[0]['start'] == 20.0
+    assert resolved[0]['end'] == 50.0
+    assert 'start_id' not in resolved[0]
+
+
+def test_reversed_ids_normalized():
+    ads, _ = parse_id_ads_from_response(
+        '[{"start_id": 4, "end_id": 2, "confidence": 0.9, '
+        '"category": "sponsor", "reason": "x"}]')
+    resolved = resolve_segment_id_ads(ads, SEGS)
+    assert resolved[0]['start'] == 20.0 and resolved[0]['end'] == 50.0
+
+
+def test_out_of_range_id_dropped():
+    ads, _ = parse_id_ads_from_response(
+        '[{"start_id": 2, "end_id": 99, "confidence": 0.9, '
+        '"category": "sponsor", "reason": "x"}]')
+    assert resolve_segment_id_ads(ads, SEGS) == []
+
+
+def test_timestamp_response_falls_back():
+    ads, used = parse_id_ads_from_response(
+        '[{"start": 45.0, "end": 82.0, "confidence": 0.9, '
+        '"category": "sponsor", "reason": "x"}]')
+    assert used is False
+
+
+def test_start_id_never_misread_as_seconds():
+    # The generic fuzzy start/end matcher must not turn start_id=2 into
+    # start=2.0 seconds; the ID branch owns any object carrying id fields.
+    ads, used = parse_id_ads_from_response(
+        '[{"start_id": 2, "end_id": 4, "confidence": 0.9, '
+        '"category": "sponsor", "reason": "x"}]')
+    assert used is True
+    assert all('start' not in ad for ad in ads)
+    resolved = resolve_segment_id_ads(ads, SEGS)
+    assert resolved[0]['start'] == 20.0  # not 2.0

--- a/tests/unit/test_segment_id_addressing.py
+++ b/tests/unit/test_segment_id_addressing.py
@@ -1,0 +1,35 @@
+"""Segment-ID addressing: rendering side."""
+from unittest.mock import MagicMock
+
+from ad_detector import AdDetector
+from ad_detector.prompts import SEGMENT_ID_SYSTEM_SECTION
+
+
+def _detector(mode):
+    d = AdDetector.__new__(AdDetector)
+    d.db = MagicMock()
+    d.db.get_setting.side_effect = (
+        lambda key: mode if key == 'ad_addressing_mode' else None)
+    return d
+
+
+def test_mode_resolution():
+    assert _detector('segment_ids')._resolve_addressing_mode() == 'segment_ids'
+    assert _detector('timestamps')._resolve_addressing_mode() == 'timestamps'
+    assert _detector('SEGMENT_IDS ')._resolve_addressing_mode() == 'segment_ids'
+    assert _detector('bogus')._resolve_addressing_mode() == 'timestamps'
+    assert _detector(None)._resolve_addressing_mode() == 'timestamps'
+
+
+def test_id_transcript_lines():
+    segs = [{'sid': 0, 'start': 0.0, 'end': 5.0, 'text': 'hello'},
+            {'sid': 1, 'start': 5.0, 'end': 9.0, 'text': 'world'}]
+    lines = AdDetector._format_transcript_lines(segs, 'segment_ids')
+    assert lines == ['[0] hello', '[1] world']
+    ts_lines = AdDetector._format_transcript_lines(segs, 'timestamps')
+    assert ts_lines == ['[0.0s - 5.0s] hello', '[5.0s - 9.0s] world']
+
+
+def test_system_section_mentions_ids_not_timestamps():
+    assert 'start_id' in SEGMENT_ID_SYSTEM_SECTION
+    assert 'end_id' in SEGMENT_ID_SYSTEM_SECTION

--- a/tests/unit/test_segment_id_addressing.py
+++ b/tests/unit/test_segment_id_addressing.py
@@ -2,7 +2,7 @@
 from unittest.mock import MagicMock
 
 from ad_detector import AdDetector
-from ad_detector.prompts import SEGMENT_ID_SYSTEM_SECTION
+from ad_detector.prompts import SEGMENT_ID_SYSTEM_SECTION, format_window_prompt
 
 
 def _detector(mode):
@@ -33,3 +33,22 @@ def test_id_transcript_lines():
 def test_system_section_mentions_ids_not_timestamps():
     assert 'start_id' in SEGMENT_ID_SYSTEM_SECTION
     assert 'end_id' in SEGMENT_ID_SYSTEM_SECTION
+
+
+def _window_kwargs():
+    return dict(
+        podcast_name='Test', episode_title='Ep1',
+        description_section='', transcript_lines=['[0] hello'],
+        window_index=0, total_windows=1,
+        window_start=0.0, window_end=600.0,
+    )
+
+
+def test_window_prompt_rules_are_mode_exclusive():
+    id_out = format_window_prompt(**_window_kwargs(), addressing_mode='segment_ids')
+    assert 'start_id' in id_out
+    assert 'Use absolute timestamps' not in id_out
+
+    ts_out = format_window_prompt(**_window_kwargs(), addressing_mode='timestamps')
+    assert 'Use absolute timestamps' in ts_out
+    assert 'start_id' not in ts_out

--- a/tests/unit/test_segment_id_addressing.py
+++ b/tests/unit/test_segment_id_addressing.py
@@ -38,6 +38,15 @@ def test_system_section_mentions_ids_not_timestamps():
     assert 'end_id' in SEGMENT_ID_SYSTEM_SECTION
 
 
+def test_system_section_supersedes_timestamp_instructions():
+    # The base system prompts (user-editable, stored in DB) still tell the
+    # model to read [Xs] markers and emit numeric start/end; this section
+    # must explicitly override that so ID mode and the base prompt don't
+    # conflict.
+    assert '[Xs]' in SEGMENT_ID_SYSTEM_SECTION
+    assert 'Ignore any earlier instruction' in SEGMENT_ID_SYSTEM_SECTION
+
+
 def _window_kwargs():
     return dict(
         podcast_name='Test', episode_title='Ep1',
@@ -104,3 +113,35 @@ def test_start_id_never_misread_as_seconds():
     assert all('start' not in ad for ad in ads)
     resolved = resolve_segment_id_ads(ads, SEGS)
     assert resolved[0]['start'] == 20.0  # not 2.0
+
+
+def test_malformed_confidence_drops_one_ad_not_the_whole_pass():
+    # A malformed confidence value used to raise ValueError out of
+    # _normalize_ad, escaping resolve_segment_id_ads and failing the whole
+    # window instead of just the one bad ad.
+    ads, used = parse_id_ads_from_response(
+        '[{"start_id": 0, "end_id": 1, "confidence": "certain", '
+        '"category": "sponsor", "reason": "bad ad"},'
+        '{"start_id": 2, "end_id": 4, "confidence": 0.9, '
+        '"category": "sponsor", "reason": "promo code read"}]')
+    assert used is True
+    resolved = resolve_segment_id_ads(ads, SEGS)
+    assert len(resolved) == 1
+    assert resolved[0]['start'] == 20.0
+    assert resolved[0]['end'] == 50.0
+
+
+def test_mixed_id_and_timestamp_objects_keeps_id_ad():
+    # Some models mix formats in one response: one object with ids, one with
+    # timestamps instead. The id-less object is skipped (surfaced via a
+    # logged warning); used_ids stays True and the id ad still resolves.
+    ads, used = parse_id_ads_from_response(
+        '[{"start_id": 2, "end_id": 4, "confidence": 0.9, '
+        '"category": "sponsor", "reason": "promo code read"},'
+        '{"start": 45.0, "end": 82.0, "confidence": 0.9, '
+        '"category": "sponsor", "reason": "x"}]')
+    assert used is True
+    assert len(ads) == 1
+    resolved = resolve_segment_id_ads(ads, SEGS)
+    assert resolved[0]['start'] == 20.0
+    assert resolved[0]['end'] == 50.0

--- a/tests/unit/test_settings_registry.py
+++ b/tests/unit/test_settings_registry.py
@@ -54,6 +54,10 @@ SEED_SNAPSHOT = {
     'chapters_enabled': 'true',
     'community_sync_categories': DEFAULT_COMMUNITY_SYNC_CATEGORIES_JSON,
     'detect_show_segments': '0',
+    'seed_sponsors_detection': 'true',
+    'seed_sponsors_verification': 'true',
+    'seed_sponsors_reviewer': 'true',
+    'seed_sponsors_resurrect': 'true',
     'jit_blocked_user_agents': '[]',
     'process_new_episodes_first': '1',
     'differential_hold_min_seconds': '10',
@@ -411,11 +415,13 @@ class TestGetDefaults:
         # jitBlockedUserAgents added after that (85 -> 86).
         # lowAdYieldAction added after that (86 -> 87).
         # episodeLogRetentionDays + episodeLogLevel added after that (87 -> 89).
+        # seed_sponsors_detection + seed_sponsors_verification +
+        # seed_sponsors_reviewer + seed_sponsors_resurrect added after that (89 -> 93).
         payload_keys = {
             spec.payload_key for spec in SETTINGS_REGISTRY.values()
             if spec.payload_key
         }
-        assert len(payload_keys) == 89
+        assert len(payload_keys) == 93
         assert 'audioCuePairOrientWindowSeconds' not in payload_keys
         assert 'audioCuePairMaxBreakFraction' in payload_keys
 

--- a/tests/unit/test_settings_registry.py
+++ b/tests/unit/test_settings_registry.py
@@ -59,6 +59,7 @@ SEED_SNAPSHOT = {
     'seed_sponsors_reviewer': 'true',
     'seed_sponsors_resurrect': 'true',
     'text_recurrence_hints': 'false',
+    'ad_addressing_mode': 'timestamps',
     'jit_blocked_user_agents': '[]',
     'process_new_episodes_first': '1',
     'differential_hold_min_seconds': '10',
@@ -419,11 +420,12 @@ class TestGetDefaults:
         # seed_sponsors_detection + seed_sponsors_verification +
         # seed_sponsors_reviewer + seed_sponsors_resurrect added after that (89 -> 93).
         # textRecurrenceHints added after that (93 -> 94).
+        # adAddressingMode added after that (94 -> 95).
         payload_keys = {
             spec.payload_key for spec in SETTINGS_REGISTRY.values()
             if spec.payload_key
         }
-        assert len(payload_keys) == 94
+        assert len(payload_keys) == 95
         assert 'audioCuePairOrientWindowSeconds' not in payload_keys
         assert 'audioCuePairMaxBreakFraction' in payload_keys
 

--- a/tests/unit/test_settings_registry.py
+++ b/tests/unit/test_settings_registry.py
@@ -58,6 +58,7 @@ SEED_SNAPSHOT = {
     'seed_sponsors_verification': 'true',
     'seed_sponsors_reviewer': 'true',
     'seed_sponsors_resurrect': 'true',
+    'text_recurrence_hints': 'false',
     'jit_blocked_user_agents': '[]',
     'process_new_episodes_first': '1',
     'differential_hold_min_seconds': '10',
@@ -417,11 +418,12 @@ class TestGetDefaults:
         # episodeLogRetentionDays + episodeLogLevel added after that (87 -> 89).
         # seed_sponsors_detection + seed_sponsors_verification +
         # seed_sponsors_reviewer + seed_sponsors_resurrect added after that (89 -> 93).
+        # textRecurrenceHints added after that (93 -> 94).
         payload_keys = {
             spec.payload_key for spec in SETTINGS_REGISTRY.values()
             if spec.payload_key
         }
-        assert len(payload_keys) == 93
+        assert len(payload_keys) == 94
         assert 'audioCuePairOrientWindowSeconds' not in payload_keys
         assert 'audioCuePairMaxBreakFraction' in payload_keys
 

--- a/tests/unit/test_text_recurrence.py
+++ b/tests/unit/test_text_recurrence.py
@@ -1,0 +1,70 @@
+"""text_recurrence: spans of the current transcript whose wording repeats
+near-verbatim across prior episodes."""
+from text_recurrence import find_recurring_spans, format_recurrence_hint
+
+INTRO = ("welcome to the weekly show where we discuss science and "
+         "science based tools for everyday life with your host")
+
+
+def _segs(*texts, dur=10.0):
+    out, t = [], 0.0
+    for text in texts:
+        out.append({'start': t, 'end': t + dur, 'text': text})
+        t += dur
+    return out
+
+
+def test_recurring_intro_found_across_two_priors():
+    current = _segs(INTRO, "today we talk about sleep", "unique content here")
+    priors = [_segs(INTRO, "today we talk about diet"),
+              _segs(INTRO, "today we talk about focus")]
+    spans = find_recurring_spans(current, priors)
+    assert len(spans) == 1
+    assert spans[0]['start'] == 0.0
+    assert spans[0]['end'] == 10.0
+    assert "welcome to the weekly show" in spans[0]['text']
+
+
+def test_requires_two_priors():
+    current = _segs(INTRO)
+    assert find_recurring_spans(current, [_segs(INTRO)]) == []
+    assert find_recurring_spans(current, []) == []
+
+
+def test_one_off_short_phrases_not_flagged():
+    current = _segs("thanks for listening everyone see you next time maybe")
+    priors = [_segs("totally different episode about gardening and soil"),
+              _segs("another episode about baking bread at home today")]
+    assert find_recurring_spans(current, priors) == []
+
+
+def test_in_episode_repetition_alone_does_not_trigger():
+    # The shingle appears twice in ONE prior but not in a second prior.
+    current = _segs(INTRO)
+    priors = [_segs(INTRO, INTRO),
+              _segs("entirely unrelated words that never repeat anywhere else")]
+    assert find_recurring_spans(current, priors) == []
+
+
+def test_gap_bridging_merges_across_one_segment():
+    current = _segs(INTRO, "a short unique aside right here", INTRO)
+    priors = [_segs(INTRO, INTRO), _segs(INTRO, INTRO)]
+    spans = find_recurring_spans(current, priors)
+    assert len(spans) == 1
+    assert spans[0]['start'] == 0.0
+    assert spans[0]['end'] == 30.0
+
+
+def test_min_span_seconds_filter():
+    current = _segs(INTRO, dur=3.0)  # 3s span, below the 5s floor
+    priors = [_segs(INTRO), _segs(INTRO)]
+    assert find_recurring_spans(current, priors) == []
+
+
+def test_hint_filters_to_window_and_empty_cases():
+    spans = [{'start': 0.0, 'end': 10.0, 'text': 'intro spiel'},
+             {'start': 500.0, 'end': 520.0, 'text': 'credits roll'}]
+    hint = format_recurrence_hint(spans, 0.0, 60.0)
+    assert 'intro spiel' in hint and 'credits roll' not in hint
+    assert format_recurrence_hint(spans, 100.0, 400.0) == ""
+    assert format_recurrence_hint([], 0.0, 60.0) == ""

--- a/tests/unit/test_text_recurrence.py
+++ b/tests/unit/test_text_recurrence.py
@@ -68,3 +68,20 @@ def test_hint_filters_to_window_and_empty_cases():
     assert 'intro spiel' in hint and 'credits roll' not in hint
     assert format_recurrence_hint(spans, 100.0, 400.0) == ""
     assert format_recurrence_hint([], 0.0, 60.0) == ""
+
+
+def test_cross_segment_shingles_short_segment_full_coverage():
+    # Regression: verify cross-segment shingles work for boilerplate split
+    # across multiple short segments. 12-word intro split into three 4-word
+    # segments; short segments require 100% coverage to avoid false positives
+    # from connector phrases. dur=4.0 makes total span 12s, passing MIN_SPAN_SECONDS.
+    seg1 = "welcome to the weekly"
+    seg2 = "show where we discuss"
+    seg3 = "science and nothing else"
+    current = _segs(seg1, seg2, seg3, "unique outro section", dur=4.0)
+    priors = [_segs(seg1, seg2, seg3, "different outro one", dur=4.0),
+              _segs(seg1, seg2, seg3, "different outro two", dur=4.0)]
+    spans = find_recurring_spans(current, priors)
+    assert len(spans) == 1
+    assert spans[0]['start'] == 0.0
+    assert spans[0]['end'] == 12.0

--- a/tests/unit/test_text_recurrence_wiring.py
+++ b/tests/unit/test_text_recurrence_wiring.py
@@ -1,0 +1,78 @@
+"""Recurrence hint wiring: per-window injection into the detection prompt."""
+import json
+from unittest.mock import patch
+
+from ad_detector import AdDetector
+from text_recurrence import format_recurrence_hint
+
+
+def test_get_recent_original_segments_parses_json(temp_db):
+    # temp_db fixture: tests/conftest.py:23 (fresh Database per test).
+    # upsert_episode kwargs style: tests/unit/test_positional_prior.py:386.
+    slug = 'recur-pod'
+    temp_db.create_podcast(slug, 'https://example.com/feed.xml', 'Recur Pod')
+    for i, eid in enumerate(('ep-1', 'ep-2')):
+        temp_db.upsert_episode(slug, eid, title=f'Episode {i}',
+                               status='processed', original_duration=1800.0,
+                               published_at=f'2026-08-{20 + i:02d}T00:00:00Z')
+        temp_db.save_original_segments(slug, eid, [
+            {'start': 0.0, 'end': 5.0, 'text': f'hello from {eid}'}])
+    lists = temp_db.get_recent_original_segments(slug, limit=5)
+    assert len(lists) == 2
+    assert lists[0][0]['text'].startswith('hello from')
+    # exclude_episode_id filters the current episode out
+    assert len(temp_db.get_recent_original_segments(
+        slug, exclude_episode_id='ep-2')) == 1
+
+
+def test_window_prompt_contains_hint_only_for_overlapping_window():
+    spans = [{'start': 0.0, 'end': 12.0, 'text': 'welcome to the show'}]
+    assert 'welcome to the show' in format_recurrence_hint(spans, 0.0, 600.0)
+    assert format_recurrence_hint(spans, 1200.0, 1800.0) == ""
+
+
+class _StubResponse:
+    """LLMResponse-shaped duck: the parse path reads .content and .usage."""
+
+    def __init__(self, content):
+        self.content = content
+        self.usage = {}
+
+
+def _window(start=0.0, end=60.0):
+    return {
+        'start': start, 'end': end,
+        'segments': [{'start': start, 'end': start + 1.0, 'text': 'hello'}],
+    }
+
+
+def _run_window(detector, *, recurrence_spans, captured):
+    def fake_call(*, prompt, window_label, **_kw):
+        captured.append(prompt)
+        return _StubResponse(json.dumps([])), None
+
+    with patch.object(detector, '_call_llm_for_window', side_effect=fake_call):
+        detector._process_single_window(
+            window_idx=0, window=_window(), total_windows=1,
+            model='m', system_prompt='sys', description_section='',
+            podcast_name='p', episode_title='t',
+            audio_enforcer=None, audio_analysis=None,
+            llm_timeout=30, max_retries=1,
+            slug='s', episode_id='e', pass_name='pass1',
+            window_label_prefix='Window', validate_timestamps=False,
+            recurrence_spans=recurrence_spans,
+        )
+
+
+def test_process_single_window_injects_recurrence_hint_only_when_spans_given():
+    detector = AdDetector(api_key='test-key')
+    spans = [{'start': 0.0, 'end': 30.0, 'text': 'welcome to the show'}]
+
+    with_spans = []
+    _run_window(detector, recurrence_spans=spans, captured=with_spans)
+    assert 'RECURRING BOILERPLATE' in with_spans[0]
+    assert 'welcome to the show' in with_spans[0]
+
+    without_spans = []
+    _run_window(detector, recurrence_spans=None, captured=without_spans)
+    assert 'RECURRING BOILERPLATE' not in without_spans[0]


### PR DESCRIPTION
Three detection improvements adapted from ideas surfaced while studying edspencer/hushpod (MIT), shipped behind settings whose defaults preserve current behavior exactly.

## Phase 1: Seed-sponsors toggles

Four global booleans control which LLM prompts receive the dynamic known-sponsor block, all default on:

| Setting | Gates |
|---|---|
| seed_sponsors_detection | Pass 1 detection system prompt |
| seed_sponsors_verification | Pass 2 verification prompt |
| seed_sponsors_reviewer | Reviewer review prompt |
| seed_sponsors_resurrect | Reviewer resurrect prompt |

Turning the reviewer toggle off makes that pass an independent second opinion instead of one primed with the same sponsor hints as the detector. Toggle reads fail open so a settings problem can never silently strip the block. Exposed in GET /api/v1/settings, PUT /api/v1/settings/ad-detection, and a new Seed sponsors section in the settings UI. The existing opt-out (editing the {sponsor_database} placeholder out of a prompt override) still works and still wins.

## Phase 2: Cross-episode text recurrence hints

New pure module src/text_recurrence.py finds spans of the current transcript whose wording repeats near-verbatim across the feed's recent episodes (8-word shingles over the whole token stream, 2+ prior episodes required, coverage roll-up with a full-coverage rule for segments shorter than 8 words). Matching spans are fed to pass-1 detection as a per-window hint only; nothing is ever cut on text evidence alone, and the verification pass never receives hints.

This complements the audio fingerprinter: re-recorded boilerplate (intro spiels, disclaimers, credits) is verbatim in words but acoustically different every week, so fingerprints miss it and text shingles catch it. Priors come from the already-stored original_segments_json; no schema change. Setting text_recurrence_hints defaults off until benchmarked.

## Phase 3: Segment-ID addressing mode (experimental)

New setting ad_addressing_mode (timestamps, the default, or segment_ids), exposed in the Experiments section of the settings UI. In segment_ids mode the transcript renders as numbered [id] lines, the model returns start_id/end_id integers, and MinusPod maps them back to exact Whisper segment times. A hallucinated timestamp is plausible and undetectable; a hallucinated segment ID is either valid or provably out of range, so this removes a bug class by construction instead of correcting it after the fact.

Safety rails: reversed IDs are normalized, out-of-range IDs drop only that detection, a malformed field drops only that ad rather than failing the pass, and a response that ignores the ID contract falls back to timestamp parsing (with the usual timestamp validation) so no window is lost. Resolved ID ads flow through the exact same normalization as timestamp ads via a shared helper. In timestamps mode every prompt and parse path is byte-identical to before this branch.

## Docs

New glossary entries (Addressing mode, Seed sponsors, Text recurrence hint), configuration.md sections for all three features, and openapi.yaml coverage for the six new payload keys.

## Test plan

- Full backend suite: 5292 unit + integration tests passing
- Frontend: 562 vitest tests passing, tsc clean, production build clean
- ruff clean
- Live visual pass: all three UI areas verified in light and dark themes; toggle and select persistence verified end-to-end against the running API
- Registry guard tests updated for the six new settings keys

## Follow-ups (not in this PR)

- Benchmark A/B: reviewer un-primed vs primed (F0.5) to quantify the independence claim
- Benchmark A/B: segment_ids vs timestamps; results decide whether the experimental mode ever becomes the default
- Flipping text_recurrence_hints or ad_addressing_mode defaults is benchmark-gated
