### PR TITLE
fix(ad-detector): make api_key property dynamic on singleton detectors

### DIFF
--- a/src/ad_detector/__init__.py
+++ b/src/ad_detector/__init__.py
@@ -538,9 +538,7 @@ class AdDetector:
     """
 
     def __init__(self, api_key: str | None = None):
-        self.api_key = api_key or get_api_key()
-        if not self.api_key:
-            logger.warning("No LLM API key found")
+        self._api_key_override: str | None = api_key
         self._llm_client_override: LLMClient | None = None
 
         # Dependency attributes. Previously these were lazy @property
@@ -557,6 +555,17 @@ class AdDetector:
         self.text_pattern_matcher = None
         self.pattern_service = None
         self.sponsor_service = None
+
+    @property
+    def api_key(self) -> str | None:
+        """Active API key. Resolves dynamically via get_api_key() unless overridden."""
+        if self._api_key_override is not None:
+            return self._api_key_override
+        return get_api_key()
+
+    @api_key.setter
+    def api_key(self, value: str | None) -> None:
+        self._api_key_override = value
 
     @property
     def _llm_client(self) -> LLMClient | None:

--- a/src/chapters_generator.py
+++ b/src/chapters_generator.py
@@ -193,17 +193,6 @@ class ChaptersGenerator:
             api_key: LLM API key (defaults to environment configuration)
         """
         self._api_key_override: str | None = api_key
-
-    @property
-    def api_key(self) -> str | None:
-        """Active API key. Resolves dynamically via get_api_key() unless overridden."""
-        if self._api_key_override is not None:
-            return self._api_key_override
-        return get_api_key()
-
-    @api_key.setter
-    def api_key(self, value: str | None) -> None:
-        self._api_key_override = value
         self._llm_client_override: LLMClient | None = None
         self._episode_id: str | None = None
         # (template, override), read once per run rather than per window.
@@ -218,6 +207,17 @@ class ChaptersGenerator:
         self._model_not_configured_message: str | None = None
         self.chapters_degraded: bool = False
         self.chapters_degradation_reason: str | None = None
+
+    @property
+    def api_key(self) -> str | None:
+        """Active API key. Resolves dynamically via get_api_key() unless overridden."""
+        if self._api_key_override is not None:
+            return self._api_key_override
+        return get_api_key()
+
+    @api_key.setter
+    def api_key(self, value: str | None) -> None:
+        self._api_key_override = value
 
     @property
     def _llm_client(self) -> LLMClient | None:

--- a/src/chapters_generator.py
+++ b/src/chapters_generator.py
@@ -192,7 +192,18 @@ class ChaptersGenerator:
         Args:
             api_key: LLM API key (defaults to environment configuration)
         """
-        self.api_key = api_key or get_api_key()
+        self._api_key_override: str | None = api_key
+
+    @property
+    def api_key(self) -> str | None:
+        """Active API key. Resolves dynamically via get_api_key() unless overridden."""
+        if self._api_key_override is not None:
+            return self._api_key_override
+        return get_api_key()
+
+    @api_key.setter
+    def api_key(self, value: str | None) -> None:
+        self._api_key_override = value
         self._llm_client_override: LLMClient | None = None
         self._episode_id: str | None = None
         # (template, override), read once per run rather than per window.

--- a/tests/unit/test_ad_detector_dynamic_key.py
+++ b/tests/unit/test_ad_detector_dynamic_key.py
@@ -1,18 +1,39 @@
 
 def test_ad_detector_dynamic_api_key_resolution(monkeypatch):
     """Verify that AdDetector.api_key dynamically resolves get_api_key() when not explicitly overridden."""
+    import ad_detector
     from ad_detector import AdDetector
-    import llm_client
 
     # 1. When constructed without an explicit key and get_api_key returns None
-    monkeypatch.setattr(llm_client, "get_api_key", lambda: None)
+    monkeypatch.setattr(ad_detector, "get_api_key", lambda: None)
     detector = AdDetector()
     assert detector.api_key is None
 
     # 2. When get_api_key later returns a key (e.g. after user updates settings in UI)
-    monkeypatch.setattr(llm_client, "get_api_key", lambda: "sk-test-dynamic-key")
+    monkeypatch.setattr(ad_detector, "get_api_key", lambda: "sk-test-dynamic-key")
     assert detector.api_key == "sk-test-dynamic-key"
 
     # 3. Explicit override still takes precedence
     override_detector = AdDetector(api_key="sk-override-key")
     assert override_detector.api_key == "sk-override-key"
+
+
+def test_chapters_generator_dynamic_api_key_resolution(monkeypatch):
+    """Verify that ChaptersGenerator.api_key dynamically resolves get_api_key() when not explicitly overridden."""
+    import chapters_generator
+    from chapters_generator import ChaptersGenerator
+
+    # 1. When constructed without an explicit key and get_api_key returns None
+    monkeypatch.setattr(chapters_generator, "get_api_key", lambda: None)
+    generator = ChaptersGenerator()
+    assert generator.api_key is None
+    assert generator._chapter_prompt is None
+    assert generator.chapters_degraded is False
+
+    # 2. When get_api_key later returns a key
+    monkeypatch.setattr(chapters_generator, "get_api_key", lambda: "sk-test-dynamic-key")
+    assert generator.api_key == "sk-test-dynamic-key"
+
+    # 3. Explicit override takes precedence
+    override_generator = ChaptersGenerator(api_key="sk-override-key")
+    assert override_generator.api_key == "sk-override-key"

--- a/tests/unit/test_ad_detector_dynamic_key.py
+++ b/tests/unit/test_ad_detector_dynamic_key.py
@@ -1,0 +1,18 @@
+
+def test_ad_detector_dynamic_api_key_resolution(monkeypatch):
+    """Verify that AdDetector.api_key dynamically resolves get_api_key() when not explicitly overridden."""
+    from ad_detector import AdDetector
+    import llm_client
+
+    # 1. When constructed without an explicit key and get_api_key returns None
+    monkeypatch.setattr(llm_client, "get_api_key", lambda: None)
+    detector = AdDetector()
+    assert detector.api_key is None
+
+    # 2. When get_api_key later returns a key (e.g. after user updates settings in UI)
+    monkeypatch.setattr(llm_client, "get_api_key", lambda: "sk-test-dynamic-key")
+    assert detector.api_key == "sk-test-dynamic-key"
+
+    # 3. Explicit override still takes precedence
+    override_detector = AdDetector(api_key="sk-override-key")
+    assert override_detector.api_key == "sk-override-key"


### PR DESCRIPTION
### Summary
Makes `AdDetector.api_key` and `ChaptersGenerator.api_key` dynamic `@property` getters that resolve through `get_api_key()` on each access (unless an explicit `api_key` was passed during construction).

### Problem
`AdDetector` and `ChaptersGenerator` are instantiated once at module import (`main_app/__init__.py`). If the container boots before an API key is configured or before the database is populated, `self.api_key` statically stores `None`. Subsequent API key saves via the Settings UI update the database, but detection and chapter generation in running workers continue checking `if not self.api_key:`, see `None`, and skip LLM detection with `"Skipping ad detection - no API key"` until container restart.

### Solution
1. Wrap `self.api_key` as a dynamic `@property` that calls `get_api_key()` on demand (matching the existing dynamic behavior of `self._llm_client`).
2. Preserve `self._api_key_override` so explicit construction in unit tests (`AdDetector(api_key="...")`) continues to take precedence.
3. Added unit tests in `tests/unit/test_ad_detector_dynamic_key.py`.
