### PR TITLE
Allow multi-span Mark ad from transcript selection

### DIFF
--- a/.github/workflows/ghcr-cpu-image.yml
+++ b/.github/workflows/ghcr-cpu-image.yml
@@ -1,0 +1,72 @@
+name: GHCR CPU image (fork)
+
+# Publishes ghcr.io/tylermiranda/minuspod for personal Tower deploys.
+# Tower (Unraid amd64) uses the -amd64 tag; arm64 leg omitted to keep CI fast.
+# Upstream still publishes ttlequals0/minuspod via cpu-image.yml (Docker Hub).
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      tag_suffix:
+        description: "Optional extra tag suffix (e.g. stable-cpu). Empty = branch tags only."
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ghcr-cpu-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/minuspod
+
+jobs:
+  build-amd64:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Read version from version.py
+        id: ver
+        run: |
+          set -euo pipefail
+          VERSION=$(sed -nE 's/^__version__ = "([^"]+)"$/\1/p' version.py)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push CPU image (amd64)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: ./Dockerfile.cpu
+          platforms: linux/amd64
+          push: true
+          build-args: MINUSPOD_VERSION=${{ steps.ver.outputs.version }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main-cpu-amd64
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.ver.outputs.version }}-cpu-amd64
+          cache-from: type=gha,scope=ghcr-cpu-amd64
+          cache-to: type=gha,scope=ghcr-cpu-amd64,mode=max
+
+      - name: Optional extra tag
+        if: github.event_name == 'workflow_dispatch' && inputs.tag_suffix != ''
+        run: |
+          set -euo pipefail
+          SRC="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main-cpu-amd64"
+          DST="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.tag_suffix }}-amd64"
+          docker buildx imagetools create -t "$DST" "$SRC"
+          echo "Tagged $DST"

--- a/frontend/src/api/status.ts
+++ b/frontend/src/api/status.ts
@@ -1,0 +1,32 @@
+import { apiRequest } from './client';
+
+export interface ProcessingStatusJob {
+  slug: string;
+  episodeId: string;
+  title: string;
+  podcastName: string;
+  stage: string;
+  progress: number;
+  startedAt: number;
+  elapsed: number;
+}
+
+export interface ProcessingStatusQueuedEpisode {
+  slug: string;
+  episodeId: string;
+  title: string;
+  podcastName: string;
+  queuedAt: number;
+}
+
+export interface ProcessingStatusResponse {
+  currentJob: ProcessingStatusJob | null;
+  queueLength: number;
+  queuedEpisodes: ProcessingStatusQueuedEpisode[];
+  feedRefreshes: unknown[];
+  lastUpdated: number;
+}
+
+export async function getProcessingStatus(): Promise<ProcessingStatusResponse> {
+  return apiRequest<ProcessingStatusResponse>('/status');
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -207,6 +207,12 @@ export interface DaiDifferential {
   error?: string | null;
 }
 
+export interface AppliedCut {
+  start: number;
+  end: number;
+  replacementDuration?: number;
+}
+
 export interface EpisodeDetail extends Episode {
   description?: string;
   // Local feeds only; absent on a subscribed feed's episodes. The
@@ -234,6 +240,7 @@ export interface EpisodeDetail extends Episode {
   // configuration outcome, not a rejected detection.
   keptMarkers?: AdSegment[];
   corrections?: EpisodeCorrection[];
+  appliedCuts?: AppliedCut[] | null;
   cueDetections?: CueDetection[];
   originalDuration?: number;
   newDuration?: number;
@@ -418,6 +425,7 @@ export interface AdSegment {
   // What the resolved segment-action map did with this marker's category.
   // Null when the marker predates the feature or the action never resolved.
   actionApplied?: SegmentAction | null;
+  pattern_id?: number;
 }
 
 export interface SettingValue {

--- a/frontend/src/components/TranscriptSegmentWorkspace.test.tsx
+++ b/frontend/src/components/TranscriptSegmentWorkspace.test.tsx
@@ -5,6 +5,18 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import TranscriptSegmentWorkspace from './TranscriptSegmentWorkspace';
 import type { EpisodeDetail } from '../api/types';
 
+vi.mock('../hooks/useEpisodeRecutWatch', () => ({
+  useEpisodeRecutWatch: () => ({
+    phase: 'idle',
+    stageLabel: null,
+    progress: 0,
+    watching: false,
+    startWatching: vi.fn(),
+    stopWatching: vi.fn(),
+    dismissCompletion: vi.fn(),
+  }),
+}));
+
 vi.mock('../api/feeds', () => ({
   getOriginalSegments: vi.fn(),
   episodeOriginalUrl: (slug: string, id: string) => `/api/v1/feeds/${slug}/episodes/${id}/original.mp3`,
@@ -39,7 +51,7 @@ function renderWorkspace(props: Partial<React.ComponentProps<typeof TranscriptSe
         episode={episode}
         onClose={vi.fn()}
         onSubmitCorrection={onSubmitCorrection}
-        onRecut={vi.fn()}
+        onRecut={vi.fn().mockResolvedValue(undefined)}
         onOpenWaveform={vi.fn()}
         {...props}
       />

--- a/frontend/src/components/TranscriptSegmentWorkspace.test.tsx
+++ b/frontend/src/components/TranscriptSegmentWorkspace.test.tsx
@@ -20,7 +20,6 @@ function renderWorkspace(props: Partial<React.ComponentProps<typeof TranscriptSe
   const episode: EpisodeDetail = {
     id: 'ep-1',
     title: 'Test episode',
-    slug: 'test-feed',
     status: 'completed',
     published: '2026-01-01T00:00:00Z',
     hasOriginalAudio: true,

--- a/frontend/src/components/TranscriptSegmentWorkspace.test.tsx
+++ b/frontend/src/components/TranscriptSegmentWorkspace.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import TranscriptSegmentWorkspace from './TranscriptSegmentWorkspace';
+import type { EpisodeDetail } from '../api/types';
+
+vi.mock('../api/feeds', () => ({
+  getOriginalSegments: vi.fn(),
+  episodeOriginalUrl: (slug: string, id: string) => `/api/v1/feeds/${slug}/episodes/${id}/original.mp3`,
+}));
+
+import { getOriginalSegments } from '../api/feeds';
+
+const mockGetOriginalSegments = vi.mocked(getOriginalSegments);
+
+function renderWorkspace(props: Partial<React.ComponentProps<typeof TranscriptSegmentWorkspace>> = {}) {
+  const onSubmitCorrection = vi.fn().mockResolvedValue(undefined);
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const episode: EpisodeDetail = {
+    id: 'ep-1',
+    title: 'Test episode',
+    slug: 'test-feed',
+    status: 'completed',
+    published: '2026-01-01T00:00:00Z',
+    hasOriginalAudio: true,
+    originalTranscriptAvailable: true,
+    adMarkers: [{ start: 5, end: 12, confidence: 0.9, reason: 'Squarespace' }],
+    pendingReviewMarkers: [],
+    rejectedAdMarkers: [],
+    keptMarkers: [],
+    corrections: [],
+    appliedCuts: [{ start: 5, end: 12 }],
+  };
+  const utils = render(
+    <QueryClientProvider client={qc}>
+      <TranscriptSegmentWorkspace
+        slug="test-feed"
+        episodeId="ep-1"
+        episode={episode}
+        onClose={vi.fn()}
+        onSubmitCorrection={onSubmitCorrection}
+        onRecut={vi.fn()}
+        onOpenWaveform={vi.fn()}
+        {...props}
+      />
+    </QueryClientProvider>,
+  );
+  return { ...utils, onSubmitCorrection, episode };
+}
+
+describe('TranscriptSegmentWorkspace', () => {
+  beforeEach(() => {
+    mockGetOriginalSegments.mockResolvedValue({
+      episodeId: 'ep-1',
+      segments: [
+        { start: 0, end: 5, text: 'Intro content here for the episode start.' },
+        { start: 5, end: 12, text: 'Squarespace dot com slash show promo here today for you.' },
+        { start: 12, end: 20, text: 'Back to the show after the break continues now.' },
+      ],
+    });
+  });
+
+  it('renders segment rows and mark actions', async () => {
+    renderWorkspace();
+
+    await screen.findByText(/Review transcript/i);
+    await screen.findByText(/Squarespace dot com/i);
+    screen.getByRole('button', { name: /Mark content/i });
+    screen.getByRole('button', { name: /Mark ad/i });
+  });
+
+  it('submits reject correction when marking content on selected row', async () => {
+    const user = userEvent.setup();
+    const { onSubmitCorrection } = renderWorkspace();
+
+    await screen.findByText(/Squarespace dot com/i);
+    const checkbox = screen.getByRole('checkbox', { name: /Select segment 2/i });
+    await user.click(checkbox);
+    await user.click(screen.getByRole('button', { name: /Mark content/i }));
+
+    await waitFor(() => {
+      expect(onSubmitCorrection).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'reject',
+        originalAd: expect.objectContaining({ start: 5, end: 12 }),
+      }));
+    });
+  });
+
+  it('requires sponsor before marking ad', async () => {
+    const user = userEvent.setup();
+    const { onSubmitCorrection } = renderWorkspace();
+
+    await screen.findByText(/Squarespace dot com/i);
+    await user.click(screen.getByRole('checkbox', { name: /Select segment 2/i }));
+    await user.click(screen.getByRole('button', { name: /Mark ad/i }));
+
+    await screen.findByText(/Enter a sponsor name/i);
+    expect(onSubmitCorrection).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/TranscriptSegmentWorkspace.tsx
+++ b/frontend/src/components/TranscriptSegmentWorkspace.tsx
@@ -185,7 +185,7 @@ function TranscriptSegmentWorkspace({
             start: bounds.start,
             end: bounds.end,
             pattern_id: marker?.pattern_id,
-            confidence: marker?.confidence,
+            confidence: marker?.confidence ?? 1,
             reason: marker?.reason || '',
             sponsor: marker?.sponsor,
           },
@@ -467,7 +467,7 @@ function SegmentTableRow({
           aria-label={`Select segment ${row.sequenceNum}`}
           onChange={(e) => {
             e.stopPropagation();
-            onToggleSelect(e.nativeEvent.shiftKey);
+            onToggleSelect((e.nativeEvent as MouseEvent).shiftKey);
           }}
         />
       </td>

--- a/frontend/src/components/TranscriptSegmentWorkspace.tsx
+++ b/frontend/src/components/TranscriptSegmentWorkspace.tsx
@@ -1,0 +1,488 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { X } from 'lucide-react';
+import {
+  episodeOriginalUrl,
+  getOriginalSegments,
+} from '../api/feeds';
+import type { AdSegment, EpisodeDetail as EpisodeDetailType } from '../api/types';
+import type { AdCorrection } from '../components/AdEditor';
+import { btnDestructive, btnPrimary, btnSecondary } from './buttonStyles';
+import { focusRing } from './fieldStyles';
+import { formatTime } from '../utils/adReviewHelpers';
+import {
+  allEpisodeMarkers,
+  boundsFromManualTimes,
+  boundsFromSelectedIndexes,
+  buildSegmentReviewRows,
+  ensureMinTextTemplate,
+  findOverlappingMarker,
+  labelDisplay,
+  labelPillClass,
+  MIN_TEXT_TEMPLATE_CHARS,
+  rangeIndexes,
+  rowBackgroundClass,
+  selectionOverlapsKept,
+  type AppliedCutRange,
+  type SegmentReviewRow,
+} from '../utils/segmentReviewModel';
+
+type SaveStatus = 'idle' | 'saving' | 'success' | 'error';
+
+interface Props {
+  slug: string;
+  episodeId: string;
+  episode: EpisodeDetailType;
+  onClose: () => void;
+  onSubmitCorrection: (correction: AdCorrection) => Promise<void>;
+  onRecut: () => void;
+  onOpenWaveform: (opts: { start: number; end: number; createMode: boolean; marker?: AdSegment }) => void;
+  saveStatus?: SaveStatus;
+  correctionError?: string | null;
+}
+
+function TranscriptSegmentWorkspace({
+  slug,
+  episodeId,
+  episode,
+  onClose,
+  onSubmitCorrection,
+  onRecut,
+  onOpenWaveform,
+  saveStatus = 'idle',
+  correctionError = null,
+}: Props) {
+  const queryClient = useQueryClient();
+  const originalAudioRef = useRef<HTMLAudioElement>(null);
+  const [selectedIndexes, setSelectedIndexes] = useState<Set<number>>(() => new Set());
+  const [rangeAnchor, setRangeAnchor] = useState<number | null>(null);
+  const [startTime, setStartTime] = useState('');
+  const [endTime, setEndTime] = useState('');
+  const [currentTime, setCurrentTime] = useState(0);
+  const [sponsor, setSponsor] = useState('');
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const { data: segmentsData, isLoading, error: segmentsError } = useQuery({
+    queryKey: ['originalSegments', slug, episodeId],
+    queryFn: () => getOriginalSegments(slug, episodeId),
+    enabled: !!slug && !!episodeId,
+  });
+
+  const segments = segmentsData?.segments ?? [];
+  const appliedCuts: AppliedCutRange[] = useMemo(
+    () => (episode.appliedCuts ?? []).map((c) => ({
+      start: c.start,
+      end: c.end,
+      replacementDuration: c.replacementDuration,
+    })),
+    [episode.appliedCuts],
+  );
+
+  const rows = useMemo(
+    () => buildSegmentReviewRows(segments, episode, appliedCuts),
+    [segments, episode, appliedCuts],
+  );
+
+  const allMarkers = useMemo(() => allEpisodeMarkers(episode), [episode]);
+
+  const selectionSummary = useMemo(() => {
+    if (selectedIndexes.size === 0) return null;
+    const groups = boundsFromSelectedIndexes(selectedIndexes, rows, segments);
+    return `${groups.length} span${groups.length === 1 ? '' : 's'} · ${selectedIndexes.size} segment${selectedIndexes.size === 1 ? '' : 's'} selected`;
+  }, [selectedIndexes, rows, segments]);
+
+  const playFrom = useCallback((time: number) => {
+    const audio = originalAudioRef.current;
+    if (!audio) return;
+    audio.currentTime = time;
+    void audio.play();
+  }, []);
+
+  const updateBoundsFromSelection = useCallback(
+    (indexes: Set<number>) => {
+      const groups = boundsFromSelectedIndexes(indexes, rows, segments);
+      if (groups.length !== 1) return;
+      const bounds = groups[0];
+      setStartTime(bounds.start.toFixed(1));
+      setEndTime(bounds.end.toFixed(1));
+    },
+    [rows, segments],
+  );
+
+  const toggleSegmentSelection = useCallback(
+    (index: number, shiftKey: boolean) => {
+      setSelectedIndexes((prev) => {
+        let next: Set<number>;
+        if (shiftKey && rangeAnchor !== null) {
+          next = new Set([...prev, ...rangeIndexes(rangeAnchor, index)]);
+        } else {
+          next = new Set(prev);
+          if (next.has(index)) next.delete(index);
+          else next.add(index);
+        }
+        updateBoundsFromSelection(next);
+        return next;
+      });
+      setRangeAnchor(index);
+    },
+    [rangeAnchor, updateBoundsFromSelection],
+  );
+
+  const clearSelection = useCallback(() => {
+    setSelectedIndexes(new Set());
+    setRangeAnchor(null);
+    setStartTime('');
+    setEndTime('');
+  }, []);
+
+  const resolveSelectionBounds = useCallback((): { start: number; end: number; text: string }[] => {
+    if (selectedIndexes.size > 0) {
+      return boundsFromSelectedIndexes(selectedIndexes, rows, segments);
+    }
+    const manual = boundsFromManualTimes(Number(startTime), Number(endTime), segments);
+    return manual ? [manual] : [];
+  }, [selectedIndexes, rows, segments, startTime, endTime]);
+
+  const refreshAfterCorrection = useCallback(async () => {
+    await queryClient.invalidateQueries({ queryKey: ['episode', slug, episodeId] });
+    await queryClient.invalidateQueries({ queryKey: ['originalSegments', slug, episodeId] });
+  }, [queryClient, slug, episodeId]);
+
+  useEffect(() => {
+    if (saveStatus === 'success') {
+      void refreshAfterCorrection();
+      clearSelection();
+      setStatusMessage('Correction saved.');
+    }
+  }, [saveStatus, refreshAfterCorrection, clearSelection]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [onClose]);
+
+  const markContent = async () => {
+    setLocalError(null);
+    const boundsList = resolveSelectionBounds();
+    if (boundsList.length === 0) {
+      setLocalError('Select segment rows or enter start and end times.');
+      return;
+    }
+    if (boundsList.some((b) => selectionOverlapsKept(b, episode.keptMarkers))) {
+      setLocalError('Selection overlaps a kept segment; kept markers cannot be corrected.');
+      return;
+    }
+    try {
+      for (const bounds of boundsList) {
+        const marker = findOverlappingMarker(bounds.start, bounds.end, allMarkers);
+        await onSubmitCorrection({
+          type: 'reject',
+          originalAd: {
+            start: bounds.start,
+            end: bounds.end,
+            pattern_id: marker?.pattern_id,
+            confidence: marker?.confidence,
+            reason: marker?.reason || '',
+            sponsor: marker?.sponsor,
+          },
+        });
+      }
+      setStatusMessage(
+        `Saved ${boundsList.length} content correction${boundsList.length === 1 ? '' : 's'}.`,
+      );
+    } catch {
+      setLocalError('Failed to save correction.');
+    }
+  };
+
+  const markAd = async () => {
+    setLocalError(null);
+    const sponsorText = sponsor.trim();
+    if (!sponsorText) {
+      setLocalError('Enter a sponsor name to mark a missed ad.');
+      return;
+    }
+    const boundsList = resolveSelectionBounds();
+    if (boundsList.length === 0) {
+      setLocalError('Select segment rows or enter start and end times.');
+      return;
+    }
+    if (boundsList.length > 1) {
+      setLocalError('Mark one contiguous span at a time when creating a new ad.');
+      return;
+    }
+    const bounds = boundsList[0];
+    const textTemplate = ensureMinTextTemplate(bounds.text, segments, bounds.start, bounds.end);
+    if (textTemplate.length < MIN_TEXT_TEMPLATE_CHARS) {
+      setLocalError(`Selected text is too short (${textTemplate.length} chars). Select more segments.`);
+      return;
+    }
+    try {
+      await onSubmitCorrection({
+        type: 'create',
+        start: bounds.start,
+        end: bounds.end,
+        sponsor: sponsorText,
+        text_template: textTemplate,
+        scope: 'podcast',
+        reason: `${sponsorText}: manually marked from transcript`,
+      });
+      setStatusMessage('Missed ad saved.');
+    } catch {
+      setLocalError('Failed to save correction.');
+    }
+  };
+
+  const handleRecut = () => {
+    setLocalError(null);
+    onRecut();
+    setStatusMessage('Recut started.');
+  };
+
+  const handleFineTune = () => {
+    const boundsList = resolveSelectionBounds();
+    if (boundsList.length !== 1) {
+      setLocalError('Select one span to open in the waveform editor.');
+      return;
+    }
+    const bounds = boundsList[0];
+    const marker = findOverlappingMarker(bounds.start, bounds.end, allMarkers);
+    onOpenWaveform({
+      start: bounds.start,
+      end: bounds.end,
+      createMode: !marker,
+      marker: marker ?? undefined,
+    });
+  };
+
+  const busy = saveStatus === 'saving';
+  const displayError = localError || correctionError;
+  const originalAudioUrl = episode.hasOriginalAudio
+    ? episodeOriginalUrl(slug, episodeId)
+    : null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex flex-col bg-background"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Transcript segment review"
+    >
+      <header className="flex shrink-0 items-center justify-between gap-3 border-b border-border px-4 py-3 sm:px-6">
+        <div className="min-w-0">
+          <h2 className="text-lg font-semibold text-foreground truncate">
+            Review transcript
+          </h2>
+          <p className="text-sm text-muted-foreground truncate">{episode.title}</p>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close transcript review"
+          className={`shrink-0 rounded-md p-2 ${btnSecondary} ${focusRing}`}
+        >
+          <X className="h-5 w-5" />
+        </button>
+      </header>
+
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <div className="shrink-0 space-y-3 border-b border-border px-4 py-4 sm:px-6">
+          {originalAudioUrl ? (
+            <div>
+              <p className="mb-2 text-sm text-muted-foreground">
+                Original audio. Click a row to play. Check rows to mark them; Shift+click a checkbox for a range.
+              </p>
+              <audio
+                ref={originalAudioRef}
+                controls
+                className="w-full"
+                src={originalAudioUrl}
+                preload="metadata"
+                onTimeUpdate={(event) => setCurrentTime(event.currentTarget.currentTime)}
+              />
+            </div>
+          ) : (
+            <p className="text-sm text-amber-700 dark:text-amber-300">
+              Original audio is not retained for this episode; marking still updates patterns for future runs.
+            </p>
+          )}
+
+          <div className="flex flex-wrap items-end gap-2">
+            <label className="text-sm text-muted-foreground">
+              Start
+              <input
+                type="text"
+                value={startTime}
+                onChange={(e) => setStartTime(e.target.value)}
+                className="mt-1 block w-24 rounded-md border border-input bg-background px-2 py-1 text-sm"
+              />
+            </label>
+            <label className="text-sm text-muted-foreground">
+              End
+              <input
+                type="text"
+                value={endTime}
+                onChange={(e) => setEndTime(e.target.value)}
+                className="mt-1 block w-24 rounded-md border border-input bg-background px-2 py-1 text-sm"
+              />
+            </label>
+            <label className="text-sm text-muted-foreground flex-1 min-w-[10rem]">
+              Sponsor (for Mark ad)
+              <input
+                type="text"
+                value={sponsor}
+                onChange={(e) => setSponsor(e.target.value)}
+                placeholder="e.g. Squarespace"
+                className="mt-1 block w-full rounded-md border border-input bg-background px-2 py-1 text-sm"
+              />
+            </label>
+          </div>
+
+          {selectionSummary && (
+            <p className="text-sm text-muted-foreground">{selectionSummary}</p>
+          )}
+
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              disabled={busy}
+              onClick={markContent}
+              className={`px-3 py-1.5 text-sm rounded-md ${btnSecondary} disabled:opacity-50 ${focusRing}`}
+            >
+              Mark content
+            </button>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={markAd}
+              className={`px-3 py-1.5 text-sm rounded-md ${btnDestructive} disabled:opacity-50 ${focusRing}`}
+            >
+              Mark ad
+            </button>
+            <button
+              type="button"
+              disabled={busy || !episode.hasOriginalAudio}
+              onClick={handleRecut}
+              className={`px-3 py-1.5 text-sm rounded-md ${btnPrimary} disabled:opacity-50 ${focusRing}`}
+            >
+              Recut audio
+            </button>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={handleFineTune}
+              className={`px-3 py-1.5 text-sm rounded-md ${btnSecondary} disabled:opacity-50 ${focusRing}`}
+            >
+              Fine-tune in waveform
+            </button>
+            {selectedIndexes.size > 0 && (
+              <button
+                type="button"
+                onClick={clearSelection}
+                className={`px-3 py-1.5 text-sm rounded-md ${btnSecondary} ${focusRing}`}
+              >
+                Clear selection
+              </button>
+            )}
+          </div>
+
+          {displayError && (
+            <p className="text-sm text-destructive">{displayError}</p>
+          )}
+          {statusMessage && !displayError && (
+            <p className="text-sm text-muted-foreground">{statusMessage}</p>
+          )}
+          {saveStatus === 'saving' && (
+            <p className="text-sm text-muted-foreground">Saving…</p>
+          )}
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-auto px-4 pb-6 sm:px-6">
+          {isLoading && (
+            <p className="py-6 text-sm text-muted-foreground">Loading segments…</p>
+          )}
+          {segmentsError && (
+            <p className="py-6 text-sm text-destructive">Failed to load transcript segments.</p>
+          )}
+          {!isLoading && !segmentsError && rows.length === 0 && (
+            <p className="py-6 text-sm text-muted-foreground">No transcript segments available.</p>
+          )}
+          {rows.length > 0 && (
+            <table className="w-full text-left text-sm">
+              <thead className="sticky top-0 bg-background border-b border-border">
+                <tr>
+                  <th className="w-10 py-2 pr-2 font-medium text-muted-foreground"> </th>
+                  <th className="w-12 py-2 pr-2 font-medium text-muted-foreground">#</th>
+                  <th className="w-36 py-2 pr-2 font-medium text-muted-foreground">Time</th>
+                  <th className="w-28 py-2 pr-2 font-medium text-muted-foreground">Label</th>
+                  <th className="py-2 font-medium text-muted-foreground">Text</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <SegmentTableRow
+                    key={row.index}
+                    row={row}
+                    selected={selectedIndexes.has(row.index)}
+                    playing={currentTime >= row.start && currentTime < row.end}
+                    onToggleSelect={(shiftKey) => toggleSegmentSelection(row.index, shiftKey)}
+                    onRowClick={() => playFrom(row.start)}
+                  />
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SegmentTableRow({
+  row,
+  selected,
+  playing,
+  onToggleSelect,
+  onRowClick,
+}: {
+  row: SegmentReviewRow;
+  selected: boolean;
+  playing: boolean;
+  onToggleSelect: (shiftKey: boolean) => void;
+  onRowClick: () => void;
+}) {
+  return (
+    <tr
+      className={`border-b border-border/60 cursor-pointer ${rowBackgroundClass(row, { selected, playing })}`}
+      onClick={onRowClick}
+    >
+      <td className="py-2 pr-2 align-top" onClick={(e) => e.stopPropagation()}>
+        <input
+          type="checkbox"
+          checked={selected}
+          aria-label={`Select segment ${row.sequenceNum}`}
+          onChange={(e) => {
+            e.stopPropagation();
+            onToggleSelect(e.nativeEvent.shiftKey);
+          }}
+        />
+      </td>
+      <td className="py-2 pr-2 align-top tabular-nums text-muted-foreground">{row.sequenceNum}</td>
+      <td className="py-2 pr-2 align-top tabular-nums whitespace-nowrap text-muted-foreground">
+        {formatTime(row.start)} – {formatTime(row.end)}
+      </td>
+      <td className="py-2 pr-2 align-top">
+        <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${labelPillClass(row.label)}`}>
+          {labelDisplay(row.label, row.mixed)}
+        </span>
+      </td>
+      <td className="py-2 align-top text-foreground">{row.text}</td>
+    </tr>
+  );
+}
+
+export default TranscriptSegmentWorkspace;

--- a/frontend/src/components/TranscriptSegmentWorkspace.tsx
+++ b/frontend/src/components/TranscriptSegmentWorkspace.tsx
@@ -7,6 +7,7 @@ import {
 } from '../api/feeds';
 import type { AdSegment, EpisodeDetail as EpisodeDetailType } from '../api/types';
 import type { AdCorrection } from '../components/AdEditor';
+import { useEpisodeRecutWatch } from '../hooks/useEpisodeRecutWatch';
 import { btnDestructive, btnPrimary, btnSecondary } from './buttonStyles';
 import { focusRing } from './fieldStyles';
 import { formatTime } from '../utils/adReviewHelpers';
@@ -35,7 +36,7 @@ interface Props {
   episode: EpisodeDetailType;
   onClose: () => void;
   onSubmitCorrection: (correction: AdCorrection) => Promise<void>;
-  onRecut: () => void;
+  onRecut: () => Promise<void>;
   onOpenWaveform: (opts: { start: number; end: number; createMode: boolean; marker?: AdSegment }) => void;
   saveStatus?: SaveStatus;
   correctionError?: string | null;
@@ -62,6 +63,7 @@ function TranscriptSegmentWorkspace({
   const [sponsor, setSponsor] = useState('');
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [localError, setLocalError] = useState<string | null>(null);
+  const recutWatch = useEpisodeRecutWatch(slug, episodeId, episode.title);
 
   const { data: segmentsData, isLoading, error: segmentsError } = useQuery({
     queryKey: ['originalSegments', slug, episodeId],
@@ -237,10 +239,18 @@ function TranscriptSegmentWorkspace({
     }
   };
 
-  const handleRecut = () => {
+  const handleRecut = async () => {
     setLocalError(null);
-    onRecut();
-    setStatusMessage('Recut started.');
+    recutWatch.dismissCompletion();
+    recutWatch.startWatching();
+    try {
+      await onRecut();
+      setStatusMessage('Recut queued — progress updates below.');
+    } catch {
+      recutWatch.stopWatching();
+      setLocalError('Failed to start recut.');
+      setStatusMessage(null);
+    }
   };
 
   const handleFineTune = () => {
@@ -259,8 +269,9 @@ function TranscriptSegmentWorkspace({
     });
   };
 
-  const busy = saveStatus === 'saving';
+  const busy = saveStatus === 'saving' || recutWatch.watching;
   const displayError = localError || correctionError;
+  const recutActive = recutWatch.phase === 'queued' || recutWatch.phase === 'processing';
   const originalAudioUrl = episode.hasOriginalAudio
     ? episodeOriginalUrl(slug, episodeId)
     : null;
@@ -366,10 +377,10 @@ function TranscriptSegmentWorkspace({
             <button
               type="button"
               disabled={busy || !episode.hasOriginalAudio}
-              onClick={handleRecut}
+              onClick={() => { void handleRecut(); }}
               className={`px-3 py-1.5 text-sm rounded-md ${btnPrimary} disabled:opacity-50 ${focusRing}`}
             >
-              Recut audio
+              {recutWatch.watching ? 'Recutting…' : 'Recut audio'}
             </button>
             <button
               type="button"
@@ -389,6 +400,68 @@ function TranscriptSegmentWorkspace({
               </button>
             )}
           </div>
+
+          {recutActive && (
+            <div className="rounded-lg border border-primary/30 bg-primary/5 p-3 space-y-2">
+              <div className="flex items-center justify-between gap-2 text-sm">
+                <span className="font-medium text-foreground">
+                  {recutWatch.stageLabel ?? 'Recutting'}
+                </span>
+                <span className="tabular-nums text-muted-foreground">
+                  {Math.round(recutWatch.progress)}%
+                </span>
+              </div>
+              <div className="h-2 w-full rounded-full bg-muted overflow-hidden">
+                <div
+                  className="h-full bg-primary transition-all duration-300"
+                  style={{ width: `${Math.max(recutWatch.progress, recutWatch.phase === 'queued' ? 8 : 3)}%` }}
+                />
+              </div>
+              <p className="text-xs text-muted-foreground">
+                {recutWatch.phase === 'queued'
+                  ? 'Waiting in the processing queue…'
+                  : 'Updating processed audio from your corrections…'}
+              </p>
+            </div>
+          )}
+
+          {recutWatch.phase === 'completed' && (
+            <div className="rounded-lg border border-emerald-500/40 bg-emerald-500/10 p-3 flex items-start justify-between gap-3">
+              <div>
+                <p className="text-sm font-medium text-emerald-800 dark:text-emerald-200">
+                  Recut complete
+                </p>
+                <p className="text-sm text-emerald-700 dark:text-emerald-300">
+                  Processed audio is updated. Segment labels will refresh on the next load.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={recutWatch.dismissCompletion}
+                className={`shrink-0 text-sm ${btnSecondary} px-2 py-1 rounded ${focusRing}`}
+              >
+                Dismiss
+              </button>
+            </div>
+          )}
+
+          {recutWatch.phase === 'failed' && (
+            <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-3 flex items-start justify-between gap-3">
+              <div>
+                <p className="text-sm font-medium text-destructive">Recut failed</p>
+                <p className="text-sm text-destructive/90">
+                  Check the episode status or processing logs for details.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={recutWatch.dismissCompletion}
+                className={`shrink-0 text-sm ${btnSecondary} px-2 py-1 rounded ${focusRing}`}
+              >
+                Dismiss
+              </button>
+            </div>
+          )}
 
           {displayError && (
             <p className="text-sm text-destructive">{displayError}</p>

--- a/frontend/src/hooks/useEpisodeRecutWatch.ts
+++ b/frontend/src/hooks/useEpisodeRecutWatch.ts
@@ -1,0 +1,177 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { getEpisode } from '../api/feeds';
+import { getProcessingStatus } from '../api/status';
+import { getStageLabel } from '../utils/processingStage';
+import {
+  ensureNotificationPermission,
+  startCompletionAlert,
+  stopActiveCompletionAlert,
+} from '../utils/completionAlert';
+
+export type RecutWatchPhase =
+  | 'idle'
+  | 'queued'
+  | 'processing'
+  | 'completed'
+  | 'failed';
+
+export interface EpisodeRecutWatchState {
+  phase: RecutWatchPhase;
+  stageLabel: string | null;
+  progress: number;
+  watching: boolean;
+  startWatching: () => void;
+  stopWatching: () => void;
+  dismissCompletion: () => void;
+}
+
+const POLL_MS = 2000;
+
+function episodeMatches(slug: string, episodeId: string, s: string, e: string): boolean {
+  return s === slug && e === episodeId;
+}
+
+export function useEpisodeRecutWatch(
+  slug: string,
+  episodeId: string,
+  episodeTitle: string,
+): EpisodeRecutWatchState {
+  const queryClient = useQueryClient();
+  const [watching, setWatching] = useState(false);
+  const [phase, setPhase] = useState<RecutWatchPhase>('idle');
+  const [stageLabel, setStageLabel] = useState<string | null>(null);
+  const [progress, setProgress] = useState(0);
+  const sawActivityRef = useRef(false);
+  const completionAlertRef = useRef<ReturnType<typeof startCompletionAlert> | null>(null);
+
+  const { data: status } = useQuery({
+    queryKey: ['processing-status'],
+    queryFn: getProcessingStatus,
+    enabled: watching,
+    refetchInterval: watching ? POLL_MS : false,
+  });
+
+  const { data: episode } = useQuery({
+    queryKey: ['episode', slug, episodeId],
+    queryFn: () => getEpisode(slug, episodeId),
+    enabled: watching && !!slug && !!episodeId,
+    refetchInterval: watching ? POLL_MS : false,
+  });
+
+  const finishSuccess = useCallback(() => {
+    setPhase('completed');
+    setWatching(false);
+    setStageLabel(null);
+    setProgress(100);
+    void queryClient.invalidateQueries({ queryKey: ['episode', slug, episodeId] });
+    void queryClient.invalidateQueries({ queryKey: ['originalSegments', slug, episodeId] });
+    void queryClient.invalidateQueries({ queryKey: ['episodes', slug] });
+    completionAlertRef.current = startCompletionAlert({
+      title: 'MinusPod — recut complete',
+      body: `"${episodeTitle}" — processed audio is updated.`,
+      blinkTitle: 'Recut complete',
+      tag: `minuspod-recut-${slug}-${episodeId}`,
+    });
+  }, [queryClient, slug, episodeId, episodeTitle]);
+
+  const finishFailure = useCallback(() => {
+    setPhase('failed');
+    setWatching(false);
+    setStageLabel(null);
+    setProgress(0);
+    void queryClient.invalidateQueries({ queryKey: ['episode', slug, episodeId] });
+  }, [queryClient, slug, episodeId]);
+
+  useEffect(() => {
+    if (!watching) return;
+
+    const job = status?.currentJob ?? null;
+    const isCurrentJob = job
+      ? episodeMatches(slug, episodeId, job.slug, job.episodeId)
+      : false;
+    const isQueued = (status?.queuedEpisodes ?? []).some(
+      (row) => episodeMatches(slug, episodeId, row.slug, row.episodeId),
+    );
+    const epStatus = episode?.status;
+
+    if (isCurrentJob || isQueued || epStatus === 'processing' || epStatus === 'pending') {
+      sawActivityRef.current = true;
+    }
+
+    if (isCurrentJob && job) {
+      setPhase('processing');
+      setStageLabel(getStageLabel(job.stage));
+      setProgress(Math.max(0, Math.min(100, job.progress)));
+      return;
+    }
+
+    if (isQueued) {
+      setPhase('queued');
+      setStageLabel('Queued');
+      setProgress(0);
+      return;
+    }
+
+    if (epStatus === 'processing' || epStatus === 'pending') {
+      setPhase('processing');
+      if (!isCurrentJob) {
+        setStageLabel((prev) => prev ?? 'Processing');
+      }
+      return;
+    }
+
+    if (sawActivityRef.current && epStatus === 'completed') {
+      finishSuccess();
+      return;
+    }
+
+    if (
+      sawActivityRef.current
+      && (epStatus === 'failed' || epStatus === 'permanently_failed')
+    ) {
+      finishFailure();
+    }
+  }, [watching, status, episode, slug, episodeId, finishSuccess, finishFailure]);
+
+  useEffect(() => () => {
+    stopActiveCompletionAlert();
+  }, []);
+
+  const startWatching = useCallback(() => {
+    sawActivityRef.current = false;
+    completionAlertRef.current?.stop();
+    completionAlertRef.current = null;
+    setWatching(true);
+    setPhase('queued');
+    setStageLabel('Starting…');
+    setProgress(0);
+    void ensureNotificationPermission();
+  }, []);
+
+  const stopWatching = useCallback(() => {
+    setWatching(false);
+    setPhase('idle');
+    setStageLabel(null);
+    setProgress(0);
+    sawActivityRef.current = false;
+  }, []);
+
+  const dismissCompletion = useCallback(() => {
+    completionAlertRef.current?.stop();
+    completionAlertRef.current = null;
+    if (phase === 'completed' || phase === 'failed') {
+      setPhase('idle');
+    }
+  }, [phase]);
+
+  return {
+    phase,
+    stageLabel,
+    progress,
+    watching,
+    startWatching,
+    stopWatching,
+    dismissCompletion,
+  };
+}

--- a/frontend/src/pages/AddFeed.test.tsx
+++ b/frontend/src/pages/AddFeed.test.tsx
@@ -71,11 +71,12 @@ beforeEach(() => {
 });
 
 describe('AddFeed: mode toggle', () => {
-  it('starts in subscribe mode with the search/URL input and OPML section visible', async () => {
+  it('starts in subscribe mode with search selected and OPML section visible', async () => {
     renderAddFeed();
     await waitFor(() => {
-      expect(screen.getByLabelText('Search podcasts or enter RSS URL')).toBeDefined();
+      expect(screen.getByLabelText('Search podcasts')).toBeDefined();
     });
+    expect(screen.getByRole('button', { name: 'Search', pressed: true })).toBeDefined();
     expect(screen.getByText('Import from OPML')).toBeDefined();
     expect(screen.queryByLabelText('Title')).toBeNull();
   });
@@ -84,7 +85,7 @@ describe('AddFeed: mode toggle', () => {
     const user = userEvent.setup();
     renderAddFeed();
     await waitFor(() => {
-      expect(screen.getByLabelText('Search podcasts or enter RSS URL')).toBeDefined();
+      expect(screen.getByLabelText('Search podcasts')).toBeDefined();
     });
 
     await user.click(screen.getByRole('button', { name: 'Create local feed' }));
@@ -92,7 +93,20 @@ describe('AddFeed: mode toggle', () => {
     expect(screen.getByLabelText('Title')).toBeDefined();
     expect(screen.getByLabelText('Slug')).toBeDefined();
     expect(screen.queryByText('Import from OPML')).toBeNull();
-    expect(screen.queryByLabelText('Search podcasts or enter RSS URL')).toBeNull();
+    expect(screen.queryByLabelText('Search podcasts')).toBeNull();
+  });
+
+  it('switches to RSS URL mode', async () => {
+    const user = userEvent.setup();
+    renderAddFeed();
+    await waitFor(() => {
+      expect(screen.getByLabelText('Search podcasts')).toBeDefined();
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Enter RSS URL' }));
+
+    expect(screen.getByLabelText('Podcast RSS Feed URL')).toBeDefined();
+    expect(screen.queryByLabelText('Search podcasts')).toBeNull();
   });
 });
 
@@ -101,7 +115,7 @@ describe('AddFeed: local feed form', () => {
     const user = userEvent.setup();
     renderAddFeed();
     await waitFor(() => {
-      expect(screen.getByLabelText('Search podcasts or enter RSS URL')).toBeDefined();
+      expect(screen.getByLabelText('Search podcasts')).toBeDefined();
     });
     await user.click(screen.getByRole('button', { name: 'Create local feed' }));
     return user;
@@ -197,7 +211,7 @@ describe('AddFeed: artwork upload after create', () => {
     const user = userEvent.setup();
     renderAddFeed();
     await waitFor(() => {
-      expect(screen.getByLabelText('Search podcasts or enter RSS URL')).toBeDefined();
+      expect(screen.getByLabelText('Search podcasts')).toBeDefined();
     });
     await user.click(screen.getByRole('button', { name: 'Create local feed' }));
     await user.type(screen.getByLabelText('Title'), 'My Archive Show');
@@ -277,10 +291,10 @@ describe('AddFeed: podcast search', () => {
     const user = userEvent.setup();
     renderAddFeed();
     await waitFor(() => {
-      expect(screen.getByLabelText('Search podcasts or enter RSS URL')).toBeDefined();
+      expect(screen.getByLabelText('Search podcasts')).toBeDefined();
     });
 
-    await user.type(screen.getByLabelText('Search podcasts or enter RSS URL'), 'test show');
+    await user.type(screen.getByLabelText('Search podcasts'), 'test show');
 
     await waitFor(() => {
       expect(mockSearchPodcasts).toHaveBeenCalledWith('test show', expect.any(AbortSignal));

--- a/frontend/src/pages/AddFeed.test.tsx
+++ b/frontend/src/pages/AddFeed.test.tsx
@@ -52,8 +52,12 @@ function makeClient() {
   });
 }
 
-function renderAddFeed() {
-  mockGetSettings.mockResolvedValue({ podcastIndexApiKeyConfigured: false });
+function renderAddFeed(settingsOverrides: Record<string, unknown> = {}) {
+  mockGetSettings.mockResolvedValue({
+    podcastIndexApiKeyConfigured: false,
+    podcastSearchProvider: { value: 'itunes', isDefault: true },
+    ...settingsOverrides,
+  });
   mockGetFeedsResponse.mockResolvedValue({ feeds: [], lastRefreshCompletedAt: null });
   return render(
     <QueryClientProvider client={makeClient()}>
@@ -67,10 +71,10 @@ beforeEach(() => {
 });
 
 describe('AddFeed: mode toggle', () => {
-  it('starts in subscribe mode with the URL input and OPML section visible', async () => {
+  it('starts in subscribe mode with the search/URL input and OPML section visible', async () => {
     renderAddFeed();
     await waitFor(() => {
-      expect(screen.getByLabelText('Podcast RSS Feed URL')).toBeDefined();
+      expect(screen.getByLabelText('Search podcasts or enter RSS URL')).toBeDefined();
     });
     expect(screen.getByText('Import from OPML')).toBeDefined();
     expect(screen.queryByLabelText('Title')).toBeNull();
@@ -80,7 +84,7 @@ describe('AddFeed: mode toggle', () => {
     const user = userEvent.setup();
     renderAddFeed();
     await waitFor(() => {
-      expect(screen.getByLabelText('Podcast RSS Feed URL')).toBeDefined();
+      expect(screen.getByLabelText('Search podcasts or enter RSS URL')).toBeDefined();
     });
 
     await user.click(screen.getByRole('button', { name: 'Create local feed' }));
@@ -88,7 +92,7 @@ describe('AddFeed: mode toggle', () => {
     expect(screen.getByLabelText('Title')).toBeDefined();
     expect(screen.getByLabelText('Slug')).toBeDefined();
     expect(screen.queryByText('Import from OPML')).toBeNull();
-    expect(screen.queryByLabelText('Podcast RSS Feed URL')).toBeNull();
+    expect(screen.queryByLabelText('Search podcasts or enter RSS URL')).toBeNull();
   });
 });
 
@@ -97,7 +101,7 @@ describe('AddFeed: local feed form', () => {
     const user = userEvent.setup();
     renderAddFeed();
     await waitFor(() => {
-      expect(screen.getByLabelText('Podcast RSS Feed URL')).toBeDefined();
+      expect(screen.getByLabelText('Search podcasts or enter RSS URL')).toBeDefined();
     });
     await user.click(screen.getByRole('button', { name: 'Create local feed' }));
     return user;
@@ -193,7 +197,7 @@ describe('AddFeed: artwork upload after create', () => {
     const user = userEvent.setup();
     renderAddFeed();
     await waitFor(() => {
-      expect(screen.getByLabelText('Podcast RSS Feed URL')).toBeDefined();
+      expect(screen.getByLabelText('Search podcasts or enter RSS URL')).toBeDefined();
     });
     await user.click(screen.getByRole('button', { name: 'Create local feed' }));
     await user.type(screen.getByLabelText('Title'), 'My Archive Show');
@@ -253,5 +257,46 @@ describe('AddFeed: artwork upload after create', () => {
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith('/feeds/my-archive-show', undefined);
     });
+  });
+});
+
+describe('AddFeed: podcast search', () => {
+  it('searches via iTunes without PodcastIndex credentials', async () => {
+    mockSearchPodcasts.mockResolvedValue([
+      {
+        id: 123,
+        title: 'Test Show',
+        description: 'A test podcast',
+        artworkUrl: '',
+        feedUrl: 'https://example.com/feed.xml',
+        author: 'Test Author',
+        link: 'https://podcasts.apple.com/podcast/id123',
+      },
+    ]);
+
+    const user = userEvent.setup();
+    renderAddFeed();
+    await waitFor(() => {
+      expect(screen.getByLabelText('Search podcasts or enter RSS URL')).toBeDefined();
+    });
+
+    await user.type(screen.getByLabelText('Search podcasts or enter RSS URL'), 'test show');
+
+    await waitFor(() => {
+      expect(mockSearchPodcasts).toHaveBeenCalledWith('test show', expect.any(AbortSignal));
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Test Show')).toBeDefined();
+    });
+  });
+
+  it('shows a credentials banner when PodcastIndex is selected without API keys', async () => {
+    renderAddFeed({
+      podcastSearchProvider: { value: 'podcastindex', isDefault: false },
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/Configure PodcastIndex API credentials/)).toBeDefined();
+    });
+    expect(screen.getByLabelText('Podcast RSS Feed URL')).toBeDefined();
   });
 });

--- a/frontend/src/pages/AddFeed.tsx
+++ b/frontend/src/pages/AddFeed.tsx
@@ -326,7 +326,7 @@ function SearchResultItem({ result, isSubscribed, isAdding, onAdd }: {
         <div className="flex items-start justify-between gap-2">
           <div className="min-w-0">
             <a
-              href={`https://podcastindex.org/podcast/${result.id}`}
+              href={result.link || `https://podcastindex.org/podcast/${result.id}`}
               target="_blank"
               rel="noopener noreferrer"
               className={`text-sm font-semibold text-foreground hover:text-primary truncate block ${focusRing}`}
@@ -403,12 +403,14 @@ function AddFeed() {
   const urlValidation = useMemo(() => isUrl ? validateUrl(inputValue) : { isValid: false, error: null, warning: null }, [inputValue, isUrl]);
   const [touched, setTouched] = useState(false);
 
-  // Settings query to check if PodcastIndex is configured
+  // Settings query: search works via iTunes with no setup, or PodcastIndex when creds exist.
   const { data: settings } = useQuery({
     queryKey: ['settings'],
     queryFn: getSettings,
   });
   const podcastIndexConfigured = settings?.podcastIndexApiKeyConfigured ?? false;
+  const searchProvider = settings?.podcastSearchProvider?.value ?? 'itunes';
+  const searchEnabled = searchProvider === 'itunes' || podcastIndexConfigured;
 
   // Existing feeds for "already added" detection
   const { data: feedsData } = useQuery({ ...feedsQueryOptions, select: (r) => r.feeds });
@@ -418,7 +420,7 @@ function AddFeed() {
   }, [feedsData]);
 
   const inputTrimmed = inputValue.trim();
-  const shouldSearch = !isUrl && podcastIndexConfigured && inputTrimmed.length >= 2;
+  const shouldSearch = !isUrl && searchEnabled && inputTrimmed.length >= 2;
 
   // Clear stale search state during render when the search is no longer
   // applicable. Avoids a setState-in-effect for the early-return branch.
@@ -551,14 +553,14 @@ function AddFeed() {
 
       {mode === 'subscribe' && (
       <>
-      {/* No-credentials info banner */}
-      {!podcastIndexConfigured && (
+      {/* PodcastIndex selected but credentials missing */}
+      {searchProvider === 'podcastindex' && !podcastIndexConfigured && (
         <div className="mb-6 p-4 rounded-lg bg-accent/50 border border-border">
           <p className="text-sm text-muted-foreground">
             <Link to="/settings#podcast-index" className={`text-primary hover:underline font-medium ${focusRing}`}>
               Configure PodcastIndex API credentials
             </Link>
-            {' '}to search for podcasts by name. You can still add feeds by URL below.
+            {' '}to search for podcasts by name, or switch to iTunes in Settings (no setup needed). You can still add feeds by URL below.
           </p>
         </div>
       )}
@@ -567,7 +569,7 @@ function AddFeed() {
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
           <label htmlFor="podcastInput" className="block text-sm font-medium text-foreground mb-2">
-            {podcastIndexConfigured ? 'Search podcasts or enter RSS URL' : 'Podcast RSS Feed URL'}
+            {searchEnabled ? 'Search podcasts or enter RSS URL' : 'Podcast RSS Feed URL'}
           </label>
           <input
             type="text"
@@ -575,7 +577,7 @@ function AddFeed() {
             value={inputValue}
             onChange={(e) => setInputValue(e.target.value)}
             onBlur={() => { if (isUrl) setTouched(true); }}
-            placeholder={podcastIndexConfigured ? 'Search by name or paste an RSS feed URL...' : 'https://example.com/podcast/feed.xml'}
+            placeholder={searchEnabled ? 'Search by name or paste an RSS feed URL...' : 'https://example.com/podcast/feed.xml'}
             className={`w-full px-4 py-2 rounded-lg border bg-background text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-ring ${
               isUrl && touched && urlValidation.error
                 ? 'border-destructive focus:ring-destructive'
@@ -696,7 +698,7 @@ function AddFeed() {
       </form>
 
       {/* Section C: Search Results */}
-      {!isUrl && inputValue.trim() && podcastIndexConfigured && (
+      {!isUrl && inputValue.trim() && searchEnabled && (
         <div className="mt-4 space-y-2">
           {isSearching && (
             <div className="space-y-3">

--- a/frontend/src/pages/AddFeed.tsx
+++ b/frontend/src/pages/AddFeed.tsx
@@ -12,6 +12,7 @@ import DraftNumberInput, { DRAFT_NUMBER_INPUT_CLASS, parseOptionalNumber } from 
 import { focusRing } from '../components/fieldStyles';
 
 type AddFeedMode = 'subscribe' | 'local';
+type SubscribeInputMode = 'search' | 'url';
 
 // Mirrors the shape of the backend's make_slug (python-slugify): lowercase,
 // strip diacritics, collapse runs of non-alphanumerics to a single hyphen,
@@ -377,6 +378,7 @@ function AddFeed() {
   const queryClient = useQueryClient();
 
   const [mode, setMode] = useState<AddFeedMode>('subscribe');
+  const [subscribeInputMode, setSubscribeInputMode] = useState<SubscribeInputMode>('search');
 
   // Input state
   const [inputValue, setInputValue] = useState('');
@@ -396,8 +398,8 @@ function AddFeed() {
   const [isDragging, setIsDragging] = useState(false);
   const [opmlResult, setOpmlResult] = useState<OpmlImportResult | null>(null);
 
-  // Detect URL vs search
-  const isUrl = /^https?:\/\//.test(inputValue);
+  // Detect URL vs search (URL mode, or a pasted URL while in search mode)
+  const isUrl = subscribeInputMode === 'url' || /^https?:\/\//.test(inputValue);
 
   // URL validation (only when it looks like a URL)
   const urlValidation = useMemo(() => isUrl ? validateUrl(inputValue) : { isValid: false, error: null, warning: null }, [inputValue, isUrl]);
@@ -420,7 +422,8 @@ function AddFeed() {
   }, [feedsData]);
 
   const inputTrimmed = inputValue.trim();
-  const shouldSearch = !isUrl && searchEnabled && inputTrimmed.length >= 2;
+  const inSearchMode = searchEnabled && subscribeInputMode === 'search' && !/^https?:\/\//.test(inputValue);
+  const shouldSearch = inSearchMode && inputTrimmed.length >= 2;
 
   // Clear stale search state during render when the search is no longer
   // applicable. Avoids a setState-in-effect for the early-return branch.
@@ -512,10 +515,18 @@ function AddFeed() {
     setIsDragging(false);
   }, []);
 
+  const switchSubscribeInputMode = (next: SubscribeInputMode) => {
+    setSubscribeInputMode(next);
+    setInputValue('');
+    setSearchResults([]);
+    setSearchError(null);
+    setTouched(false);
+  };
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setTouched(true);
-    if (isUrl && inputValue.trim() && urlValidation.isValid) {
+    if ((subscribeInputMode === 'url' || !searchEnabled) && inputValue.trim() && urlValidation.isValid) {
       mutation.mutate();
     }
   };
@@ -565,32 +576,92 @@ function AddFeed() {
         </div>
       )}
 
-      {/* Section A: Unified Input */}
+      {searchEnabled && (
+        <div className="flex border border-border rounded overflow-hidden mb-4 w-fit">
+          <button
+            type="button"
+            onClick={() => switchSubscribeInputMode('search')}
+            aria-pressed={subscribeInputMode === 'search'}
+            className={`px-4 py-2 text-sm font-medium transition-colors ${
+              subscribeInputMode === 'search' ? btnPrimary : btnSecondary
+            } ${focusRing}`}
+          >
+            Search
+          </button>
+          <button
+            type="button"
+            onClick={() => switchSubscribeInputMode('url')}
+            aria-pressed={subscribeInputMode === 'url'}
+            className={`px-4 py-2 text-sm font-medium transition-colors ${
+              subscribeInputMode === 'url' ? btnPrimary : btnSecondary
+            } ${focusRing}`}
+          >
+            Enter RSS URL
+          </button>
+        </div>
+      )}
+
+      {/* Section A: Search or URL input */}
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
-          <label htmlFor="podcastInput" className="block text-sm font-medium text-foreground mb-2">
-            {searchEnabled ? 'Search podcasts or enter RSS URL' : 'Podcast RSS Feed URL'}
-          </label>
-          <input
-            type="text"
-            id="podcastInput"
-            value={inputValue}
-            onChange={(e) => setInputValue(e.target.value)}
-            onBlur={() => { if (isUrl) setTouched(true); }}
-            placeholder={searchEnabled ? 'Search by name or paste an RSS feed URL...' : 'https://example.com/podcast/feed.xml'}
-            className={`w-full px-4 py-2 rounded-lg border bg-background text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-ring ${
-              isUrl && touched && urlValidation.error
-                ? 'border-destructive focus:ring-destructive'
-                : isUrl && touched && urlValidation.warning
-                  ? 'border-warning focus:ring-warning'
-                  : 'border-input'
-            }`}
-          />
-          {isUrl && touched && urlValidation.error && (
-            <p className="mt-1 text-sm text-destructive">{urlValidation.error}</p>
-          )}
-          {isUrl && touched && !urlValidation.error && urlValidation.warning && (
-            <p className="mt-1 text-sm text-warning">{urlValidation.warning}</p>
+          {inSearchMode || (searchEnabled && subscribeInputMode === 'search' && !isUrl) ? (
+            <>
+              <label htmlFor="podcastInput" className="block text-sm font-medium text-foreground mb-2">
+                Search podcasts
+              </label>
+              <div className="relative">
+                <svg
+                  className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-muted-foreground pointer-events-none"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  aria-hidden="true"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                </svg>
+                <input
+                  type="search"
+                  id="podcastInput"
+                  value={inputValue}
+                  onChange={(e) => setInputValue(e.target.value)}
+                  placeholder="e.g. Radiolab, Hard Fork, NPR..."
+                  autoComplete="off"
+                  className="w-full pl-10 pr-4 py-2 rounded-lg border border-input bg-background text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-ring"
+                />
+              </div>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {searchProvider === 'itunes'
+                  ? "Searches Apple's podcast directory. Results appear as you type."
+                  : 'Results appear as you type.'}
+              </p>
+            </>
+          ) : (
+            <>
+              <label htmlFor="podcastInput" className="block text-sm font-medium text-foreground mb-2">
+                Podcast RSS Feed URL
+              </label>
+              <input
+                type="url"
+                id="podcastInput"
+                value={inputValue}
+                onChange={(e) => setInputValue(e.target.value)}
+                onBlur={() => setTouched(true)}
+                placeholder="https://example.com/podcast/feed.xml"
+                className={`w-full px-4 py-2 rounded-lg border bg-background text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-ring ${
+                  touched && urlValidation.error
+                    ? 'border-destructive focus:ring-destructive'
+                    : touched && urlValidation.warning
+                      ? 'border-warning focus:ring-warning'
+                      : 'border-input'
+                }`}
+              />
+              {touched && urlValidation.error && (
+                <p className="mt-1 text-sm text-destructive">{urlValidation.error}</p>
+              )}
+              {touched && !urlValidation.error && urlValidation.warning && (
+                <p className="mt-1 text-sm text-warning">{urlValidation.warning}</p>
+              )}
+            </>
           )}
         </div>
 
@@ -670,7 +741,7 @@ function AddFeed() {
         </details>
 
         {/* URL mode: show Add Feed button */}
-        {isUrl && (
+        {(subscribeInputMode === 'url' || !searchEnabled) && (
           <>
             {mutation.error && (
               <div className="p-4 rounded-lg bg-destructive/10 text-destructive">
@@ -698,7 +769,7 @@ function AddFeed() {
       </form>
 
       {/* Section C: Search Results */}
-      {!isUrl && inputValue.trim() && searchEnabled && (
+      {inSearchMode && inputValue.trim() && (
         <div className="mt-4 space-y-2">
           {isSearching && (
             <div className="space-y-3">

--- a/frontend/src/pages/EpisodeDetail.tsx
+++ b/frontend/src/pages/EpisodeDetail.tsx
@@ -392,8 +392,8 @@ function EpisodeDetail() {
   const submitCorrectionAsync = (correction: AdCorrection) =>
     correctionMutation.mutateAsync(correction);
 
-  const handleTranscriptRecut = () => {
-    reprocessMutation.mutate('recut');
+  const handleTranscriptRecut = async () => {
+    await reprocessMutation.mutateAsync('recut');
   };
 
   const handleTranscriptWaveformHandoff = (opts: {

--- a/frontend/src/pages/EpisodeDetail.tsx
+++ b/frontend/src/pages/EpisodeDetail.tsx
@@ -19,6 +19,7 @@ import { CORROBORATION_CLASS, CORROBORATION_META } from '../utils/corroboration'
 import { formatConfidence } from '../utils/confidence';
 import AdEditor, { AdCorrection } from '../components/AdEditor';
 import AdReviewModal from '../components/AdReviewModal';
+import TranscriptSegmentWorkspace from '../components/TranscriptSegmentWorkspace';
 import type { AdSegment, Feed, EpisodeDetail as EpisodeDetailApi } from '../api/types';
 import PatternLink from '../components/PatternLink';
 import ExpandableText from '../components/ExpandableText';
@@ -245,6 +246,7 @@ type SaveStatus = 'idle' | 'saving' | 'success' | 'error';
 function EpisodeDetail() {
   const { slug, episodeId } = useParams<{ slug: string; episodeId: string }>();
   const [showEditor, setShowEditor] = useState(false);
+  const [showTranscriptWorkspace, setShowTranscriptWorkspace] = useState(false);
   const [createModeRequested, setCreateModeRequested] = useState(false);
   const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
   // Transient error toast for a rejected correction submit (e.g. a 409 on a
@@ -255,6 +257,12 @@ function EpisodeDetail() {
   // Held/rejected row currently open in the standalone waveform editor
   // (issue #563). Independent of showEditor/AdEditor state.
   const [reviewMarker, setReviewMarker] = useState<{ segment: AdSegment; key: string; fromHeld: boolean } | null>(null);
+  const [transcriptWaveformHandoff, setTranscriptWaveformHandoff] = useState<{
+    start: number;
+    end: number;
+    createMode: boolean;
+    marker?: AdSegment;
+  } | null>(null);
   const [savedScrollY, setSavedScrollY] = useState<number | null>(null);
   const [reviewMode, setReviewMode] = useLocalStorageState<'processed' | 'original'>(
     'ad-editor-review-mode',
@@ -379,6 +387,31 @@ function EpisodeDetail() {
   // Handle ad corrections from AdEditor
   const handleCorrection = (correction: AdCorrection) => {
     correctionMutation.mutate(correction);
+  };
+
+  const submitCorrectionAsync = (correction: AdCorrection) =>
+    correctionMutation.mutateAsync(correction);
+
+  const handleTranscriptRecut = () => {
+    reprocessMutation.mutate('recut');
+  };
+
+  const handleTranscriptWaveformHandoff = (opts: {
+    start: number;
+    end: number;
+    createMode: boolean;
+    marker?: AdSegment;
+  }) => {
+    setShowTranscriptWorkspace(false);
+    if (opts.marker && !opts.createMode) {
+      setReviewMarker({
+        segment: opts.marker,
+        key: `transcript-${opts.start}-${opts.end}`,
+        fromHeld: !!opts.marker.held_for_review,
+      });
+      return;
+    }
+    setTranscriptWaveformHandoff(opts);
   };
 
   // Per-row save status for the Held-for-Review and Detections-Not-Cut rows.
@@ -778,6 +811,18 @@ function EpisodeDetail() {
           </div>
         )}
 
+        {episode.status === 'completed' && episode.originalTranscriptAvailable && (
+          <div className="mt-4 pt-4 border-t border-border flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => setShowTranscriptWorkspace(true)}
+              className={`px-3 py-1.5 text-sm rounded-md ${btnPrimary} transition-colors ${focusRing}`}
+            >
+              Review transcript
+            </button>
+          </div>
+        )}
+
         {episode.status === 'completed' && (
           <div className="mt-4 pt-4 border-t border-border">
             {/* processedUrl is server-built and carries the feed auth key when
@@ -899,15 +944,15 @@ function EpisodeDetail() {
                 <div className="flex items-center gap-1.5 shrink-0">
                   <button
                     onClick={() => openEditorFresh(false)}
-                    aria-label={showEditor ? 'Hide editor' : 'Edit ads'}
-                    title={showEditor ? 'Hide editor' : 'Edit ads'}
+                    aria-label={showEditor ? 'Hide waveform editor' : 'Fine-tune in waveform'}
+                    title={showEditor ? 'Hide waveform editor' : 'Fine-tune in waveform'}
                     className={`inline-flex items-center gap-1.5 px-2 sm:px-3 py-1.5 text-xs sm:text-sm ${btnSecondary} rounded-md transition-colors whitespace-nowrap ${focusRing}`}
                   >
                     <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
                         d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
                     </svg>
-                    <span className="hidden sm:inline">{showEditor ? 'Hide Editor' : 'Edit Ads'}</span>
+                    <span className="hidden sm:inline">{showEditor ? 'Hide waveform' : 'Fine-tune in waveform'}</span>
                   </button>
                   <button
                     onClick={() => openEditorFresh(true)}
@@ -1201,6 +1246,83 @@ function EpisodeDetail() {
           />
         );
       })()}
+
+      {showTranscriptWorkspace && (
+        <TranscriptSegmentWorkspace
+          slug={slug!}
+          episodeId={episodeId!}
+          episode={episode}
+          onClose={() => setShowTranscriptWorkspace(false)}
+          onSubmitCorrection={submitCorrectionAsync}
+          onRecut={handleTranscriptRecut}
+          onOpenWaveform={handleTranscriptWaveformHandoff}
+          saveStatus={saveStatus}
+          correctionError={correctionError}
+        />
+      )}
+
+      {transcriptWaveformHandoff && (
+        <AdReviewModal
+          key={`transcript-handoff-${transcriptWaveformHandoff.start}-${transcriptWaveformHandoff.end}`}
+          mode={transcriptWaveformHandoff.createMode ? 'create' : 'review'}
+          hasNext={false}
+          item={{
+            podcastSlug: slug!,
+            episodeId: episodeId!,
+            start: transcriptWaveformHandoff.start,
+            end: transcriptWaveformHandoff.end,
+            sponsor: transcriptWaveformHandoff.marker?.sponsor ?? null,
+            reason: transcriptWaveformHandoff.marker?.reason ?? '',
+            confidence: transcriptWaveformHandoff.marker?.confidence ?? null,
+            detectionStage: transcriptWaveformHandoff.marker?.detection_stage ?? 'manual',
+            patternId: transcriptWaveformHandoff.marker?.pattern_id ?? null,
+            correctedBounds: null,
+          }}
+          audioMode="original"
+          hasOriginal={!!episode.hasOriginalAudio}
+          episodeDuration={episode.originalDuration ?? 0}
+          onSubmit={(s) => {
+            const marker = transcriptWaveformHandoff.marker;
+            const originalAd = marker
+              ? toOriginalAd(marker)
+              : {
+                  start: transcriptWaveformHandoff.start,
+                  end: transcriptWaveformHandoff.end,
+                  confidence: 1,
+                  reason: '',
+                };
+            if (s.kind === 'reject') {
+              handleCorrection({ type: 'reject', originalAd });
+            } else if (s.kind === 'adjust') {
+              handleCorrection({
+                type: 'adjust',
+                originalAd,
+                adjustedStart: s.adjustedStart,
+                adjustedEnd: s.adjustedEnd,
+                sponsor: s.sponsor,
+              });
+            } else {
+              handleCorrection({ type: 'confirm', originalAd, sponsor: s.sponsor });
+            }
+            setTranscriptWaveformHandoff(null);
+          }}
+          onCreate={(s) => {
+            handleCorrection({
+              type: 'create',
+              start: s.start,
+              end: s.end,
+              sponsor: s.sponsor,
+              text_template: s.textTemplate,
+              scope: s.scope,
+              reason: s.reason,
+              category: s.category,
+            });
+            setTranscriptWaveformHandoff(null);
+          }}
+          onSkip={() => setTranscriptWaveformHandoff(null)}
+          onClose={() => setTranscriptWaveformHandoff(null)}
+        />
+      )}
 
       {heldMarkers.length > 0 && (
         <div className="bg-card rounded-lg border border-warning/30 p-6 mb-6" data-testid="held-for-review-section">

--- a/frontend/src/pages/patterns/AdReviewTab.test.tsx
+++ b/frontend/src/pages/patterns/AdReviewTab.test.tsx
@@ -259,13 +259,26 @@ describe('AdReviewTab row actions', () => {
     expect(screen.queryByRole('button', { name: /play/i })).toBeNull();
   });
 
+  it('kept segments show no review actions', async () => {
+    mockGetDetections.mockResolvedValue({
+      detections: [detection({ actionApplied: 'keep', status: 'rejected' })],
+      total: 1, page: 1, totalPages: 1, limit: 20, counts: COUNTS,
+    });
+    renderTab();
+    await screen.findAllByRole('link', { name: 'Episode One' });
+    expect(screen.queryByRole('button', { name: 'Confirm ad' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Not an ad' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull();
+    expect(screen.getAllByText('Kept').length).toBeGreaterThan(0);
+  });
+
   it('shows error banner when correction fails and does not call reprocess', async () => {
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     mockSubmitCorrection.mockRejectedValueOnce(new Error('boom'));
     renderTab();
     const user = userEvent.setup();
     await user.click((await screen.findAllByRole('button', { name: 'Confirm ad' }))[0]);
-    expect(await screen.findByText('Failed to save correction. Try again.')).toBeTruthy();
+    expect(await screen.findByText('boom')).toBeTruthy();
     expect(mockReprocess).not.toHaveBeenCalled();
     errSpy.mockRestore();
   });

--- a/frontend/src/pages/patterns/DetectionRows.tsx
+++ b/frontend/src/pages/patterns/DetectionRows.tsx
@@ -61,7 +61,9 @@ function DetectionBadges({ d, showCategory }: { d: ReviewDetection; showCategory
     <div className="flex gap-1.5 shrink-0">
       <DetectionStatusBadge status={d.status} />
       <ResolutionBadge resolution={d.resolution} />
-      {showCategory && <ActionBadge action={d.actionApplied} />}
+      {(showCategory || d.actionApplied === 'keep') && (
+        <ActionBadge action={d.actionApplied} />
+      )}
     </div>
   );
 }
@@ -123,7 +125,8 @@ function DetectionActions({ d, variant, playing, onTogglePlay, actions }: {
   const btn = isCard
     ? 'px-2 py-2.5 text-xs min-[370px]:px-2.5 min-[370px]:text-sm rounded touch-manipulation whitespace-nowrap text-center max-w-full overflow-hidden'
     : 'px-1.5 py-1 text-xs rounded whitespace-nowrap';
-  const undecided = d.resolution === 'unresolved';
+  // Deliberate keeps are final per-feed decisions; the API rejects corrections.
+  const undecided = d.resolution === 'unresolved' && d.actionApplied !== 'keep';
   // grow exists to balance the Confirm/Not-an-ad pair on review cards. With
   // no Confirm (Detected Ads), a lone grow turns Not an ad into a full-width
   // slab, so the buttons stay content-sized there.
@@ -165,14 +168,16 @@ function DetectionActions({ d, variant, playing, onTogglePlay, actions }: {
           Split
         </button>
       )}
-      <button
-        type="button"
-        onClick={() => actions.onEdit(d)}
-        disabled={actions.busy}
-        className={`${btn} ${isCard ? 'ml-auto ' : ''}${btnOutline} disabled:opacity-50 ${focusRing}`}
-      >
-        Edit
-      </button>
+      {d.actionApplied !== 'keep' && (
+        <button
+          type="button"
+          onClick={() => actions.onEdit(d)}
+          disabled={actions.busy}
+          className={`${btn} ${isCard ? 'ml-auto ' : ''}${btnOutline} disabled:opacity-50 ${focusRing}`}
+        >
+          Edit
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/patterns/useDetectionCorrections.ts
+++ b/frontend/src/pages/patterns/useDetectionCorrections.ts
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useMutation, useQueryClient, type QueryClient } from '@tanstack/react-query';
 import type { ReviewDetection } from '../../api/detections';
 import { reprocessEpisode } from '../../api/feeds';
+import { getErrorMessage } from '../../api/client';
 import { submitCorrection, type PatternCorrection } from '../../api/patterns';
 
 // Refresh what a recut changes, then start it. Logs and resolves false when
@@ -61,7 +62,7 @@ export function useDetectionCorrections({ stopAudition, onSettled }: Options) {
     },
     onError: (error) => {
       console.error('Failed to save correction:', error);
-      setActionError('Failed to save correction. Try again.');
+      setActionError(getErrorMessage(error, 'Failed to save correction. Try again.'));
     },
   });
 

--- a/frontend/src/utils/completionAlert.ts
+++ b/frontend/src/utils/completionAlert.ts
@@ -1,0 +1,173 @@
+export type CompletionAlertOptions = {
+  title: string;
+  body: string;
+  blinkTitle?: string;
+  tag?: string;
+  playSound?: boolean;
+  icon?: string;
+};
+
+export type CompletionAlertController = {
+  stopBlink: () => void;
+  stop: () => void;
+};
+
+const BLINK_MS = 1000;
+
+let activeAlert: CompletionAlertController | null = null;
+
+export async function ensureNotificationPermission(): Promise<NotificationPermission | 'unsupported'> {
+  if (typeof window === 'undefined' || typeof Notification === 'undefined') {
+    return 'unsupported';
+  }
+  if (Notification.permission === 'default') {
+    try {
+      return await Notification.requestPermission();
+    } catch {
+      return Notification.permission;
+    }
+  }
+  return Notification.permission;
+}
+
+function playCompletionChime(): void {
+  if (typeof window === 'undefined') return;
+  const AC =
+    window.AudioContext
+    || (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+  if (!AC) return;
+
+  try {
+    const ctx = new AC();
+    const playTone = (freq: number, start: number, duration: number) => {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = 'sine';
+      osc.frequency.value = freq;
+      gain.gain.setValueAtTime(0.0001, start);
+      gain.gain.exponentialRampToValueAtTime(0.18, start + 0.02);
+      gain.gain.exponentialRampToValueAtTime(0.0001, start + duration);
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      osc.start(start);
+      osc.stop(start + duration + 0.02);
+    };
+
+    void ctx.resume().then(() => {
+      const t0 = ctx.currentTime;
+      playTone(880, t0, 0.12);
+      playTone(1174.7, t0 + 0.14, 0.18);
+      window.setTimeout(() => {
+        void ctx.close().catch(() => undefined);
+      }, 500);
+    });
+  } catch {
+    // autoplay blocked or unsupported
+  }
+}
+
+function defaultNotificationIcon(): string | undefined {
+  if (typeof window === 'undefined') return undefined;
+  try {
+    return new URL('/images/logos/logo.webp', window.location.origin).href;
+  } catch {
+    return undefined;
+  }
+}
+
+function showDesktopNotification(
+  options: CompletionAlertOptions,
+): Notification | null {
+  if (typeof window === 'undefined' || typeof Notification === 'undefined') {
+    return null;
+  }
+  if (Notification.permission !== 'granted') {
+    return null;
+  }
+
+  const icon = options.icon ?? defaultNotificationIcon();
+  try {
+    const notification = new Notification(options.title, {
+      body: options.body,
+      tag: options.tag ?? 'minuspod-recut-complete',
+      requireInteraction: true,
+      silent: false,
+      ...(icon ? { icon } : {}),
+    });
+    notification.onclick = () => {
+      try {
+        window.focus();
+      } catch {
+        // ignore
+      }
+      notification.close();
+    };
+    return notification;
+  } catch {
+    return null;
+  }
+}
+
+export function stopActiveCompletionAlert(): void {
+  activeAlert?.stop();
+  activeAlert = null;
+}
+
+export function startCompletionAlert(
+  options: CompletionAlertOptions,
+): CompletionAlertController {
+  stopActiveCompletionAlert();
+
+  const blinkTitle = options.blinkTitle ?? 'Recut complete';
+  const originalTitle =
+    typeof document !== 'undefined' ? document.title : '';
+  let intervalId: ReturnType<typeof setInterval> | null = null;
+  let showingAlertTitle = false;
+  let notification: Notification | null = null;
+  let stopped = false;
+
+  const stopBlink = () => {
+    if (intervalId !== null) {
+      clearInterval(intervalId);
+      intervalId = null;
+    }
+    if (typeof document !== 'undefined' && originalTitle) {
+      document.title = originalTitle;
+    }
+    showingAlertTitle = false;
+  };
+
+  const stop = () => {
+    if (stopped) return;
+    stopped = true;
+    stopBlink();
+    if (notification) {
+      try {
+        notification.close();
+      } catch {
+        // ignore
+      }
+      notification = null;
+    }
+    if (activeAlert === controller) {
+      activeAlert = null;
+    }
+  };
+
+  if (options.playSound !== false) {
+    playCompletionChime();
+  }
+
+  notification = showDesktopNotification(options);
+
+  if (typeof document !== 'undefined') {
+    intervalId = setInterval(() => {
+      showingAlertTitle = !showingAlertTitle;
+      document.title = showingAlertTitle ? blinkTitle : originalTitle;
+    }, BLINK_MS);
+  }
+
+  const controller: CompletionAlertController = { stopBlink, stop };
+  activeAlert = controller;
+  return controller;
+}

--- a/frontend/src/utils/segmentReviewModel.test.ts
+++ b/frontend/src/utils/segmentReviewModel.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import type { OriginalSegment } from '../api/feeds';
+import type { AdSegment, EpisodeDetail } from '../api/types';
+import {
+  boundsFromSelectedIndexes,
+  buildSegmentReviewRows,
+  contiguousIndexGroups,
+  ensureMinTextTemplate,
+  findOverlappingMarker,
+  overlaps,
+  rangeIndexes,
+  selectionOverlapsKept,
+  snapToWords,
+} from './segmentReviewModel';
+
+const segments: OriginalSegment[] = [
+  { start: 0, end: 5, text: 'Hello world this is content.', words: [
+    { word: 'Hello', start: 0, end: 0.5 },
+    { word: 'world', start: 0.5, end: 1 },
+  ] },
+  { start: 5, end: 12, text: 'Squarespace dot com slash show promo here today.', words: [
+    { word: 'Squarespace', start: 5, end: 6 },
+    { word: 'promo', start: 10, end: 11 },
+  ] },
+  { start: 12, end: 20, text: 'Back to the show after the break.', words: [] },
+];
+
+const baseEpisode: Pick<
+  EpisodeDetail,
+  'adMarkers' | 'pendingReviewMarkers' | 'rejectedAdMarkers' | 'keptMarkers' | 'corrections'
+> = {
+  adMarkers: [{
+    start: 5,
+    end: 12,
+    confidence: 0.9,
+    reason: 'Squarespace',
+  }],
+  pendingReviewMarkers: [],
+  rejectedAdMarkers: [],
+  keptMarkers: [],
+  corrections: [],
+};
+
+describe('segmentReviewModel', () => {
+  it('overlaps detects partial overlap', () => {
+    expect(overlaps(4, 6, { start: 5, end: 12 })).toBe(true);
+    expect(overlaps(12, 14, { start: 5, end: 12 })).toBe(false);
+  });
+
+  it('buildSegmentReviewRows labels cut and content segments', () => {
+    const rows = buildSegmentReviewRows(segments, baseEpisode, [
+      { start: 5, end: 12 },
+    ]);
+    expect(rows[0].label).toBe('content');
+    expect(rows[1].label).toBe('cut');
+    expect(rows[2].label).toBe('content');
+  });
+
+  it('false positive corrections relabel as content', () => {
+    const rows = buildSegmentReviewRows(segments, {
+      ...baseEpisode,
+      corrections: [{
+        id: 1,
+        correction_type: 'false_positive',
+        original_bounds: { start: 5, end: 12 },
+        created_at: '2026-01-01T00:00:00Z',
+      }],
+    }, [{ start: 5, end: 12 }]);
+    expect(rows[1].label).toBe('content');
+  });
+
+  it('contiguousIndexGroups merges adjacent indexes', () => {
+    const groups = contiguousIndexGroups(new Set([0, 1, 3]), segments);
+    expect(groups).toEqual([[0, 1], [3]]);
+  });
+
+  it('rangeIndexes builds inclusive range', () => {
+    expect([...rangeIndexes(2, 4)]).toEqual([2, 3, 4]);
+  });
+
+  it('snapToWords snaps to nearest word boundaries', () => {
+    const snapped = snapToWords(5.1, 11.05, segments);
+    expect(snapped.start).toBe(5);
+    expect(snapped.end).toBe(11);
+  });
+
+  it('boundsFromSelectedIndexes returns snapped groups', () => {
+    const rows = buildSegmentReviewRows(segments, baseEpisode);
+    const bounds = boundsFromSelectedIndexes(new Set([1]), rows, segments);
+    expect(bounds).toHaveLength(1);
+    expect(bounds[0].start).toBe(5);
+    expect(bounds[0].text).toContain('Squarespace');
+  });
+
+  it('ensureMinTextTemplate pads short text from adjacent segments', () => {
+    const text = ensureMinTextTemplate('short', segments, 5, 12);
+    expect(text.length).toBeGreaterThanOrEqual(50);
+  });
+
+  it('findOverlappingMarker matches overlapping ad marker', () => {
+    const marker: AdSegment = { start: 5, end: 12, confidence: 0.8 };
+    expect(findOverlappingMarker(6, 10, [marker])?.start).toBe(5);
+  });
+
+  it('selectionOverlapsKept detects kept overlap', () => {
+    const kept: AdSegment = { start: 1, end: 4, confidence: 1, actionApplied: 'keep' };
+    expect(selectionOverlapsKept({ start: 2, end: 3 }, [kept])).toBe(true);
+  });
+});

--- a/frontend/src/utils/segmentReviewModel.ts
+++ b/frontend/src/utils/segmentReviewModel.ts
@@ -1,0 +1,379 @@
+import type { OriginalSegment, TranscriptWord } from '../api/feeds';
+import type { AdSegment, EpisodeCorrection, EpisodeDetail } from '../api/types';
+
+export type SegmentLabel =
+  | 'content'
+  | 'ad'
+  | 'cut'
+  | 'pending'
+  | 'rejected'
+  | 'kept';
+
+export interface TimeRange {
+  start: number;
+  end: number;
+}
+
+export interface AppliedCutRange extends TimeRange {
+  replacementDuration?: number;
+}
+
+export interface SegmentReviewRow {
+  index: number;
+  sequenceNum: number;
+  start: number;
+  end: number;
+  text: string;
+  words?: TranscriptWord[];
+  label: SegmentLabel;
+  mixed: boolean;
+}
+
+export interface SelectionBounds {
+  start: number;
+  end: number;
+  text: string;
+}
+
+export const ADJACENT_GAP_SECONDS = 1;
+export const MIN_TEXT_TEMPLATE_CHARS = 50;
+const MARKER_MATCH_TOLERANCE = 0.5;
+
+export function overlaps(aStart: number, aEnd: number, block: TimeRange): boolean {
+  return aStart < block.end && aEnd > block.start;
+}
+
+export function overlapFraction(
+  segStart: number,
+  segEnd: number,
+  block: TimeRange,
+): number {
+  const start = Math.max(segStart, block.start);
+  const end = Math.min(segEnd, block.end);
+  if (end <= start) return 0;
+  return (end - start) / (segEnd - segStart);
+}
+
+export function contiguousIndexGroups(
+  indexes: Set<number>,
+  segments: OriginalSegment[] = [],
+): number[][] {
+  if (indexes.size === 0) return [];
+  const sorted = [...indexes].sort((a, b) => a - b);
+  const groups: number[][] = [];
+  let current: number[] = [sorted[0]];
+  for (let i = 1; i < sorted.length; i += 1) {
+    const prev = sorted[i - 1];
+    const next = sorted[i];
+    const prevRow = segments[prev];
+    const nextRow = segments[next];
+    const adjacentIndex = next === prev + 1;
+    const adjacentTime =
+      prevRow && nextRow
+        ? nextRow.start - prevRow.end <= ADJACENT_GAP_SECONDS
+        : true;
+    if (adjacentIndex && adjacentTime) {
+      current.push(next);
+    } else {
+      groups.push(current);
+      current = [next];
+    }
+  }
+  groups.push(current);
+  return groups;
+}
+
+export function rangeIndexes(from: number, to: number): Set<number> {
+  const start = Math.min(from, to);
+  const end = Math.max(from, to);
+  return new Set(Array.from({ length: end - start + 1 }, (_, i) => start + i));
+}
+
+export function snapToWords(
+  start: number,
+  end: number,
+  segments: OriginalSegment[],
+  tolerance = 0.75,
+): TimeRange {
+  const words = segments.flatMap((segment) => segment.words || []);
+  if (!words.length) {
+    return { start, end };
+  }
+  const startCandidates = words.filter((word) => Math.abs(word.start - start) <= tolerance);
+  const endCandidates = words.filter((word) => Math.abs(word.end - end) <= tolerance);
+  const snappedStart = startCandidates.length
+    ? startCandidates.reduce((best, word) =>
+        Math.abs(word.start - start) < Math.abs(best.start - start) ? word : best,
+      ).start
+    : start;
+  const snappedEnd = endCandidates.length
+    ? endCandidates.reduce((best, word) =>
+        Math.abs(word.end - end) < Math.abs(best.end - end) ? word : best,
+      ).end
+    : end;
+  if (snappedEnd <= snappedStart) {
+    return { start, end };
+  }
+  return { start: snappedStart, end: snappedEnd };
+}
+
+function falsePositiveRanges(corrections: EpisodeCorrection[] | undefined): TimeRange[] {
+  return (corrections ?? [])
+    .filter((c) => c.correction_type === 'false_positive' && c.original_bounds)
+    .map((c) => c.original_bounds!);
+}
+
+export function allEpisodeMarkers(episode: Pick<
+  EpisodeDetail,
+  'adMarkers' | 'pendingReviewMarkers' | 'rejectedAdMarkers' | 'keptMarkers'
+>): AdSegment[] {
+  return [
+    ...(episode.adMarkers ?? []),
+    ...(episode.pendingReviewMarkers ?? []),
+    ...(episode.rejectedAdMarkers ?? []),
+    ...(episode.keptMarkers ?? []),
+  ];
+}
+
+function classifySegment(
+  segStart: number,
+  segEnd: number,
+  opts: {
+    appliedCuts: AppliedCutRange[];
+    falsePositives: TimeRange[];
+    kept: AdSegment[];
+    pending: AdSegment[];
+    rejected: AdSegment[];
+    cutMarkers: AdSegment[];
+  },
+): { label: SegmentLabel; mixed: boolean } {
+  const fpOverlap = opts.falsePositives.some(
+    (fp) => overlapFraction(segStart, segEnd, fp) >= 0.5,
+  );
+  if (fpOverlap) {
+    const alsoCut = opts.appliedCuts.some((c) => overlapFraction(segStart, segEnd, c) >= 0.5)
+      || opts.cutMarkers.some((m) => overlapFraction(segStart, segEnd, m) >= 0.5);
+    return { label: 'content', mixed: alsoCut };
+  }
+
+  const regions: Array<{ label: SegmentLabel; range: TimeRange }> = [
+    ...opts.appliedCuts.map((c) => ({ label: 'cut' as const, range: c })),
+    ...opts.kept.map((m) => ({ label: 'kept' as const, range: m })),
+    ...opts.pending.map((m) => ({ label: 'pending' as const, range: m })),
+    ...opts.rejected.map((m) => ({ label: 'rejected' as const, range: m })),
+    ...opts.cutMarkers.map((m) => ({ label: 'ad' as const, range: m })),
+  ];
+
+  let primary: SegmentLabel = 'content';
+  let mixed = false;
+  const priority: Record<SegmentLabel, number> = {
+    cut: 6,
+    ad: 5,
+    pending: 4,
+    rejected: 3,
+    kept: 2,
+    content: 1,
+  };
+
+  for (const { label, range } of regions) {
+    const frac = overlapFraction(segStart, segEnd, range);
+    if (frac <= 0) continue;
+    if (frac < 0.5 && primary !== 'content') {
+      mixed = true;
+      continue;
+    }
+    if (frac >= 0.5) {
+      if (priority[label] > priority[primary]) {
+        if (primary !== 'content') mixed = true;
+        primary = label;
+      } else if (label !== primary) {
+        mixed = true;
+      }
+    }
+  }
+
+  if (primary === 'ad' && opts.appliedCuts.some((c) => overlaps(segStart, segEnd, c))) {
+    primary = 'cut';
+  }
+
+  return { label: primary, mixed };
+}
+
+export function buildSegmentReviewRows(
+  segments: OriginalSegment[],
+  episode: Pick<
+    EpisodeDetail,
+    'adMarkers' | 'pendingReviewMarkers' | 'rejectedAdMarkers' | 'keptMarkers' | 'corrections'
+  >,
+  appliedCuts: AppliedCutRange[] = [],
+): SegmentReviewRow[] {
+  const falsePositives = falsePositiveRanges(episode.corrections);
+  const opts = {
+    appliedCuts,
+    falsePositives,
+    kept: episode.keptMarkers ?? [],
+    pending: episode.pendingReviewMarkers ?? [],
+    rejected: episode.rejectedAdMarkers ?? [],
+    cutMarkers: episode.adMarkers ?? [],
+  };
+
+  return segments.map((segment, index) => {
+    const { label, mixed } = classifySegment(segment.start, segment.end, opts);
+    return {
+      index,
+      sequenceNum: index + 1,
+      start: segment.start,
+      end: segment.end,
+      text: segment.text,
+      words: segment.words,
+      label,
+      mixed,
+    };
+  });
+}
+
+export function concatSegmentText(rows: SegmentReviewRow[]): string {
+  return rows.map((row) => row.text.trim()).filter(Boolean).join(' ').trim();
+}
+
+export function ensureMinTextTemplate(
+  text: string,
+  segments: OriginalSegment[],
+  start: number,
+  end: number,
+): string {
+  let out = text.trim();
+  if (out.length >= MIN_TEXT_TEMPLATE_CHARS) return out;
+
+  const inRange = segments.filter(
+    (seg) => seg.end > start && seg.start < end,
+  );
+  out = inRange.map((s) => s.text.trim()).join(' ').trim();
+  if (out.length >= MIN_TEXT_TEMPLATE_CHARS) return out;
+
+  const startIdx = segments.findIndex((seg) => seg.end > start);
+  if (startIdx >= 0) {
+    for (let i = startIdx; i < segments.length && out.length < MIN_TEXT_TEMPLATE_CHARS; i += 1) {
+      const piece = segments[i].text.trim();
+      if (piece) out = out ? `${out} ${piece}` : piece;
+    }
+  }
+  return out.slice(0, 512);
+}
+
+export function boundsFromSelectedIndexes(
+  indexes: Set<number>,
+  rows: SegmentReviewRow[],
+  segments: OriginalSegment[],
+): SelectionBounds[] {
+  const groups = contiguousIndexGroups(indexes, segments);
+  return groups.map((group) => {
+    const groupRows = group.map((idx) => rows[idx]);
+    const snapped = snapToWords(
+      groupRows[0].start,
+      groupRows[groupRows.length - 1].end,
+      groupRows.map((r) => ({ start: r.start, end: r.end, text: r.text, words: r.words })),
+    );
+    return {
+      ...snapped,
+      text: concatSegmentText(groupRows),
+    };
+  });
+}
+
+export function boundsFromManualTimes(
+  start: number,
+  end: number,
+  segments: OriginalSegment[],
+): SelectionBounds | null {
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) {
+    return null;
+  }
+  const snapped = snapToWords(start, end, segments);
+  const rows = segments
+    .map((seg, index) => ({
+      index,
+      sequenceNum: index + 1,
+      start: seg.start,
+      end: seg.end,
+      text: seg.text,
+      words: seg.words,
+      label: 'content' as const,
+      mixed: false,
+    }))
+    .filter((row) => overlaps(row.start, row.end, snapped));
+  return {
+    ...snapped,
+    text: concatSegmentText(rows),
+  };
+}
+
+export function findOverlappingMarker(
+  start: number,
+  end: number,
+  markers: AdSegment[],
+  tolerance = MARKER_MATCH_TOLERANCE,
+): AdSegment | null {
+  for (const marker of markers) {
+    if (
+      Math.abs(marker.start - start) <= tolerance
+      && Math.abs(marker.end - end) <= tolerance
+    ) {
+      return marker;
+    }
+    if (overlaps(start, end, marker)) {
+      return marker;
+    }
+  }
+  return null;
+}
+
+export function selectionOverlapsKept(
+  bounds: TimeRange,
+  keptMarkers: AdSegment[] | undefined,
+): boolean {
+  return (keptMarkers ?? []).some((m) => overlaps(bounds.start, bounds.end, m));
+}
+
+export function labelDisplay(label: SegmentLabel, mixed: boolean): string {
+  if (mixed) {
+    if (label === 'cut' || label === 'ad') return 'Cut (mixed)';
+    if (label === 'content') return 'Content (mixed)';
+  }
+  switch (label) {
+    case 'content': return 'Content';
+    case 'ad': return 'Ad';
+    case 'cut': return 'Cut';
+    case 'pending': return 'Pending';
+    case 'rejected': return 'Rejected';
+    case 'kept': return 'Kept';
+    default: return label;
+  }
+}
+
+export function labelPillClass(label: SegmentLabel): string {
+  switch (label) {
+    case 'cut':
+    case 'ad':
+      return 'bg-destructive/15 text-destructive';
+    case 'pending':
+      return 'bg-amber-500/15 text-amber-700 dark:text-amber-300';
+    case 'rejected':
+      return 'bg-muted text-muted-foreground';
+    case 'kept':
+      return 'bg-secondary text-secondary-foreground';
+    default:
+      return 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300';
+  }
+}
+
+export function rowBackgroundClass(
+  row: SegmentReviewRow,
+  opts: { selected: boolean; playing: boolean },
+): string {
+  if (opts.playing) return 'bg-sky-500/10';
+  if (opts.selected) return 'bg-indigo-500/10';
+  if (row.label === 'cut' || row.label === 'ad') return 'bg-destructive/5';
+  if (row.label === 'pending') return 'bg-amber-500/5';
+  return '';
+}

--- a/src/api/episodes.py
+++ b/src/api/episodes.py
@@ -427,6 +427,19 @@ def get_episode(slug, episode_id):
 
     processing_runs = _processing_runs(db, episode)
 
+    applied_cuts = None
+    if status == EpisodeStatus.COMPLETED:
+        cuts_raw = storage.get_applied_cuts(slug, episode_id)
+        if cuts_raw is not None:
+            applied_cuts = [
+                {
+                    'start': cut['start'],
+                    'end': cut['end'],
+                    'replacementDuration': cut.get('replacement_duration'),
+                }
+                for cut in cuts_raw
+            ]
+
     return json_response({
         **base,
         # Local-feed season/episode numbers (absent/None on a subscribed
@@ -450,6 +463,7 @@ def get_episode(slug, episode_id):
         'pendingReviewMarkers': pending_review_markers,
         'keptMarkers': kept_markers,
         'corrections': corrections,
+        'appliedCuts': applied_cuts,
         'cueDetections': cue_detections,
         'adDetectionStatus': episode.get('ad_detection_status'),
         'partialDetection': _partial_detection(episode, processing_runs),

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -865,8 +865,35 @@ def _apply_processing_flags(db, data):
         logger.info(f"Updated max feed episodes to: {max_ep}")
 
     if 'onlyExposeProcessedDefault' in data:
-        value = 'true' if data['onlyExposeProcessedDefault'] else 'false'
+        new_enabled = bool(data['onlyExposeProcessedDefault'])
+        old_enabled = db.get_setting('only_expose_processed_default') == 'true'
+        value = 'true' if new_enabled else 'false'
         db.set_setting('only_expose_processed_default', value, is_default=False)
+        if old_enabled != new_enabled:
+            # Served RSS embeds the processed_only render mode; without
+            # invalidating validators every feed would 304-skip until the
+            # next upstream change, leaving hidden episodes invisible.
+            db.clear_all_podcast_etags()
+            import threading
+            from main_app.feeds import rebuild_all_served_feeds
+
+            def _rebuild_feeds_after_processed_only_toggle():
+                try:
+                    count = rebuild_all_served_feeds()
+                    logger.info(
+                        f"Rebuilt served RSS for {count} feed(s) after "
+                        f"only-expose-processed default -> {value}"
+                    )
+                except Exception:
+                    logger.exception(
+                        "Failed to rebuild feeds after only-expose-processed "
+                        "default change"
+                    )
+
+            threading.Thread(
+                target=_rebuild_feeds_after_processed_only_toggle,
+                daemon=True,
+            ).start()
         logger.info(f"Updated only-expose-processed default to: {value}")
 
     if 'detectShowSegments' in data:

--- a/src/detection_review.py
+++ b/src/detection_review.py
@@ -111,7 +111,8 @@ def summarize_detections(items: list[dict]) -> dict:
             counts['confirmed'] += 1
         elif item['resolution'] == 'dismissed':
             counts['dismissed'] += 1
-        elif item['status'] in ('pending', 'rejected'):
+        elif (item['status'] in ('pending', 'rejected')
+              and item.get('actionApplied') != 'keep'):
             counts['needsReview'] += 1
     return counts
 
@@ -154,7 +155,8 @@ def filter_detections(items: list[dict], status: str = 'needs_review',
     if status == 'needs_review':
         out = [i for i in out
                if i['status'] in ('pending', 'rejected')
-               and i['resolution'] == 'unresolved']
+               and i['resolution'] == 'unresolved'
+               and i.get('actionApplied') != 'keep']
     elif status in ('pending', 'rejected', 'accepted'):
         out = [i for i in out if i['status'] == status]
     if category == UNSET_CATEGORY:

--- a/src/main_app/feeds.py
+++ b/src/main_app/feeds.py
@@ -30,6 +30,7 @@ from main_app.cache import TTLCache
 from main_app import db, rss_parser, storage, status_service, pattern_service
 from main_app.feed_auth import active_feed_key
 from main_app.shared_state import invalidate_episode_lookup_cache
+from rss_parser import extract_cached_processed_only
 
 import webhook_service
 
@@ -130,6 +131,39 @@ def invalidate_feed_cache():
     _feed_cache.invalidate('all_feeds')
 
 
+def is_served_rss_stale(slug: str, podcast: dict | None, cached_rss: str | None) -> bool:
+    """True when stored served RSS doesn't match current feed settings.
+
+    Detects missing processed episodes and, when only-expose-processed is off,
+    unprocessed episodes that were dropped by a prior processed_only render.
+    """
+    if not cached_rss:
+        return True
+    podcast = podcast or db.get_podcast_by_slug(slug)
+    if not podcast:
+        return False
+
+    current_processed_only = db.is_only_expose_processed_for_podcast(
+        slug, podcast=podcast)
+    cached_processed_only = extract_cached_processed_only(cached_rss)
+    if cached_processed_only is not None:
+        if cached_processed_only != current_processed_only:
+            return True
+    elif not current_processed_only:
+        # Legacy cache without the marker: unprocessed episodes missing from
+        # the served feed means it was likely built with processed_only on.
+        statuses, _ = db.get_episode_statuses_for_podcast(slug)
+        for episode_id, status in statuses.items():
+            if status != 'processed' and episode_id not in cached_rss:
+                return True
+
+    for ep in db.get_processed_episodes_for_feed(podcast['id']):
+        if ep['episode_id'] not in cached_rss:
+            return True
+
+    return False
+
+
 def refresh_rss_feed(slug: str, feed_url: str, force: bool = False):
     """Refresh RSS feed for a podcast.
 
@@ -201,11 +235,7 @@ def refresh_rss_feed(slug: str, feed_url: str, force: bool = False):
                     )
                 else:
                     cached_rss = storage.get_rss(slug)
-                    rss_stale = not cached_rss or any(
-                        ep['episode_id'] not in cached_rss
-                        for ep in db.get_processed_episodes_for_feed(podcast['id'])
-                    )
-                    if rss_stale:
+                    if is_served_rss_stale(slug, podcast, cached_rss):
                         refresh_logger.info(
                             f"[{slug}] Feed unchanged (304) but RSS cache stale, forcing full fetch"
                         )

--- a/src/main_app/routes.py
+++ b/src/main_app/routes.py
@@ -27,6 +27,7 @@ from config import (
 )
 from database.podcasts import is_local_feed
 from database.queue import compute_queue_priority
+from main_app.feeds import is_served_rss_stale
 from rss_parser import extract_cached_base_url, extract_cached_feed_auth_key
 from utils.constants import EpisodeStatus, REPROCESS_SOURCE_JIT
 from utils.safe_http import URLTrust, safe_head
@@ -422,6 +423,13 @@ def register_routes(app):
                     feed_logger.info(
                         f"[{slug}] cached RSS feed-auth key state mismatch, "
                         f"forcing refresh"
+                    )
+                elif is_served_rss_stale(slug, db.get_podcast_by_slug(slug), cached_rss):
+                    should_refresh = True
+                    force_refresh = True
+                    feed_logger.info(
+                        f"[{slug}] cached RSS only-expose-processed state "
+                        f"stale, forcing refresh"
                     )
         if not should_refresh and last_checked:
             try:

--- a/src/rss_parser.py
+++ b/src/rss_parser.py
@@ -261,6 +261,23 @@ def extract_cached_feed_auth_key(cached_rss: str) -> str | None:
     return m.group(1) if m else None
 
 
+_PROCESSED_ONLY_RE = re.compile(
+    r'<podcast:txt purpose="minuspod-processed-only">(true|false)</podcast:txt>')
+
+
+def extract_cached_processed_only(cached_rss: str) -> bool | None:
+    """Return the processed_only flag embedded in a cached RSS, or None.
+
+    Used to detect when the served feed was rendered with a different
+    only-expose-processed setting than the current resolved value (issue #181
+    toggle-off regression). Older caches without the tag return None.
+    """
+    m = _PROCESSED_ONLY_RE.search(cached_rss)
+    if not m:
+        return None
+    return m.group(1) == 'true'
+
+
 class RSSParser:
     def __init__(self, base_url: str = None):
         self._explicit_base_url = base_url
@@ -990,6 +1007,11 @@ class RSSParser:
         # Channel-level Podcasting 2.0 tags: minted guid, passthrough of safe
         # upstream tags, ai-content disclosure. See docs/podcasting-2.0.md.
         self._emit_channel_pc2_tags(lines, feed_content, slug, channel=channel_elem)
+        # Stamp the processed_only render mode so serve_rss and the 304 path
+        # can detect a settings toggle without re-parsing upstream.
+        lines.append(
+            f'<podcast:txt purpose="minuspod-processed-only">'
+            f'{str(processed_only).lower()}</podcast:txt>')
 
         # Limit to most recent episodes to keep feed size manageable
         # Pocket Casts and other apps may reject very large feeds (>1MB)

--- a/src/utils/community_tags.py
+++ b/src/utils/community_tags.py
@@ -19,6 +19,10 @@ UNIVERSAL_TAG = 'universal'
 # Single source of truth for the upstream MinusPod repo identity. Used by
 # both the export pipeline's prefilled-PR URL builder and the sync job's
 # manifest fetch URL.
+#
+# Fork note (tylermiranda/minuspod): keep this pointing at upstream so
+# community pattern sync pulls the shared catalog from ttlequals0/MinusPod.
+# Only change if operating a separate community pattern feed.
 GITHUB_REPO = 'ttlequals0/MinusPod'
 # Per-pattern files and the index live side by side under this directory; the
 # sync client builds each per-pattern fetch URL as COMMUNITY_PATTERN_BASE_URL +

--- a/tests/unit/test_detection_review.py
+++ b/tests/unit/test_detection_review.py
@@ -27,6 +27,8 @@ REJECTED = {'start': 100.0, 'end': 130.0, 'confidence': 0.4, 'was_cut': False,
             'validation': {'decision': 'REJECT'}}
 HELD = {'start': 200.0, 'end': 230.0, 'confidence': 0.6,
         'held_for_review': True, 'was_cut': False}
+KEPT_OUTRO = {'start': 400.0, 'end': 420.0, 'confidence': 0.7,
+              'category': 'outro', 'action_applied': 'keep', 'was_cut': False}
 
 
 class TestFlatten:
@@ -155,6 +157,16 @@ class TestFilter:
         out = filter_detections(items, status='needs_review')
         assert [i['start'] for i in out] == [200.0]
 
+    def test_needs_review_excludes_deliberate_keeps(self):
+        items = flatten_detections([_row(markers=[REJECTED, KEPT_OUTRO])], [])
+        out = filter_detections(items, status='needs_review')
+        assert [i['start'] for i in out] == [100.0]
+
+    def test_needs_review_count_excludes_deliberate_keeps(self):
+        items = flatten_detections([_row(markers=[REJECTED, KEPT_OUTRO])], [])
+        counts = summarize_detections(items)
+        assert counts['needsReview'] == 1
+
     def test_single_status_filters(self):
         out = filter_detections(self._items(), status='accepted')
         assert [i['start'] for i in out] == [10.0]
@@ -240,8 +252,6 @@ class TestSortAndPaginate:
 CROSS_PROMO = {'start': 300.0, 'end': 340.0, 'confidence': 0.8,
                'category': 'cross_promo', 'action_applied': 'remove',
                'sponsor': 'The Daily Tech Show'}
-KEPT_OUTRO = {'start': 400.0, 'end': 420.0, 'confidence': 0.7,
-              'category': 'outro', 'action_applied': 'keep', 'was_cut': False}
 
 
 class TestCategoryFields:

--- a/tests/unit/test_rss_parser_processed_only.py
+++ b/tests/unit/test_rss_parser_processed_only.py
@@ -118,3 +118,12 @@ class TestProcessedOnlyFilter:
             processed_only=True, processed_episode_ids=None,
         )
         assert "/episodes/test-pod/" not in result
+
+    def test_emits_processed_only_marker(self, parser, feed_with_three_entries):
+        on = parser.modify_feed(
+            feed_with_three_entries, "test-pod",
+            processed_only=True, processed_episode_ids=set(),
+        )
+        off = parser.modify_feed(feed_with_three_entries, "test-pod")
+        assert 'purpose="minuspod-processed-only">true<' in on
+        assert 'purpose="minuspod-processed-only">false<' in off

--- a/tests/unit/test_served_rss_stale.py
+++ b/tests/unit/test_served_rss_stale.py
@@ -1,0 +1,169 @@
+"""Tests for is_served_rss_stale and the processed_only render marker."""
+from unittest.mock import MagicMock, patch
+
+from tests.app_bootstrap import bootstrap
+
+_test_data_dir = bootstrap('rss_stale_test_')
+
+import main_app.feeds as feeds_mod
+from rss_parser import RSSParser, extract_cached_processed_only
+
+
+def _cached_rss(processed_only: bool | None, episode_ids: list[str]) -> str:
+    """Minimal served RSS with optional processed_only marker and enclosures."""
+    tag = ''
+    if processed_only is not None:
+        tag = (
+            f'<podcast:txt purpose="minuspod-processed-only">'
+            f'{str(processed_only).lower()}</podcast:txt>'
+        )
+    items = ''.join(
+        f'<item><enclosure url="https://mp.example.com/show/episodes/{eid}.mp3" '
+        f'type="audio/mpeg" /></item>'
+        for eid in episode_ids
+    )
+    return f'<?xml version="1.0"?><rss><channel>{tag}{items}</channel></rss>'
+
+
+class TestExtractCachedProcessedOnly:
+    def test_roundtrip_true(self):
+        rss = _cached_rss(True, [])
+        assert extract_cached_processed_only(rss) is True
+
+    def test_roundtrip_false(self):
+        rss = _cached_rss(False, ['abc123'])
+        assert extract_cached_processed_only(rss) is False
+
+    def test_missing_tag_returns_none(self):
+        assert extract_cached_processed_only('<rss><channel></channel></rss>') is None
+
+
+class TestIsServedRssStale:
+    PODCAST = {'id': 1, 'only_expose_processed_episodes': None}
+
+    @patch.object(feeds_mod, 'db')
+    def test_empty_cache_is_stale(self, db):
+        assert feeds_mod.is_served_rss_stale('show', self.PODCAST, None) is True
+
+    @patch.object(feeds_mod, 'db')
+    def test_marker_mismatch_when_turning_off_processed_only(self, db):
+        db.is_only_expose_processed_for_podcast.return_value = False
+        db.get_processed_episodes_for_feed.return_value = []
+        cached = _cached_rss(True, [])
+        assert feeds_mod.is_served_rss_stale('show', self.PODCAST, cached) is True
+
+    @patch.object(feeds_mod, 'db')
+    def test_marker_mismatch_when_turning_on_processed_only(self, db):
+        db.is_only_expose_processed_for_podcast.return_value = True
+        db.get_processed_episodes_for_feed.return_value = []
+        cached = _cached_rss(False, ['aaa111', 'bbb222'])
+        assert feeds_mod.is_served_rss_stale('show', self.PODCAST, cached) is True
+
+    @patch.object(feeds_mod, 'db')
+    def test_legacy_cache_missing_unprocessed_episodes(self, db):
+        """Pre-marker feeds: unprocessed DB rows absent from cache => stale."""
+        db.is_only_expose_processed_for_podcast.return_value = False
+        db.get_processed_episodes_for_feed.return_value = []
+        db.get_episode_statuses_for_podcast.return_value = (
+            {'disc111': 'discovered', 'proc222': 'processed'}, {}
+        )
+        cached = _cached_rss(None, ['proc222'])
+        assert feeds_mod.is_served_rss_stale('show', self.PODCAST, cached) is True
+
+    @patch.object(feeds_mod, 'db')
+    def test_legacy_cache_ok_when_processed_only_on(self, db):
+        """With processed_only on, missing unprocessed rows is expected."""
+        db.is_only_expose_processed_for_podcast.return_value = True
+        db.get_processed_episodes_for_feed.return_value = [
+            {'episode_id': 'proc222'},
+        ]
+        db.get_episode_statuses_for_podcast.return_value = (
+            {'disc111': 'discovered', 'proc222': 'processed'}, {}
+        )
+        cached = _cached_rss(None, ['proc222'])
+        assert feeds_mod.is_served_rss_stale('show', self.PODCAST, cached) is False
+
+    @patch.object(feeds_mod, 'db')
+    def test_missing_processed_episode_is_stale(self, db):
+        db.is_only_expose_processed_for_podcast.return_value = False
+        db.get_processed_episodes_for_feed.return_value = [
+            {'episode_id': 'proc222'},
+        ]
+        db.get_episode_statuses_for_podcast.return_value = (
+            {'proc222': 'processed'}, {}
+        )
+        cached = _cached_rss(False, [])
+        assert feeds_mod.is_served_rss_stale('show', self.PODCAST, cached) is True
+
+    @patch.object(feeds_mod, 'db')
+    def test_current_settings_match_is_fresh(self, db):
+        db.is_only_expose_processed_for_podcast.return_value = False
+        db.get_processed_episodes_for_feed.return_value = []
+        db.get_episode_statuses_for_podcast.return_value = (
+            {'aaa111': 'discovered'}, {}
+        )
+        cached = _cached_rss(False, ['aaa111'])
+        assert feeds_mod.is_served_rss_stale('show', self.PODCAST, cached) is False
+
+
+class TestProcessedOnlyMarkerInModifyFeed:
+    def test_modify_feed_emits_marker(self):
+        parser = RSSParser(base_url='https://mp.example.com')
+        feed = """<?xml version="1.0"?><rss version="2.0"><channel>
+            <title>T</title><link>https://example.com</link>
+            <description>d</description>
+            <item><title>E</title><guid>g1</guid>
+            <enclosure url="https://cdn.example.com/a.mp3" type="audio/mpeg"/>
+            </item></channel></rss>"""
+        result = parser.modify_feed(feed, 'show', processed_only=True,
+                                    processed_episode_ids=set())
+        assert 'purpose="minuspod-processed-only">true<' in result
+        result_off = parser.modify_feed(feed, 'show', processed_only=False)
+        assert 'purpose="minuspod-processed-only">false<' in result_off
+
+
+class Test304ForcesFetchWhenProcessedOnlyStale:
+    """refresh_rss_feed must not 304-skip when the served RSS is stale."""
+
+    @patch.object(feeds_mod, 'pattern_service')
+    @patch.object(feeds_mod, 'status_service')
+    @patch.object(feeds_mod, 'storage')
+    @patch.object(feeds_mod, 'rss_parser')
+    @patch.object(feeds_mod, 'db')
+    def test_304_forces_fetch_when_unprocessed_missing(
+        self, db, rss_parser, storage, status_service, pattern_service
+    ):
+        feeds_mod._refresh_coalesce.invalidate()
+        slug = 'stale-processed-only-feed'
+        podcast = {
+            'id': 1, 'etag': 'etag-1', 'last_modified_header': None,
+            'artwork_cached': True,
+            'podping_checked_at': '2026-07-26T00:00:00Z',
+            'channel_metadata_at': '2026-07-26T00:00:00Z',
+        }
+        db.get_podcast_by_slug.return_value = podcast
+        db.get_episodes.return_value = ([], 1)
+        db.get_processed_episodes_for_feed.return_value = []
+        db.is_only_expose_processed_for_podcast.return_value = False
+        db.get_episode_statuses_for_podcast.return_value = (
+            {'disc111': 'discovered'}, {}
+        )
+
+        rss_parser.fetch_feed_conditional.side_effect = [
+            (None, 'etag-1', None),
+            (b'<rss/>', 'etag-1', None),
+        ]
+        storage.get_rss.return_value = _cached_rss(True, [])
+
+        parsed = MagicMock()
+        parsed.feed = {'title': 'Show', 'description': '', 'link': 'https://example.com'}
+        parsed.entries = []
+        parsed.bozo = False
+        rss_parser.parse_feed.return_value = parsed
+        rss_parser.extract_podcast_artwork_url.return_value = None
+        rss_parser.extract_episodes.return_value = []
+
+        with patch('main_app.feeds._build_and_save_served_rss'):
+            feeds_mod.refresh_rss_feed(slug, 'https://example.com/f.xml')
+
+        assert rss_parser.fetch_feed_conditional.call_count == 2


### PR DESCRIPTION
## Summary
- Mark ad now creates one missed-ad correction per contiguous selection span (same sponsor), matching Mark content
- Preflights text-template length across all spans before submitting to avoid partial creates
- Adds coverage for multi-span success, short-text rejection, and time-gap span splitting

## Test plan
- [x] `npm test -- --run src/components/TranscriptSegmentWorkspace.test.tsx src/utils/segmentReviewModel.test.ts`
- [ ] In Review transcript, select two gap-split spans, enter sponsor, Mark ad → both saves succeed
- [ ] Confirm Fine-tune still requires a single span


Made with [Cursor](https://cursor.com)